### PR TITLE
[BUG]: fix encoding for temperature pvs

### DIFF
--- a/bec_server/bec_server/device_server/__init__.py
+++ b/bec_server/bec_server/device_server/__init__.py
@@ -1,8 +1,0 @@
-import logging
-
-from bec_lib.devicemanager import DeviceManagerBase
-
-from . import devices
-from .device_server import DeviceServer
-
-loggers = logging.getLogger(__name__)

--- a/bec_server/bec_server/device_server/cli/launch.py
+++ b/bec_server/bec_server/device_server/cli/launch.py
@@ -18,7 +18,7 @@ import threading
 from bec_lib.bec_service import parse_cmdline_args
 from bec_lib.logger import bec_logger
 from bec_lib.redis_connector import RedisConnector
-from bec_server import device_server
+from bec_server.device_server.device_server import DeviceServer
 
 logger = bec_logger.logger
 bec_logger.level = bec_logger.LOGLEVEL.INFO
@@ -30,7 +30,7 @@ def main():
     """
     _, _, config = parse_cmdline_args()
 
-    s = device_server.DeviceServer(config, RedisConnector)
+    s = DeviceServer(config, RedisConnector)
     try:
         event = threading.Event()
         s.start()

--- a/bec_server/tests/tests_device_server/test_device_server.py
+++ b/bec_server/tests/tests_device_server/test_device_server.py
@@ -12,8 +12,7 @@ from bec_lib.endpoints import MessageEndpoints
 from bec_lib.messages import BECStatus
 from bec_lib.service_config import ServiceConfig
 from bec_lib.tests.utils import ConnectorMock
-from bec_server.device_server import DeviceServer
-from bec_server.device_server.device_server import InvalidDeviceError
+from bec_server.device_server.device_server import DeviceServer, InvalidDeviceError
 from bec_server.device_server.devices.devicemanager import DeviceManagerDS
 
 # pylint: disable=missing-function-docstring

--- a/bec_server/tests/tests_device_server/test_device_server_cli_launch.py
+++ b/bec_server/tests/tests_device_server/test_device_server_cli_launch.py
@@ -7,7 +7,7 @@ def test_main():
     with mock.patch(
         "bec_server.device_server.cli.launch.parse_cmdline_args", return_value=(None, None, None)
     ) as mock_parser:
-        with mock.patch("bec_server.device_server.DeviceServer") as mock_device_server:
+        with mock.patch("bec_server.device_server.cli.launch.DeviceServer") as mock_device_server:
             with mock.patch("bec_server.device_server.cli.launch.threading.Event") as mock_event:
                 main()
                 mock_parser.assert_called_once()
@@ -19,7 +19,7 @@ def test_main_shutdown():
     with mock.patch(
         "bec_server.device_server.cli.launch.parse_cmdline_args", return_value=(None, None, None)
     ) as mock_parser:
-        with mock.patch("bec_server.device_server.DeviceServer") as mock_device_server:
+        with mock.patch("bec_server.device_server.cli.launch.DeviceServer") as mock_device_server:
             with mock.patch("bec_server.device_server.cli.launch.threading.Event") as mock_event:
                 mock_event.return_value.wait.side_effect = KeyboardInterrupt
                 main()


### PR DESCRIPTION
The encoding must be set before any other ophyd or pyepics import. To this end, this PR removes the (unnecessary) imports of the device server module to ensure that the launch.py file can properly set the encoding according to the plugin config.

closes #491 