### PR TITLE
refactor: enforce device config keys

### DIFF
--- a/bec_lib/bec_lib/atlas_models.py
+++ b/bec_lib/bec_lib/atlas_models.py
@@ -28,13 +28,9 @@ def make_all_fields_optional(model: Type[BM], model_name: str) -> Type[BM]:
     return create_model(model_name, **fields, __config__=model.model_config)
 
 
-class Device(BaseModel):
-    """
-    Represents a device in the BEC Atlas API. This model is also used by the SciHub service to
-    validate updates to the device configuration.
-    """
+class _DeviceModelCore(BaseModel):
+    """Represents the internal config values for a device"""
 
-    name: str
     enabled: bool
     deviceClass: str
     deviceConfig: dict | None = None
@@ -44,6 +40,15 @@ class Device(BaseModel):
     softwareTrigger: bool = False
     deviceTags: list[str] = []
     userParameter: dict = {}
+
+
+class Device(_DeviceModelCore):
+    """
+    Represents a device in the BEC Atlas API. This model is also used by the SciHub service to
+    validate updates to the device configuration.
+    """
+
+    name: str
 
 
 DevicePartial = make_all_fields_optional(Device, "DevicePartial")

--- a/bec_lib/bec_lib/devicemanager.py
+++ b/bec_lib/bec_lib/devicemanager.py
@@ -15,10 +15,19 @@ from rich.console import Console
 from rich.table import Table
 from typeguard import typechecked
 
+from bec_lib.atlas_models import Device as DeviceModel
 from bec_lib.bec_errors import DeviceConfigError
 from bec_lib.callback_handler import EventType
 from bec_lib.config_helper import ConfigHelper
-from bec_lib.device import ComputedSignal, Device, DeviceBase, Positioner, ReadoutPriority, Signal
+from bec_lib.device import (
+    ComputedSignal,
+    Device,
+    DeviceBase,
+    Positioner,
+    ReadoutPriority,
+    Signal,
+    set_device_config,
+)
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.logger import bec_logger
 from bec_lib.utils.import_utils import lazy_import_from
@@ -644,24 +653,26 @@ class DeviceManagerBase:
 
         base_class = info["device_info"]["device_base_class"]
         class_name = info["device_info"]["device_class"]
+
         if base_class == "device":
             logger.info(f"Adding new device {name}")
-            obj = Device(name=name, info=info, parent=self, class_name=class_name)
+            obj = Device(name=name, info=info, config=dev, parent=self, class_name=class_name)
         elif base_class == "positioner":
             logger.info(f"Adding new positioner {name}")
-            obj = Positioner(name=name, info=info, parent=self, class_name=class_name)
+            obj = Positioner(name=name, info=info, config=dev, parent=self, class_name=class_name)
         elif base_class == "signal":
             logger.info(f"Adding new signal {name}")
-            obj = Signal(name=name, info=info, parent=self, class_name=class_name)
+            obj = Signal(name=name, info=info, config=dev, parent=self, class_name=class_name)
         elif base_class == "computed_signal":
             logger.info(f"Adding new computed signal {name}")
-            obj = ComputedSignal(name=name, info=info, parent=self, class_name=class_name)
+            obj = ComputedSignal(
+                name=name, info=info, config=dev, parent=self, class_name=class_name
+            )
         else:
             logger.error(f"Trying to add new device {name} of type {base_class}")
             return
 
-        # pylint: disable=protected-access
-        obj._config = dev
+        set_device_config(obj, dev)
         self.devices._add_device(name, obj)
 
     def _remove_device(self, dev_name):

--- a/bec_lib/tests/test_devices.py
+++ b/bec_lib/tests/test_devices.py
@@ -1,9 +1,11 @@
+from typing import Any, Callable, Literal
 from unittest import mock
 
 import pytest
 from typeguard import TypeCheckError
 
 from bec_lib import messages
+from bec_lib.client import BECClient
 from bec_lib.device import (
     AdjustableMixin,
     ComputedSignal,
@@ -19,25 +21,25 @@ from bec_lib.device import (
 from bec_lib.devicemanager import DeviceContainer, DeviceManagerBase
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.tests.fixtures import device_manager_class
-from bec_lib.tests.utils import ConnectorMock, get_device_info_mock
+from bec_lib.tests.utils import ClientMock, ConnectorMock, get_device_info_mock
 
 # pylint: disable=missing-function-docstring
 # pylint: disable=protected-access
 
 
 @pytest.fixture(name="dev")
-def fixture_dev(bec_client_mock):
+def fixture_dev(bec_client_mock: ClientMock | BECClient):
     yield bec_client_mock.device_manager.devices
 
 
-def test_nested_device_root(dev):
+def test_nested_device_root(dev: Any):
     assert dev.dyn_signals.name == "dyn_signals"
     assert dev.dyn_signals.messages.name == "messages"
     assert dev.dyn_signals.root == dev.dyn_signals
     assert dev.dyn_signals.messages.root == dev.dyn_signals
 
 
-def test_read(dev):
+def test_read(dev: Any):
     with mock.patch.object(dev.samx.root.parent.connector, "get") as mock_get:
         mock_get.return_value = messages.DeviceMessage(
             signals={
@@ -56,7 +58,7 @@ def test_read(dev):
         }
 
 
-def test_read_filtered_hints(dev):
+def test_read_filtered_hints(dev: Any):
     with mock.patch.object(dev.samx.root.parent.connector, "get") as mock_get:
         mock_get.return_value = messages.DeviceMessage(
             signals={
@@ -71,7 +73,7 @@ def test_read_filtered_hints(dev):
         assert res == {"samx": {"value": 0, "timestamp": 1701105880.1711318}}
 
 
-def test_read_use_read(dev):
+def test_read_use_read(dev: Any):
     with mock.patch.object(dev.samx.root.parent.connector, "get") as mock_get:
         data = {
             "samx": {"value": 0, "timestamp": 1701105880.1711318},
@@ -86,7 +88,7 @@ def test_read_use_read(dev):
         assert res == data
 
 
-def test_read_nested_device(dev):
+def test_read_nested_device(dev: Any):
     with mock.patch.object(dev.dyn_signals.root.parent.connector, "get") as mock_get:
         data = {
             "dyn_signals_messages_message1": {"value": 0, "timestamp": 1701105880.0716832},
@@ -106,26 +108,32 @@ def test_read_nested_device(dev):
 @pytest.mark.parametrize(
     "kind,cached", [("normal", True), ("hinted", True), ("config", False), ("omitted", False)]
 )
-def test_read_kind_hinted(dev, kind, cached):
-    with mock.patch.object(dev.samx.readback, "_run") as mock_run:
-        with mock.patch.object(dev.samx.root.parent.connector, "get") as mock_get:
-            data = {
-                "samx": {"value": 0, "timestamp": 1701105880.1711318},
-                "samx_setpoint": {"value": 0, "timestamp": 1701105880.1693492},
-                "samx_motor_is_moving": {"value": 0, "timestamp": 1701105880.16935},
-            }
-            mock_get.return_value = messages.DeviceMessage(
-                signals=data, metadata={"scan_id": "scan_id", "scan_type": "scan_type"}
-            )
-            dev.samx.readback._signal_info["kind_str"] = f"Kind.{kind}"
-            res = dev.samx.readback.read(cached=cached)
-            if cached:
-                mock_get.assert_called_once_with(MessageEndpoints.device_readback("samx"))
-                mock_run.assert_not_called()
-                assert res == {"samx": {"value": 0, "timestamp": 1701105880.1711318}}
-            else:
-                mock_run.assert_called_once_with(cached=False, fcn=dev.samx.readback.read)
-                mock_get.assert_not_called()
+def test_read_kind_hinted(
+    dev: Any,
+    kind: Literal["normal"] | Literal["hinted"] | Literal["config"] | Literal["omitted"],
+    cached: bool,
+):
+    with (
+        mock.patch.object(dev.samx.readback, "_run") as mock_run,
+        mock.patch.object(dev.samx.root.parent.connector, "get") as mock_get,
+    ):
+        data = {
+            "samx": {"value": 0, "timestamp": 1701105880.1711318},
+            "samx_setpoint": {"value": 0, "timestamp": 1701105880.1693492},
+            "samx_motor_is_moving": {"value": 0, "timestamp": 1701105880.16935},
+        }
+        mock_get.return_value = messages.DeviceMessage(
+            signals=data, metadata={"scan_id": "scan_id", "scan_type": "scan_type"}
+        )
+        dev.samx.readback._signal_info["kind_str"] = f"Kind.{kind}"
+        res = dev.samx.readback.read(cached=cached)
+        if cached:
+            mock_get.assert_called_once_with(MessageEndpoints.device_readback("samx"))
+            mock_run.assert_not_called()
+            assert res == {"samx": {"value": 0, "timestamp": 1701105880.1711318}}
+        else:
+            mock_run.assert_called_once_with(cached=False, fcn=dev.samx.readback.read)
+            mock_get.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -136,75 +144,73 @@ def test_read_kind_hinted(dev, kind, cached):
         (False, False, "read_configuration"),
     ],
 )
-def test_read_configuration_not_cached(dev, is_signal, is_config_signal, method):
-    with mock.patch.object(
-        dev.samx.readback, "_get_rpc_signal_info", return_value=(is_signal, is_config_signal, False)
+def test_read_configuration_not_cached(
+    dev: Any,
+    is_signal: bool,
+    is_config_signal: bool,
+    method: Literal["read"] | Literal["read_configuration"],
+):
+    with (
+        mock.patch.object(
+            dev.samx.readback,
+            "_get_rpc_signal_info",
+            return_value=(is_signal, is_config_signal, False),
+        ),
+        mock.patch.object(dev.samx.readback, "_run") as mock_run,
     ):
-        with mock.patch.object(dev.samx.readback, "_run") as mock_run:
-            dev.samx.readback.read_configuration(cached=False)
-            mock_run.assert_called_once_with(cached=False, fcn=getattr(dev.samx.readback, method))
+        dev.samx.readback.read_configuration(cached=False)
+        mock_run.assert_called_once_with(cached=False, fcn=getattr(dev.samx.readback, method))
 
 
 @pytest.mark.parametrize(
     "is_signal,is_config_signal,method",
     [(True, False, "read"), (False, True, "redis"), (False, False, "redis")],
 )
-def test_read_configuration_cached(dev, is_signal, is_config_signal, method):
-    with mock.patch.object(
-        dev.samx.readback, "_get_rpc_signal_info", return_value=(is_signal, is_config_signal, True)
+def test_read_configuration_cached(
+    dev: Any, is_signal: bool, is_config_signal: bool, method: Literal["read"] | Literal["redis"]
+):
+    with (
+        mock.patch.object(
+            dev.samx.readback,
+            "_get_rpc_signal_info",
+            return_value=(is_signal, is_config_signal, True),
+        ),
+        mock.patch.object(dev.samx.root.parent.connector, "get") as mock_get,
+        mock.patch.object(dev.samx.readback, "read") as mock_read,
     ):
-        with mock.patch.object(dev.samx.root.parent.connector, "get") as mock_get:
-            mock_get.return_value = messages.DeviceMessage(
-                signals={
-                    "samx": {"value": 0, "timestamp": 1701105880.1711318},
-                    "samx_setpoint": {"value": 0, "timestamp": 1701105880.1693492},
-                    "samx_motor_is_moving": {"value": 0, "timestamp": 1701105880.16935},
-                },
-                metadata={"scan_id": "scan_id", "scan_type": "scan_type"},
-            )
-            with mock.patch.object(dev.samx.readback, "read") as mock_read:
-                dev.samx.readback.read_configuration(cached=True)
-                if method == "redis":
-                    mock_get.assert_called_once_with(
-                        MessageEndpoints.device_read_configuration("samx")
-                    )
-                    mock_read.assert_not_called()
-                else:
-                    mock_read.assert_called_once_with(cached=True)
-                    mock_get.assert_not_called()
+        mock_get.return_value = messages.DeviceMessage(
+            signals={
+                "samx": {"value": 0, "timestamp": 1701105880.1711318},
+                "samx_setpoint": {"value": 0, "timestamp": 1701105880.1693492},
+                "samx_motor_is_moving": {"value": 0, "timestamp": 1701105880.16935},
+            },
+            metadata={"scan_id": "scan_id", "scan_type": "scan_type"},
+        )
+        dev.samx.readback.read_configuration(cached=True)
+        if method == "redis":
+            mock_get.assert_called_once_with(MessageEndpoints.device_read_configuration("samx"))
+            mock_read.assert_not_called()
+        else:
+            mock_read.assert_called_once_with(cached=True)
+            mock_get.assert_not_called()
 
 
-def test_run_rpc_call(dev):
-    with mock.patch.object(dev.samx.setpoint, "_get_rpc_response") as mock_rpc:
-        dev.samx.setpoint.set(1)
-        mock_rpc.assert_called_once()
+@pytest.mark.parametrize(
+    ["mock_rpc", "method", "args", "kwargs", "expected_call"],
+    [
+        ("_get_rpc_response", "set", (1,), {}, (mock.ANY, mock.ANY)),
+        ("_run_rpc_call", "set", (1,), {}, ("samx", "setpoint.set", 1)),
+        ("_run_rpc_call", "put", (1,), {"wait": True}, ("samx", "setpoint.set", 1)),
+        ("_run_rpc_call", "put", (1,), {}, ("samx", "setpoint.put", 1)),
+    ],
+)
+def test_run_rpc_call(dev: Any, mock_rpc, method, args, kwargs, expected_call):
+    with mock.patch.object(dev.samx.setpoint, mock_rpc) as mock_rpc:
+        getattr(dev.samx.setpoint, method)(*args, **kwargs)
+        mock_rpc.assert_called_once_with(*expected_call)
 
 
-def test_set_calls_rpc(dev):
-    with mock.patch.object(dev.samx.setpoint, "_run_rpc_call") as mock_rpc:
-        dev.samx.setpoint.set(1)
-        mock_rpc.assert_called_once_with("samx", "setpoint.set", 1)
-
-
-def test_put_calls_set_if_wait(dev):
-    with mock.patch.object(dev.samx.setpoint, "_run_rpc_call") as mock_rpc:
-        dev.samx.setpoint.put(1, wait=True)
-        mock_rpc.assert_called_once_with("samx", "setpoint.set", 1)
-
-
-def test_put_calls_rpc(dev):
-    with mock.patch.object(dev.samx.setpoint, "_run_rpc_call") as mock_rpc:
-        dev.samx.setpoint.put(1)
-        mock_rpc.assert_called_once_with("samx", "setpoint.put", 1)
-
-
-def test_get_rpc_func_name_decorator(dev):
-    with mock.patch.object(dev.samx.setpoint, "_run_rpc_call") as mock_rpc:
-        dev.samx.setpoint.set(1)
-        mock_rpc.assert_called_once_with("samx", "setpoint.set", 1)
-
-
-def test_get_rpc_func_name_read(dev):
+def test_get_rpc_func_name_read(dev: Any):
     with mock.patch.object(dev.samx, "_run_rpc_call") as mock_rpc:
         dev.samx.read(cached=False)
         mock_rpc.assert_called_once_with("samx", "read")
@@ -213,28 +219,34 @@ def test_get_rpc_func_name_read(dev):
 @pytest.mark.parametrize(
     "kind,cached", [("normal", True), ("hinted", True), ("config", False), ("omitted", False)]
 )
-def test_get_rpc_func_name_readback_get(dev, kind, cached):
-    with mock.patch.object(dev.samx.readback, "_run") as mock_rpc:
-        with mock.patch.object(dev.samx.root.parent.connector, "get") as mock_get:
-            mock_get.return_value = messages.DeviceMessage(
-                signals={
-                    "samx": {"value": 0, "timestamp": 1701105880.1711318},
-                    "samx_setpoint": {"value": 0, "timestamp": 1701105880.1693492},
-                    "samx_motor_is_moving": {"value": 0, "timestamp": 1701105880.16935},
-                },
-                metadata={"scan_id": "scan_id", "scan_type": "scan_type"},
-            )
-            dev.samx.readback._signal_info["kind_str"] = f"Kind.{kind}"
-            dev.samx.readback.get(cached=cached)
-            if cached:
-                mock_get.assert_called_once_with(MessageEndpoints.device_readback("samx"))
-                mock_rpc.assert_not_called()
-            else:
-                mock_rpc.assert_called_once_with(cached=False, fcn=dev.samx.readback.get)
-                mock_get.assert_not_called()
+def test_get_rpc_func_name_readback_get(
+    dev: Any,
+    kind: Literal["normal"] | Literal["hinted"] | Literal["config"] | Literal["omitted"],
+    cached: bool,
+):
+    with (
+        mock.patch.object(dev.samx.readback, "_run") as mock_rpc,
+        mock.patch.object(dev.samx.root.parent.connector, "get") as mock_get,
+    ):
+        mock_get.return_value = messages.DeviceMessage(
+            signals={
+                "samx": {"value": 0, "timestamp": 1701105880.1711318},
+                "samx_setpoint": {"value": 0, "timestamp": 1701105880.1693492},
+                "samx_motor_is_moving": {"value": 0, "timestamp": 1701105880.16935},
+            },
+            metadata={"scan_id": "scan_id", "scan_type": "scan_type"},
+        )
+        dev.samx.readback._signal_info["kind_str"] = f"Kind.{kind}"
+        dev.samx.readback.get(cached=cached)
+        if cached:
+            mock_get.assert_called_once_with(MessageEndpoints.device_readback("samx"))
+            mock_rpc.assert_not_called()
+        else:
+            mock_rpc.assert_called_once_with(cached=False, fcn=dev.samx.readback.get)
+            mock_get.assert_not_called()
 
 
-def test_get_rpc_func_name_nested(dev):
+def test_get_rpc_func_name_nested(dev: Any):
     with mock.patch.object(
         dev.rt_controller._custom_rpc_methods["dummy_controller"]._custom_rpc_methods[
             "_func_with_args"
@@ -245,12 +257,12 @@ def test_get_rpc_func_name_nested(dev):
         mock_rpc.assert_called_once_with("rt_controller", "dummy_controller._func_with_args", 1, 2)
 
 
-def test_handle_rpc_response(dev):
+def test_handle_rpc_response(dev: Any):
     msg = messages.DeviceRPCMessage(device="samx", return_val=1, out="done", success=True)
     assert dev.samx._handle_rpc_response(msg) == 1
 
 
-def test_handle_rpc_response_returns_status(dev, bec_client_mock):
+def test_handle_rpc_response_returns_status(dev: Any, bec_client_mock: ClientMock | BECClient):
     msg = messages.DeviceRPCMessage(
         device="samx", return_val={"type": "status", "RID": "request_id"}, out="done", success=True
     )
@@ -259,7 +271,7 @@ def test_handle_rpc_response_returns_status(dev, bec_client_mock):
     )
 
 
-def test_rpc_status_raises_error(dev):
+def test_rpc_status_raises_error(dev: Any):
     msg = messages.DeviceReqStatusMessage(device="samx", success=False, metadata={})
     connector = mock.MagicMock()
     status = Status(connector, "request_id")
@@ -270,7 +282,7 @@ def test_rpc_status_raises_error(dev):
     status.wait(raise_on_failure=False)
 
 
-def test_handle_rpc_response_raises(dev):
+def test_handle_rpc_response_raises(dev: Any):
     msg = messages.DeviceRPCMessage(
         device="samx",
         return_val={"type": "status", "RID": "request_id"},
@@ -285,12 +297,12 @@ def test_handle_rpc_response_raises(dev):
         dev.samx._handle_rpc_response(msg)
 
 
-def test_handle_rpc_response_returns_dict(dev):
+def test_handle_rpc_response_returns_dict(dev: Any):
     msg = messages.DeviceRPCMessage(device="samx", return_val={"a": "b"}, out="done", success=True)
     assert dev.samx._handle_rpc_response(msg) == {"a": "b"}
 
 
-def test_run_rpc_call_calls_stop_on_keyboardinterrupt(dev):
+def test_run_rpc_call_calls_stop_on_keyboardinterrupt(dev: Any):
     with mock.patch.object(dev.samx.setpoint, "_prepare_rpc_msg") as mock_rpc:
         mock_rpc.side_effect = [KeyboardInterrupt]
         with pytest.raises(RPCError):
@@ -316,34 +328,45 @@ def device_config():
     }
 
 
+BASIC_CONFIG = {
+    "enabled": True,
+    "deviceClass": "TestDevice",
+    "readoutPriority": ReadoutPriority.MONITORED.value,
+}
+
+
 @pytest.fixture
-def device_obj(device_config):
+def dev_w_config():
+    def _func(config: dict = {}):
+        return DeviceBase(
+            name="test", config=BASIC_CONFIG | config, parent=mock.MagicMock(spec=DeviceManagerBase)
+        )
+
+    return _func
+
+
+@pytest.fixture
+def device_obj(device_config: dict[str, Any]):
     service_mock = mock.MagicMock()
     service_mock.connector = ConnectorMock("")
     dm = DeviceManagerBase(service_mock)
     info = get_device_info_mock(device_config["name"], device_config["deviceClass"])
     dm._add_device(device_config, info)
-    obj = dm.devices[device_config["name"]]
-    yield obj
+    yield dm.devices[device_config["name"]]
 
 
-def _all_in_a_in_b(a: dict, b: dict):
-    return {k: v for k, v in b.items() if k in a} == a
+def test_create_device_saves_config(device_obj: DeviceBase, device_config: dict[str, Any]):
+    assert {k: v for k, v in device_obj._config.items() if k in device_config} == device_config
 
 
-def test_create_device_saves_config(device_obj, device_config):
-    assert _all_in_a_in_b(device_config, device_obj._config)
-
-
-def test_device_enabled(device_obj, device_config):
-    obj = device_obj
-    assert obj.enabled == device_config["enabled"]
+def test_device_enabled(device_obj: DeviceBase, device_config: dict[str, Any]):
+    assert device_obj.enabled == device_config["enabled"]
     device_config["enabled"] = False
-    set_device_config(obj, device_config)
-    assert obj.enabled == device_config["enabled"]
+    set_device_config(device_obj, device_config)
+    assert device_obj.enabled == device_config["enabled"]
 
 
-def test_device_enable(device_obj):
+def test_device_enable(device_obj: DeviceBase):
     with mock.patch.object(device_obj.parent.config_helper, "send_config_request") as config_req:
         device_obj.enabled = True
         config_req.assert_called_once_with(
@@ -351,28 +374,30 @@ def test_device_enable(device_obj):
         )
 
 
-def test_device_enable_set(device_obj):
-    obj = device_obj
-    with mock.patch.object(obj.parent.config_helper, "send_config_request") as config_req:
-        obj.read_only = False
-        config_req.assert_called_once_with(action="update", config={obj.name: {"readOnly": False}})
+def test_device_enable_set(device_obj: DeviceBase):
+    with mock.patch.object(device_obj.parent.config_helper, "send_config_request") as config_req:
+        device_obj.read_only = False
+        config_req.assert_called_once_with(
+            action="update", config={device_obj.name: {"readOnly": False}}
+        )
 
 
 @pytest.mark.parametrize(
     "val,raised_error",
     [({"in": 5}, None), ({"in": 5, "out": 10}, None), ({"5", "4"}, TypeCheckError)],
 )
-def test_device_set_user_parameter(device_obj, val, raised_error):
-    obj = device_obj
-    with mock.patch.object(obj.parent.config_helper, "send_config_request") as config_req:
+def test_device_set_user_parameter(
+    device_obj: DeviceBase, val: dict[str, int] | set[str], raised_error: None | TypeCheckError
+):
+    with mock.patch.object(device_obj.parent.config_helper, "send_config_request") as config_req:
         if raised_error is None:
-            obj.set_user_parameter(val)
+            device_obj.set_user_parameter(val)
             config_req.assert_called_once_with(
-                action="update", config={obj.name: {"userParameter": val}}
+                action="update", config={device_obj.name: {"userParameter": val}}
             )
         else:
             with pytest.raises(raised_error):
-                obj.set_user_parameter(val)
+                device_obj.set_user_parameter(val)
 
 
 @pytest.mark.parametrize(
@@ -384,18 +409,23 @@ def test_device_set_user_parameter(device_obj, val, raised_error):
         (None, {"in": 5}, {"in": 5}, None),
     ],
 )
-def test_device_update_user_parameter(device_obj, user_param, val, out, raised_error):
-    obj = device_obj
-    obj._config["userParameter"] = user_param
-    with mock.patch.object(obj.parent.config_helper, "send_config_request") as config_req:
+def test_device_update_user_parameter(
+    device_obj: DeviceBase,
+    user_param: dict[str, int] | None,
+    val: dict[str, int] | set[str],
+    out: dict[str, int] | None,
+    raised_error: None | TypeCheckError,
+):
+    device_obj._config["userParameter"] = user_param
+    with mock.patch.object(device_obj.parent.config_helper, "send_config_request") as config_req:
         if raised_error is None:
-            obj.update_user_parameter(val)
+            device_obj.update_user_parameter(val)
             config_req.assert_called_once_with(
-                action="update", config={obj.name: {"userParameter": out}}
+                action="update", config={device_obj.name: {"userParameter": out}}
             )
         else:
             with pytest.raises(raised_error):
-                obj.update_user_parameter(val)
+                device_obj.update_user_parameter(val)
 
 
 def test_status_wait():
@@ -417,177 +447,119 @@ def test_status_wait_raises_timeout():
         status.wait(timeout=0.1)
 
 
-BASIC_CONFIG = {
-    "enabled": True,
-    "deviceClass": "TestDevice",
-    "readoutPriority": ReadoutPriority.MONITORED.value,
-}
-
-
-def test_device_get_device_config():
-    device = DeviceBase(name="test", config=BASIC_CONFIG | {"deviceConfig": {"tolerance": 1}})
-    assert device.get_device_config() == {"tolerance": 1}
-
-
-def test_device_set_device_config():
-    parent = mock.MagicMock(spec=DeviceManagerBase)
-    device = DeviceBase(
-        name="test", config=BASIC_CONFIG | {"deviceConfig": {"tolerance": 1}}, parent=parent
-    )
+def test_device_set_device_config(dev_w_config: Callable[..., DeviceBase]):
+    device = dev_w_config({"deviceConfig": {"tolerance": 1}})
     device.set_device_config({"tolerance": 2})
     assert device.get_device_config() == {"tolerance": 2}
-    parent.config_helper.send_config_request.assert_called_once()
+    device.parent.config_helper.send_config_request.assert_called_once()
 
 
-def test_get_device_tags():
-    device = DeviceBase(name="test", config=BASIC_CONFIG | {"deviceTags": ["tag1", "tag2"]})
-    assert device.get_device_tags() == ["tag1", "tag2"]
-
-    device = DeviceBase(name="test", config=BASIC_CONFIG)
-    assert device.get_device_tags() == []
-
-
-def test_set_device_tags():
-    parent = mock.MagicMock(spec=DeviceManagerBase)
-    device = DeviceBase(
-        name="test", config=BASIC_CONFIG | {"deviceTags": ["tag1", "tag2"]}, parent=parent
+@pytest.fixture
+def device_w_tags(dev_w_config: Callable[..., DeviceBase]):
+    yield (d := dev_w_config({"deviceTags": ["tag1", "tag2"]}))
+    assert d.parent.config_helper.send_config_request.call_count == int(
+        d.get_device_tags() != ["tag1", "tag2"]
     )
-    device.set_device_tags(["tag3", "tag4"])
-    assert device.get_device_tags() == ["tag3", "tag4"]
-    parent.config_helper.send_config_request.assert_called_once()
 
 
-def test_add_device_tag():
-    parent = mock.MagicMock(spec=DeviceManagerBase)
-    device = DeviceBase(
-        name="test", config=BASIC_CONFIG | {"deviceTags": ["tag1", "tag2"]}, parent=parent
-    )
-    device.add_device_tag("tag3")
-    assert device.get_device_tags() == ["tag1", "tag2", "tag3"]
-    parent.config_helper.send_config_request.assert_called_once()
+@pytest.mark.parametrize(
+    ["method", "args", "result"],
+    [
+        ("set_device_tags", ["tag3", "tag4"], ["tag3", "tag4"]),
+        ("add_device_tag", "tag3", ["tag1", "tag2", "tag3"]),
+        ("add_device_tag", "tag1", ["tag1", "tag2"]),
+        ("remove_device_tag", "tag1", ["tag2"]),
+    ],
+)
+def test_set_device_tags(device_w_tags, method, args, result):
+    getattr(device_w_tags, method)(args)
+    assert device_w_tags.get_device_tags() == result
 
 
-def test_add_device_tags_duplicate():
-    parent = mock.MagicMock(spec=DeviceManagerBase)
-    device = DeviceBase(
-        name="test", config=BASIC_CONFIG | {"deviceTags": ["tag1", "tag2"]}, parent=parent
-    )
-    device.add_device_tag("tag1")
-    assert device.get_device_tags() == ["tag1", "tag2"]
-    parent.config_helper.send_config_request.assert_not_called()
-
-
-def test_remove_device_tag():
-    parent = mock.MagicMock(spec=DeviceManagerBase)
-    device = DeviceBase(
-        name="test", config=BASIC_CONFIG | {"deviceTags": ["tag1", "tag2"]}, parent=parent
-    )
-    device.remove_device_tag("tag1")
-    assert device.get_device_tags() == ["tag2"]
-    parent.config_helper.send_config_request.assert_called_once()
-
-
-def test_device_wm():
-    parent = mock.MagicMock(spec=DeviceManagerBase)
-    device = DeviceBase(
-        name="test", config=BASIC_CONFIG | {"deviceTags": ["tag1", "tag2"]}, parent=parent
-    )
-    with mock.patch.object(parent.devices, "wm", new_callable=mock.PropertyMock) as wm:
-        res = device.wm
-        parent.devices.wm.assert_called_once()
-
-
-def test_readout_priority():
-    parent = mock.MagicMock(spec=DeviceManagerBase)
-    device = DeviceBase(
-        name="test", config=BASIC_CONFIG | {"readoutPriority": "baseline"}, parent=parent
-    )
-    assert device.readout_priority == "baseline"
-
-
-def test_set_readout_priority():
-    parent = mock.MagicMock(spec=DeviceManagerBase)
-    device = DeviceBase(
-        name="test", config=BASIC_CONFIG | {"readoutPriority": "baseline"}, parent=parent
-    )
-    device.readout_priority = "monitored"
-    assert device.readout_priority == "monitored"
-    parent.config_helper.send_config_request.assert_called_once()
-
-
-def test_on_failure():
-    parent = mock.MagicMock(spec=DeviceManagerBase)
-    device = DeviceBase(name="test", config=BASIC_CONFIG | {"onFailure": "buffer"}, parent=parent)
-    assert device.on_failure == "buffer"
-
-
-def test_set_on_failure():
-    parent = mock.MagicMock(spec=DeviceManagerBase)
-    device = DeviceBase(name="test", config=BASIC_CONFIG | {"onFailure": "buffer"}, parent=parent)
-    device.on_failure = "retry"
-    assert device.on_failure == "retry"
-    parent.config_helper.send_config_request.assert_called_once()
-
-
-def test_read_only():
-    parent = mock.MagicMock(spec=DeviceManagerBase)
-    device = DeviceBase(name="test", config=BASIC_CONFIG | {"read_only": False}, parent=parent)
-    assert device.read_only is False
-
-
-def test_set_read_only():
-    parent = mock.MagicMock(spec=DeviceManagerBase)
-    device = DeviceBase(name="test", config=BASIC_CONFIG | {"read_only": False}, parent=parent)
-    device.read_only = True
-    assert device.read_only is True
-    parent.config_helper.send_config_request.assert_called_once()
-
-
-def test_device_container_wm():
-    devs = DeviceContainer()
-    devs["test"] = Device(
-        name="test", config=BASIC_CONFIG, parent=mock.MagicMock(spec=DeviceManagerBase)
-    )
-    with mock.patch.object(devs.test, "read", return_value={"test": {"value": 1}}) as read:
-        devs.wm("test")
-        devs.wm("tes*")
-
-
-def test_device_container_wm_with_setpoint():
-    devs = DeviceContainer()
-    devs["test"] = Device(
-        name="test", config=BASIC_CONFIG, parent=mock.MagicMock(spec=DeviceManagerBase)
-    )
+def test_device_wm(device_w_tags):
     with mock.patch.object(
-        devs.test, "read", return_value={"test": {"value": 1}, "test_setpoint": {"value": 1}}
-    ) as read:
-        devs.wm("test")
+        device_w_tags.parent.devices, "wm", new_callable=mock.PropertyMock
+    ) as wm:
+        _ = device_w_tags.wm
+        device_w_tags.parent.devices.wm.assert_called_once()
 
 
-def test_device_container_wm_with_user_setpoint():
-    devs = DeviceContainer()
-    devs["test"] = Device(
+@pytest.mark.parametrize(
+    ["config", "attr", "value"],
+    [
+        ({"onFailure": "buffer"}, "on_failure", "buffer"),
+        ({"readoutPriority": "baseline"}, "readout_priority", "baseline"),
+        ({"read_only": False}, "read_only", False),
+    ],
+)
+def test_properties(dev_w_config: Callable[..., DeviceBase], config, attr, value):
+    assert getattr(dev_w_config(config), attr) == value
+
+
+@pytest.mark.parametrize(
+    ["config", "method", "value"],
+    [
+        ({"deviceTags": ["tag1", "tag2"]}, "get_device_tags", ["tag1", "tag2"]),
+        ({"deviceConfig": {"tolerance": 1}}, "get_device_config", {"tolerance": 1}),
+    ],
+)
+def test_methods(dev_w_config: Callable[..., DeviceBase], config, method, value):
+    assert getattr(dev_w_config(config), method)() == value
+
+
+@pytest.mark.parametrize(
+    ["config", "attr", "value", "result"],
+    [
+        ({"readoutPriority": "baseline"}, "readout_priority", "monitored", "monitored"),
+        ({"onFailure": "buffer"}, "on_failure", "retry", "retry"),
+        ({"read_only": False}, "read_only", True, True),
+    ],
+)
+def test_properties_assign(dev_w_config: Callable[..., DeviceBase], config, attr, value, result):
+    device = dev_w_config(config)
+    setattr(device, attr, value)
+    assert getattr(device, attr) == result
+    device.parent.config_helper.send_config_request.assert_called_once()
+
+
+@pytest.fixture
+def dev_container():
+    (devs := DeviceContainer())["test"] = Device(
         name="test", config=BASIC_CONFIG, parent=mock.MagicMock(spec=DeviceManagerBase)
     )
-    with mock.patch.object(
-        devs.test, "read", return_value={"test": {"value": 1}, "test_user_setpoint": {"value": 1}}
-    ) as read:
-        devs.wm("test")
+    return devs
+
+
+def test_device_container_wm(dev_container):
+    with mock.patch.object(dev_container.test, "read", return_value={"test": {"value": 1}}) as read:
+        dev_container.wm("test")
+        dev_container.wm("tes*")
+
+
+@pytest.mark.parametrize(
+    "reading",
+    [
+        {"test": {"value": 1}, "test_setpoint": {"value": 1}},
+        {"test": {"value": 1}, "test_user_setpoint": {"value": 1}},
+    ],
+)
+def test_device_container_wm_with_setpoint_names(dev_container, reading):
+    with mock.patch.object(dev_container.test, "read", return_value=reading) as read:
+        dev_container.wm("test")
 
 
 @pytest.mark.parametrize("device_cls", [Device, Signal, Positioner])
-def test_device_has_describe_method(device_cls):
-    devs = DeviceContainer()
+def test_device_has_describe_method(device_cls: Device | Signal | Positioner, dev_container):
     parent = mock.MagicMock(spec=DeviceManagerBase)
-    devs["test"] = device_cls(name="test", config=BASIC_CONFIG, parent=parent)
-    assert hasattr(devs.test, "describe")
-    with mock.patch.object(devs.test, "_run_rpc_call") as mock_rpc:
-        devs.test.describe()
+    dev_container["test"] = device_cls(name="test", config=BASIC_CONFIG, parent=parent)
+    assert hasattr(dev_container.test, "describe")
+    with mock.patch.object(dev_container.test, "_run_rpc_call") as mock_rpc:
+        dev_container.test.describe()
         mock_rpc.assert_not_called()
 
 
 @pytest.mark.parametrize("device_cls", [Device, Signal, Positioner])
-def test_device_has_describe_configuration_method(device_cls):
+def test_device_has_describe_configuration_method(device_cls: Device | Signal | Positioner):
     devs = DeviceContainer()
     parent = mock.MagicMock(spec=DeviceManagerBase)
     devs["test"] = device_cls(name="test", config=BASIC_CONFIG, parent=parent)
@@ -641,33 +613,31 @@ def test_show_all():
     console.print.assert_called_once()
 
 
-def test_adjustable_mixin_limits():
-    adj = AdjustableMixin()
-    adj.root = mock.MagicMock()
+@pytest.fixture()
+def adj():
+    (adj := AdjustableMixin()).root = mock.MagicMock()
+    adj.update_config = mock.MagicMock()
+    return adj
+
+
+def test_adjustable_mixin_limits(adj):
     adj.root.parent.connector.get.return_value = messages.DeviceMessage(
         signals={"low": {"value": -12}, "high": {"value": 12}}, metadata={}
     )
     assert adj.limits == [-12, 12]
 
 
-def test_adjustable_mixin_limits_missing():
-    adj = AdjustableMixin()
-    adj.root = mock.MagicMock()
+def test_adjustable_mixin_limits_missing(adj):
     adj.root.parent.connector.get.return_value = None
     assert adj.limits == [0, 0]
 
 
-def test_adjustable_mixin_set_limits():
-    adj = AdjustableMixin()
-    adj.update_config = mock.MagicMock()
+def test_adjustable_mixin_set_limits(adj):
     adj.limits = [-12, 12]
     adj.update_config.assert_called_once_with({"deviceConfig": {"limits": [-12, 12]}})
 
 
-def test_adjustable_mixin_set_low_limit():
-    adj = AdjustableMixin()
-    adj.update_config = mock.MagicMock()
-    adj.root = mock.MagicMock()
+def test_adjustable_mixin_set_low_limit(adj):
     adj.root.parent.connector.get.return_value = messages.DeviceMessage(
         signals={"low": {"value": -12}, "high": {"value": 12}}, metadata={}
     )
@@ -675,10 +645,7 @@ def test_adjustable_mixin_set_low_limit():
     adj.update_config.assert_called_once_with({"deviceConfig": {"limits": [-20, 12]}})
 
 
-def test_adjustable_mixin_set_high_limit():
-    adj = AdjustableMixin()
-    adj.update_config = mock.MagicMock()
-    adj.root = mock.MagicMock()
+def test_adjustable_mixin_set_high_limit(adj):
     adj.root.parent.connector.get.return_value = messages.DeviceMessage(
         signals={"low": {"value": -12}, "high": {"value": 12}}, metadata={}
     )
@@ -732,7 +699,7 @@ def test_computed_signal_raises_error_on_set_compute_method():
         comp_signal.set_compute_method("a + b")
 
 
-def test_device_summary(dev):
+def test_device_summary(dev: Any):
     """Test that the device summary method creates a table with the correct structure."""
     with mock.patch("rich.console.Console.print") as mock_print:
         dev.samx.summary()
@@ -749,7 +716,7 @@ def test_device_summary(dev):
         ]
 
 
-def test_device_summary_signal_grouping(dev):
+def test_device_summary_signal_grouping(dev: Any):
     """Test that signals are correctly grouped by kind in the summary table."""
 
     with mock.patch("rich.console.Console.print"):
@@ -789,7 +756,7 @@ def test_device_summary_signal_grouping(dev):
             ]
 
 
-def test_device_summary_empty_signals(dev):
+def test_device_summary_empty_signals(dev: Any):
     """Test that summary handles devices with no signals."""
     # Create a device with no signals
     device = Device(name="empty_device", info={"signals": {}})


### PR DESCRIPTION
- make `DeviceBase` run the config initialisation through a relaxed model to ensure all required keys are present
- update tests to match
- tidy tests a little