### PR TITLE
Fix/bugfix no monitored devices

### DIFF
--- a/bec_ipython_client/bec_ipython_client/callbacks/live_table.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/live_table.py
@@ -218,6 +218,11 @@ class LiveUpdatesTable(LiveUpdatesBase):
                     break
                 if self.point_id > self.scan_item.num_points:
                     raise RuntimeError("Received more points than expected.")
+                if len(self.scan_item.live_data) == 0 and self.scan_item.status == "closed":
+                    logger.warning(
+                        f"\n Scan {self.scan_item.scan_number} finished. No monitored devices enabled, please check your config."
+                    )
+                    break
 
     @property
     def _print_table_data(self) -> bool:

--- a/bec_server/bec_server/file_writer/file_writer_manager.py
+++ b/bec_server/bec_server/file_writer/file_writer_manager.py
@@ -64,9 +64,13 @@ class ScanStorage:
             # wait for all points to be received. Since this method will be called for every
             # update of the scan segments, we can also accept to write after the scan is finished
             _ready_to_write = self.scan_finished and (self.num_points == len(self.scan_segments))
-            logger.info(
-                f"Received number of segments: {len(self.scan_segments)}, Number of points (expected): {self.num_points},  Ready to write: {_ready_to_write}"
-            )
+            if not _ready_to_write:
+                monitored_devices = self.status_msg.readout_priority.get("monitored")
+                if not monitored_devices:
+                    logger.info(
+                        f"Received number of segments: {len(self.scan_segments)}, Number of points (expected): {self.num_points},  Ready to write: {_ready_to_write}"
+                    )
+                    return self.scan_finished
             return _ready_to_write
         return self.scan_finished and self.scan_number is not None
 


### PR DESCRIPTION
This pull request addresses improved error handling and logging for scenarios where monitored devices are not enabled. The changes aim to provide clearer feedback to users and ensure appropriate handling of edge cases.

### Improvements to error handling and logging:

* [`bec_ipython_client/bec_ipython_client/callbacks/live_table.py`](diffhunk://#diff-9d637c9daaec4b375adf3c4ed66c79a46e53e1564cf4afc13ebedb908b45c4c2R221-R225): Added a warning log and an early exit condition when a scan is finished but no monitored devices are enabled, helping users identify potential configuration issues.

* [`bec_server/bec_server/file_writer/file_writer_manager.py`](diffhunk://#diff-16714b9ebac9109b540de85ad43899dcfeb053ccf807dd95a0904f7cf653e85fR67-R73): Enhanced the logic in `ready_to_write` to check for monitored devices in the status message. If no monitored devices are present, it logs the current state and returns based on scan completion status, improving clarity on readiness to write.