### PR TITLE
fix: add missing dotenv dependency

### DIFF
--- a/bec_lib/pyproject.toml
+++ b/bec_lib/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "typeguard ~= 4.1, >=4.1.5",
     "prettytable~=3.9",
     "h5py~=3.10",
+    "python-dotenv~=1.0",
 ]
 
 


### PR DESCRIPTION
While the bec server already has the dependency, using just bec_lib would crash on import as the dotenv module would not be available