### PR TITLE
feat(endpoints): publish endpoint info to redis; closes #323

### DIFF
--- a/bec_lib/bec_lib/endpoints.py
+++ b/bec_lib/bec_lib/endpoints.py
@@ -1549,3 +1549,19 @@ class MessageEndpoints:
             message_type=messages.ACLAccountsMessage,
             message_op=MessageOp.KEY_VALUE,
         )
+
+    @staticmethod
+    def endpoint_info():
+        """
+        Endpoint for endpoint info. This endpoint is used to publish the endpoint info using a
+        messages.EndpointInfoMessage message.
+
+        Returns:
+            EndpointInfo: Endpoint for endpoint info.
+        """
+        endpoint = f"{EndpointType.PUBLIC.value}/endpoints"
+        return EndpointInfo(
+            endpoint=endpoint,
+            message_type=messages.AvailableResourceMessage,
+            message_op=MessageOp.KEY_VALUE,
+        )

--- a/bec_lib/bec_lib/messages.py
+++ b/bec_lib/bec_lib/messages.py
@@ -1122,3 +1122,17 @@ class ACLAccountsMessage(BECMessage):
     accounts: dict[
         str, dict[Literal["categories", "keys", "channels", "commands", "profile"], list[str] | str]
     ]
+
+
+class EndpointInfoMessage(BECMessage):
+    """
+    Message for endpoint information
+
+    Args:
+        endpoint (str): Endpoint URL
+        metadata (dict, optional): Additional metadata.
+    """
+
+    msg_type: ClassVar[str] = "endpoint_info_message"
+    endpoint: str
+    metadata: dict | None = Field(default_factory=dict)

--- a/bec_server/tests/tests_scihub/test_atlas_connector.py
+++ b/bec_server/tests/tests_scihub/test_atlas_connector.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+from bec_lib import messages
 from bec_server.scihub.atlas.atlas_connector import AtlasConnector
 
 
@@ -44,3 +45,12 @@ def test_atlas_connector_ingest_data(atlas_connector):
         mock_xadd.assert_called_once_with(
             "internal/deployment/test-deployment/ingest", {"data": "dummy_data"}, max_size=1000
         )
+
+
+def test_atlas_connector_update_available_endpoints(atlas_connector):
+    with mock.patch.object(atlas_connector.connector, "set") as mock_set:
+        atlas_connector.update_available_endpoints()
+        mock_set.assert_called_once()
+        msg = mock_set.mock_calls[0][1][1]
+        assert isinstance(msg, messages.AvailableResourceMessage)
+        assert "device_readback" in msg.resource


### PR DESCRIPTION
This PR adds endpoint info to redis. This is useful for clients written in a different language to inspect the available endpoints and their signature. 

closes #323 