### PR TITLE
fix(test): dangling client thread

### DIFF
--- a/bec_server/tests/tests_scan_server/test_procedures.py
+++ b/bec_server/tests/tests_scan_server/test_procedures.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import fakeredis
 import pytest
 
-from bec_lib.client import RedisConnector
+from bec_lib.client import BECClient, RedisConnector
 from bec_lib.messages import (
     ProcedureExecutionMessage,
     ProcedureRequestMessage,
@@ -30,6 +30,14 @@ from bec_server.scan_server.procedures.worker_base import ProcedureWorkerStatus
 
 
 LOG_MSG_PROC_NAME = "log execution message args"
+
+
+@pytest.fixture(autouse=True)
+def shutdown_client():
+    bec_client = BECClient()
+    bec_client.start()
+    yield
+    bec_client.shutdown()
 
 
 @pytest.fixture


### PR DESCRIPTION
- makes sure the client is shutdown after procedure tests
- note that this should be handled by the procedure worker for any external process workers in the future, but not for the in-process worker which is tested here, since that would shut down the client for the process in the real BEC instance