### PR TITLE
Allow device server to deal with lazy signals

### DIFF
--- a/bec_lib/bec_lib/bec_service.py
+++ b/bec_lib/bec_lib/bec_service.py
@@ -111,6 +111,8 @@ class BECService:
         self._name = name if name else self.__class__.__name__
         self._import_config(config)
         self._connector_cls = connector_cls
+        # Log the server address
+        logger.info(f"Connecting to Redis server at {self.bootstrap_server}")
         self.connector: RedisConnector = connector_cls(self.bootstrap_server)
         self.acl = BECAccess(self.connector)
         self.acl._bec_service_login(prompt_for_acl, self._service_config.config.get("acl"))


### PR DESCRIPTION
# Summary

This MR allows the device server to deal with lazy signals for device serialization, i.e. not try to connect to signals with `wait_for_connection()` if `.hints` is called. See issue #457 for more details. In addition, it improves logging of the Redis Host for bec_services to avoid a service being stuck due to not being able to connect to Redis because of a missconfiguration

# Related Issues

closes #457 
closes #476 