### PR TITLE
subscribe to BEC signals

### DIFF
--- a/bec_lib/bec_lib/device.py
+++ b/bec_lib/bec_lib/device.py
@@ -433,6 +433,13 @@ class DeviceBase:
     def _parse_info(self):
         if self._info.get("signals"):
             for signal_name, signal_info in self._info.get("signals", {}).items():
+                if (
+                    not signal_info.get("describe", {})
+                    .get("signal_info", {})
+                    .get("rpc_access", True)
+                ):
+                    continue
+
                 setattr(
                     self,
                     signal_name,

--- a/bec_lib/bec_lib/devicemanager.py
+++ b/bec_lib/bec_lib/devicemanager.py
@@ -717,6 +717,7 @@ class DeviceManagerBase:
             return False
         return True
 
+    @typechecked
     def get_bec_signals(
         self,
         signal_type: Literal["AsyncSignal", "FileEventSignal", "PreviewSignal", "ProgressSignal"],

--- a/bec_lib/bec_lib/devicemanager.py
+++ b/bec_lib/bec_lib/devicemanager.py
@@ -9,7 +9,7 @@ import copy
 import re
 import traceback
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, Literal
 
 from rich.console import Console
 from rich.table import Table
@@ -716,6 +716,27 @@ class DeviceManagerBase:
         if not isinstance(self._config, dict):
             return False
         return True
+
+    def get_bec_signals(
+        self,
+        signal_type: Literal["AsyncSignal", "FileEventSignal", "PreviewSignal", "ProgressSignal"],
+    ) -> list[tuple[str, str, dict]]:
+        """
+        Get a list of BEC signals of the specified type.
+
+        Args:
+            signal_type (str): Type of the signal to filter by.
+        Supported types are "AsyncSignal", "FileEventSignal", "PreviewSignal", and "ProgressSignal".
+
+        Returns:
+            list: List of tuples containing the device name, component name and the signal info.
+        """
+        signals = []
+        for device in self.devices.values():
+            for comp, signal_info in device._info.get("signals", {}).items():
+                if signal_info.get("signal_class") == signal_type:
+                    signals.append((device.name, comp, signal_info))
+        return signals
 
     def shutdown(self):
         """

--- a/bec_lib/bec_lib/endpoints.py
+++ b/bec_lib/bec_lib/endpoints.py
@@ -393,6 +393,28 @@ class MessageEndpoints:
         )
 
     @staticmethod
+    def device_async_signal(scan_id: str, device: str, signal: str):
+        """
+        Endpoint for receiving an async device signal over Redis streams.
+        This endpoint is used by the device server to publish async device
+        signals using a messages.DeviceMessage. In addition to scan metadata,
+        the message metadata contains information on how to concatenate multiple readings.
+        Further keyword arguments for GUI handling might be attached.
+
+        Args:
+            scan_id (str): unique scan identifier
+            device (str): Device name, e.g. "mcs".
+            signal (str): Signal name, e.g. "image".
+
+        Returns:
+            EndpointInfo: Endpoint for device async signal of the specified device and signal.
+        """
+        endpoint = f"{EndpointType.INFO.value}/devices/async_signal/{scan_id}/{device}/{signal}"
+        return EndpointInfo(
+            endpoint=endpoint, message_type=messages.DeviceMessage, message_op=MessageOp.STREAM
+        )
+
+    @staticmethod
     def device_monitor_2d(device: str):
         """
         Endpoint for device monitoring of 2D detectors.

--- a/bec_lib/bec_lib/tests/test_config.yaml
+++ b/bec_lib/bec_lib/tests/test_config.yaml
@@ -42,6 +42,13 @@ failure_device:
   readOnly: false
   readoutPriority: baseline
 
+bec_signals_device:
+  deviceClass: ophyd_devices.sim.sim_test_devices.SimCameraWithPSIComponents
+  deviceConfig:
+  enabled: true
+  readOnly: false
+  readoutPriority: baseline
+
 ############################################################
 ####################### User motors ########################
 ############################################################

--- a/bec_lib/bec_lib/tests/utils.py
+++ b/bec_lib/bec_lib/tests/utils.py
@@ -396,7 +396,7 @@ def get_device_info_mock(device_name, device_class) -> messages.DeviceInfoMessag
                     "device_attr_name": "dyn_signals",
                     "device_base_class": "device",
                     "device_class": "SimDevice",
-                    "signals": [],
+                    "signals": {},
                     "hints": {"fields": []},
                     "describe": {
                         "dyn_signals_messages_message1": {
@@ -593,6 +593,45 @@ def get_device_info_mock(device_name, device_class) -> messages.DeviceInfoMessag
         },
         "custom_user_acces": {},
     }
+    if device_name == "eiger":
+        # add preview signals for eiger
+        dev_info["device_info"]["signals"].update(
+            {
+                "preview": {
+                    "component_name": "preview",
+                    "signal_class": "PreviewSignal",
+                    "obj_name": "eiger_preview",
+                    "kind_int": 5,
+                    "kind_str": "hinted",
+                    "doc": "",
+                    "describe": {
+                        "source": "BECMessageSignal:eiger_preview",
+                        "dtype": "DevicePreviewMessage",
+                        "shape": [],
+                        "signal_info": {
+                            "data_type": "raw",
+                            "saved": False,
+                            "ndim": 2,
+                            "scope": "scan",
+                            "role": "preview",
+                            "enabled": True,
+                            "rpc_access": False,
+                            "signals": [["preview", 5]],
+                            "signal_metadata": {"num_rotation_90": 0, "transpose": False},
+                        },
+                    },
+                    "metadata": {
+                        "connected": True,
+                        "read_access": True,
+                        "write_access": True,
+                        "timestamp": 1749046715.160324,
+                        "status": None,
+                        "severity": None,
+                        "precision": None,
+                    },
+                }
+            }
+        )
 
     return messages.DeviceInfoMessage(device=device_name, info=dev_info, metadata={})
 

--- a/bec_lib/tests/test_device_manager.py
+++ b/bec_lib/tests/test_device_manager.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import pydantic
 import pytest
-import yaml
+import typeguard
 
 import bec_lib
 from bec_lib import messages
@@ -406,3 +406,15 @@ def test_disabled_device_not_in_monitored(dm_with_devices):
     assert "motor1_disabled" in dm_with_devices.devices
     monitored_devices = dm_with_devices.devices.monitored_devices()
     assert "motor1_disabled" not in [dev.name for dev in monitored_devices]
+
+
+def test_get_bec_signals(dm_with_devices):
+    device_manager = dm_with_devices
+    with pytest.raises(typeguard.TypeCheckError):
+        device_manager.get_bec_signals("non_existing_filter")
+
+    preview_signals = device_manager.get_bec_signals("PreviewSignal")
+    assert preview_signals
+    eiger = list(filter(lambda x: x[0] == "eiger", preview_signals))[0]
+    assert eiger[1] == "preview"
+    assert isinstance(eiger[2], dict)

--- a/bec_server/bec_server/device_server/bec_message_handler.py
+++ b/bec_server/bec_server/device_server/bec_message_handler.py
@@ -12,7 +12,7 @@ from bec_lib.redis_connector import RedisConnector
 
 logger = bec_logger.logger
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from bec_server.device_server.devices.devicemanager import DeviceManagerDS
 
 

--- a/bec_server/bec_server/device_server/bec_message_handler.py
+++ b/bec_server/bec_server/device_server/bec_message_handler.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ophyd import OphydObject
+from ophyd_devices.utils import bec_signals as bms
+
+from bec_lib import messages
+from bec_lib.endpoints import MessageEndpoints
+from bec_lib.logger import bec_logger
+from bec_lib.redis_connector import RedisConnector
+
+logger = bec_logger.logger
+
+if TYPE_CHECKING:
+    from bec_server.device_server.devices.devicemanager import DeviceManagerDS
+
+
+class BECMessageHandler:
+    """
+    A message handler for the BEC device server that processes and emits messages related to device signals.
+    """
+
+    def __init__(self, device_manager: DeviceManagerDS):
+        """
+        Initialize the BECMessageHandler with a DeviceManagerDS instance.
+        This handler is responsible for processing and emitting messages related to device signals.
+
+        Args:
+            device_manager (DeviceManagerDS): The device manager instance that manages devices and their signals.
+        """
+        self.device_manager = device_manager
+        self.connector: RedisConnector = device_manager.connector
+        self.devices = device_manager.devices
+
+    def emit(self, obj: OphydObject, message: messages.BECMessage):
+        """
+        Emit a message for the given object.
+        This method handles different types of signals and publishes the appropriate messages to Redis.
+
+        Args:
+            obj (OphydObject): The object that emitted the signal.
+            message (messages.BECMessage): The message to be published.
+
+        Raises:
+            TypeError: If the object is not a supported signal type.
+        """
+
+        if isinstance(obj, bms.FileEventSignal):
+            return self._handle_file_event_signal(obj, message)
+        if isinstance(obj, bms.ProgressSignal):
+            return self._handle_progress_signal(obj, message)
+        if isinstance(obj, bms.PreviewSignal):
+            return self._handle_preview_signal(obj, message)
+
+        raise TypeError(f"Unsupported signal type: {type(obj)}")
+
+    def _handle_file_event_signal(self, obj: bms.FileEventSignal, message: messages.BECMessage):
+        if not isinstance(message, messages.FileMessage):
+            raise TypeError(f"Expected FileMessage, got {type(message)}")
+
+        device_name = obj.root.name
+        # Note: It is fine to use the metadata from the device object here,
+        # as it is safe to assume that the file event is emitted before a new scan starts.
+        metadata = self.devices[device_name].metadata
+        scan_id = metadata.get("scan_id")
+
+        pipe = self.connector.pipeline()
+        self.connector.set_and_publish(MessageEndpoints.file_event(device_name), message, pipe=pipe)
+        self.connector.set_and_publish(
+            MessageEndpoints.public_file(scan_id=scan_id, name=device_name), message, pipe=pipe
+        )
+        pipe.execute()
+
+    def _handle_progress_signal(self, obj: bms.ProgressSignal, message: messages.BECMessage):
+        if not isinstance(message, messages.ProgressMessage):
+            raise TypeError(f"Expected ProgressMessage, got {type(message)}")
+
+        device_name = obj.root.name
+        self.connector.set_and_publish(MessageEndpoints.device_progress(device_name), message)
+
+    def _handle_preview_signal(self, obj: bms.PreviewSignal, message: messages.BECMessage):
+        if not isinstance(message, messages.DevicePreviewMessage):
+            raise TypeError(f"Expected PreviewMessage, got {type(message)}")
+
+        data = message.data
+        # Convert sizes from bytes to MB
+        dsize = len(data.tobytes()) / 1e6
+        max_size = 1000
+        if dsize > max_size:
+            logger.warning(
+                f"Data size of single message is too large to send, current max_size {max_size}."
+            )
+            return
+
+        stream_msg = {"data": message}
+        self.connector.xadd(
+            MessageEndpoints.device_preview(device=obj.root.name, signal=message.signal),
+            stream_msg,
+            max_size=min(100, int(max_size // dsize)),
+        )

--- a/bec_server/bec_server/device_server/bec_message_handler.py
+++ b/bec_server/bec_server/device_server/bec_message_handler.py
@@ -129,4 +129,5 @@ class BECMessageHandler:
             ),
             {"data": message},
             max_size=obj.signal_metadata.get("max_size", 1000),
+            expire=obj.signal_metadata.get("expire", 600),  # default to 10 minutes (600 seconds)
         )

--- a/bec_server/bec_server/device_server/devices/device_serializer.py
+++ b/bec_server/bec_server/device_server/devices/device_serializer.py
@@ -7,8 +7,9 @@ import functools
 from typing import Any
 
 import msgpack
-from ophyd import Device, PositionerBase, Signal
+from ophyd import Device, Kind, PositionerBase, Signal
 from ophyd_devices import BECDeviceBase, ComputedSignal
+from ophyd_devices.utils.bec_signals import BECMessageSignal
 
 from bec_lib.bec_errors import DeviceConfigError
 from bec_lib.device import DeviceBase
@@ -134,21 +135,46 @@ def get_device_info(
                     and not comp.doc.startswith("Component attribute\n::")
                     else ""
                 )
-                signals.update(
-                    {
-                        component_name: {
-                            "component_name": component_name,
-                            "signal_class": signal_obj.__class__.__name__,
-                            "obj_name": signal_obj.name,
-                            "kind_int": signal_obj.kind.value,
-                            "kind_str": signal_obj.kind.name,
-                            "doc": doc,
-                            "describe": signal_obj.describe().get(signal_obj.name, {}),
-                            # pylint: disable=protected-access
-                            "metadata": signal_obj._metadata,
+                if isinstance(signal_obj, BECMessageSignal):
+                    info = signal_obj.describe().get(signal_obj.name, {}).get("signal_info", {})
+                    if not info:
+                        continue
+                    for signal_name, kind in info.get("signals", []):
+                        if len(info.get("signals")) == 1:
+                            obj_name = signal_obj.name
+                        else:
+                            obj_name = "_".join([signal_obj.name, signal_name])
+                        signals.update(
+                            {
+                                signal_name: {
+                                    "component_name": component_name,
+                                    "signal_class": signal_obj.__class__.__name__,
+                                    "obj_name": obj_name,
+                                    "kind_int": kind,
+                                    "kind_str": Kind(kind).name,
+                                    "doc": doc,
+                                    "describe": signal_obj.describe().get(signal_obj.name, {}),
+                                    # pylint: disable=protected-access
+                                    "metadata": signal_obj._metadata,
+                                }
+                            }
+                        )
+                else:
+                    signals.update(
+                        {
+                            component_name: {
+                                "component_name": component_name,
+                                "signal_class": signal_obj.__class__.__name__,
+                                "obj_name": signal_obj.name,
+                                "kind_int": signal_obj.kind.value,
+                                "kind_str": signal_obj.kind.name,
+                                "doc": doc,
+                                "describe": signal_obj.describe().get(signal_obj.name, {}),
+                                # pylint: disable=protected-access
+                                "metadata": signal_obj._metadata,
+                            }
                         }
-                    }
-                )
+                    )
     sub_devices = []
 
     if hasattr(obj, "walk_subdevices") and connect:

--- a/bec_server/bec_server/device_server/devices/device_serializer.py
+++ b/bec_server/bec_server/device_server/devices/device_serializer.py
@@ -142,11 +142,13 @@ def get_device_info(
                     for signal_name, kind in info.get("signals", []):
                         if len(info.get("signals")) == 1:
                             obj_name = signal_obj.name
+                            comp_name = component_name
                         else:
                             obj_name = "_".join([signal_obj.name, signal_name])
+                            comp_name = ".".join([component_name, signal_name])
                         signals.update(
                             {
-                                signal_name: {
+                                comp_name: {
                                     "component_name": component_name,
                                     "signal_class": signal_obj.__class__.__name__,
                                     "obj_name": obj_name,

--- a/bec_server/pyproject.toml
+++ b/bec_server/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "msgpack~=1.0",
     "numpy>=1.24, <3.0",
     "ophyd~=1.9",
-    "ophyd_devices>=1.20.0, <2.0",
+    "ophyd_devices>=1.21.0, <2.0",
     "psutil",
     "pydantic~=2.8",
     "pyyaml~=6.0",

--- a/bec_server/pyproject.toml
+++ b/bec_server/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "msgpack~=1.0",
     "numpy>=1.24, <3.0",
     "ophyd~=1.9",
-    "ophyd_devices>=1.10.3, <2.0",
+    "ophyd_devices>=1.20.0, <2.0",
     "psutil",
     "pydantic~=2.8",
     "pyyaml~=6.0",

--- a/bec_server/tests/tests_device_server/test_device_manager_ds.py
+++ b/bec_server/tests/tests_device_server/test_device_manager_ds.py
@@ -362,3 +362,27 @@ def test_device_manager_ds_obj_callback_progress_signal_disabled_device(dm_with_
                 ),
             )
             mock_emit.assert_not_called()
+
+
+@pytest.mark.parametrize("device_manager_class", [DeviceManagerDS])
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        messages.DeviceMessage(
+            signals={"async_signal": {"value": np.random.rand(10), "timestamp": time.time()}}
+        ),
+        "some string",
+    ],
+)
+def test_device_manager_ds_obj_callback_async_signal(dm_with_devices, value):
+    device_manager = dm_with_devices
+    device = dm_with_devices.devices.bec_signals_device.obj
+    dm_with_devices.devices.bec_signals_device.metadata = {"scan_id": "12345"}
+    with mock.patch.object(device_manager.connector, "xadd") as mock_xadd:
+        device_manager._obj_callback_bec_message_signal(obj=device.async_signal, value=value)
+
+        if not isinstance(value, messages.DeviceMessage):
+            mock_xadd.assert_not_called()
+        else:
+            mock_xadd.assert_called_once()

--- a/bec_server/tests/tests_device_server/test_device_manager_ds.py
+++ b/bec_server/tests/tests_device_server/test_device_manager_ds.py
@@ -386,3 +386,19 @@ def test_device_manager_ds_obj_callback_async_signal(dm_with_devices, value):
             mock_xadd.assert_not_called()
         else:
             mock_xadd.assert_called_once()
+
+
+@pytest.mark.parametrize("device_manager_class", [DeviceManagerDS])
+@pytest.mark.parametrize("metadata", [{}, {"scan_id": 12345}])  # Invalid scan_id type
+def test_device_manager_ds_obj_callback_async_signal_incomplete_info(dm_with_devices, metadata):
+    device_manager = dm_with_devices
+    device = dm_with_devices.devices.bec_signals_device.obj
+    dm_with_devices.devices.bec_signals_device.metadata = metadata
+
+    msg = messages.DeviceMessage(
+        signals={"async_signal": {"value": np.random.rand(10), "timestamp": time.time()}}
+    )
+    with mock.patch.object(device_manager.connector, "xadd") as mock_xadd:
+        device_manager._obj_callback_bec_message_signal(obj=device.async_signal, value=msg)
+
+        mock_xadd.assert_not_called()


### PR DESCRIPTION
This PR adds a default subscription to the BEC signals. These signals will fully replace the custom bec events at some point but for now, they co-exist until we've migrated all repositories. To better separate the core events from the about to be deprecated bec-specific events, this PR also separates the subscription into dedicated methods. 

`_subscribe_to_bec_device_events` can be removed once we've fully migrated to BEC signals. 


closes #441 