### PR TITLE
feat(serializer): speed up serialization by avoiding ExtType; add new…

### DIFF
--- a/bec_lib/bec_lib/codecs.py
+++ b/bec_lib/bec_lib/codecs.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import enum
+from abc import ABC, abstractmethod
+from typing import Any, Type
+
+import numpy as np
+from pydantic import BaseModel
+
+from bec_lib import messages as messages_module
+from bec_lib import numpy_encoder
+from bec_lib.device import DeviceBase
+from bec_lib.endpoints import EndpointInfo
+from bec_lib.messages import BECMessage, BECStatus
+
+
+class BECCodec(ABC):
+    """Abstract base class for custom encoders"""
+
+    obj_type: Type | list[Type]
+
+    @staticmethod
+    @abstractmethod
+    def encode(obj: Any) -> Any:
+        """Encode an object into a serializable format."""
+
+    @staticmethod
+    @abstractmethod
+    def decode(type_name: str, data: dict):
+        """Decode data into an object."""
+
+
+class NumpyEncoder(BECCodec):
+    obj_type: list[Type] = [np.ndarray, np.bool_, np.number, complex]
+
+    @staticmethod
+    def encode(obj: np.ndarray) -> dict:
+        return numpy_encoder.numpy_encode(obj)
+
+    @staticmethod
+    def decode(type_name: str, data: dict) -> np.ndarray:
+        return numpy_encoder.numpy_decode(data)
+
+
+class NumpyEncoderList(BECCodec):
+    obj_type: list[Type] = [np.ndarray, np.bool_, np.number, complex]
+
+    @staticmethod
+    def encode(obj: np.ndarray) -> dict:
+        return numpy_encoder.numpy_encode_list(obj)
+
+    @staticmethod
+    def decode(type_name: str, data: dict) -> np.ndarray:
+        return numpy_encoder.numpy_decode_list(data)
+
+
+class BECMessageEncoder(BECCodec):
+    obj_type: Type = BECMessage
+
+    @staticmethod
+    def encode(obj: BECMessage) -> dict:
+        return obj.__dict__
+
+    @staticmethod
+    def decode(type_name: str, data: dict) -> BECMessage:
+        return getattr(messages_module, type_name)(**data)
+
+
+class EnumEncoder(BECCodec):
+    obj_type: Type = enum.Enum
+
+    @staticmethod
+    def encode(obj: enum.Enum) -> Any:
+        return obj.value
+
+    @staticmethod
+    def decode(type_name: str, data: Any) -> Any:
+        if type_name == "BECStatus":
+            return BECStatus(data)
+        return data
+
+
+class BECDeviceEncoder(BECCodec):
+    obj_type: Type = DeviceBase
+
+    @staticmethod
+    def encode(obj: DeviceBase) -> str:
+        if hasattr(obj, "_compile_function_path"):
+            # pylint: disable=protected-access
+            return obj._compile_function_path()
+        return obj.name
+
+    @staticmethod
+    def decode(type_name: str, data: str) -> str:
+        """
+        DeviceBase objects are encoded as strings. No decoding is necessary.
+        """
+        return data
+
+
+class PydanticEncoder(BECCodec):
+    obj_type: Type = BaseModel
+
+    @staticmethod
+    def encode(obj: BaseModel) -> dict:
+        return obj.model_dump()
+
+    @staticmethod
+    def decode(type_name: str, data: dict) -> dict:
+        return data
+
+
+class EndpointInfoEncoder(BECCodec):
+    obj_type: Type = EndpointInfo
+
+    @staticmethod
+    def encode(obj: EndpointInfo) -> dict:
+        return {
+            "endpoint": obj.endpoint,
+            "message_type": obj.message_type.__name__,
+            "message_op": obj.message_op,
+        }
+
+    @staticmethod
+    def decode(type_name: str, data: dict) -> EndpointInfo:
+        return EndpointInfo(
+            endpoint=data["endpoint"],
+            message_type=getattr(messages_module, data["message_type"]),
+            message_op=data["message_op"],
+        )
+
+
+class SetEncoder(BECCodec):
+    obj_type: Type = set
+
+    @staticmethod
+    def encode(obj: set) -> list:
+        return list(obj)
+
+    @staticmethod
+    def decode(type_name: str, data: list) -> set:
+        return set(data)
+
+
+class BECTypeEncoder(BECCodec):
+    obj_type: Type = type
+
+    @staticmethod
+    def encode(obj: type) -> dict:
+        return {"type_name": obj.__name__, "module": obj.__module__}
+
+    @staticmethod
+    def decode(type_name: str, data: dict) -> type:
+        if data["module"] == "builtins":
+            return __builtins__.get(data["type_name"])
+        if data["module"] == "bec_lib.messages":
+            return getattr(messages_module, data["type_name"])
+        if data["module"] == "numpy":
+            return getattr(np, data["type_name"])
+        raise ValueError(f"Unknown type {data['type_name']} in module {data['module']}")

--- a/bec_lib/bec_lib/numpy_encoder.py
+++ b/bec_lib/bec_lib/numpy_encoder.py
@@ -103,7 +103,7 @@ def numpy_encode_list(obj, chain=None):
 
         return {"nd": True, "type": descr, "kind": kind, "shape": obj.shape, "data": obj.tolist()}
     if isinstance(obj, (np.bool_, np.number)):
-        return {"nd": False, "type": obj.dtype.str, "data": obj.data}
+        return {"nd": False, "type": obj.__class__.__name__, "data": obj.data.tolist()}
     if isinstance(obj, complex):
         return {"complex": True, "data": repr(obj)}
 
@@ -130,7 +130,8 @@ def numpy_decode_list(obj, chain=None):
                     descr = obj["type"]
                 return np.array(obj["data"], dtype=_unpack_dtype(descr)).reshape(obj["shape"])
             descr = obj["type"]
-            return np.array(obj["data"], dtype=_unpack_dtype(descr))[0]
+            numpy_dtype = getattr(np, descr)
+            return numpy_dtype(obj["data"])
         if "complex" in obj:
             return complex(tostr(obj["data"]))
         return obj if chain is None else chain(obj)

--- a/bec_lib/bec_lib/serialization.py
+++ b/bec_lib/bec_lib/serialization.py
@@ -6,405 +6,18 @@ from __future__ import annotations
 
 import contextlib
 import gc
-import inspect
 import json
 from abc import abstractmethod
 
 import msgpack as msgpack_module
-from pydantic import BaseModel
 
 from bec_lib import messages as messages_module
-from bec_lib import numpy_encoder
-from bec_lib.device import DeviceBase
-from bec_lib.endpoints import EndpointInfo
 from bec_lib.logger import bec_logger
-from bec_lib.messages import BECMessage, BECStatus
+from bec_lib.messages import BECMessage
+from bec_lib.serialization_registry import SerializationRegistry
+from bec_lib.serialization_registry_v1 import msgpack as deprecated_msgpack
 
 logger = bec_logger.logger
-
-
-def encode_bec_message_v12(msg):
-    if not isinstance(msg, BECMessage):
-        return msg
-
-    msg_version = 1.2
-    msg_body = msgpack.dumps(msg.__dict__)
-    msg_header = json.dumps({"msg_type": msg.msg_type}).encode()
-    header = f"BECMSG_{msg_version}_{len(msg_header)}_{len(msg_body)}_EOH_".encode()
-    return header + msg_header + msg_body
-
-
-def decode_bec_message_v12(raw_bytes):
-    try:
-        # kept for the record:
-        # offset = MsgpackSerialization.ext_type_offset_to_data[raw_bytes[0]]
-        # (was not so easy to find from msgpack doc)
-        if raw_bytes.startswith(b"BECMSG"):
-            version = float(raw_bytes[7:10])
-            if version < 1.2:
-                raise RuntimeError(f"Unsupported BECMessage version {version}")
-    except Exception as exception:
-        raise RuntimeError("Failed to decode BECMessage") from exception
-
-    try:
-        declaration, msg_header_body = raw_bytes.split(b"_EOH_", maxsplit=1)
-        _, version, header_length, _ = declaration.split(b"_")
-        header = msg_header_body[: int(header_length)]
-        body = msg_header_body[int(header_length) :]
-        header = json.loads(header.decode())
-        msg_body = msgpack.loads(body)
-        msg_class = get_message_class(header.pop("msg_type"))
-        msg = msg_class(**header, **msg_body)
-    except Exception as exception:
-        raise RuntimeError("Failed to decode BECMessage") from exception
-
-    # shouldn't this be checked when the msg is used? or when the message is created?
-    return msg
-
-
-def encode_bec_message_json(msg):
-    if not isinstance(msg, BECMessage):
-        return msg
-
-    msg_version = 1.2
-    out = {"msg_type": msg.msg_type, "msg_version": msg_version, "msg_body": msg.__dict__}
-    return out
-
-
-def decode_bec_message_json(data):
-    if not isinstance(data, dict):
-        return data
-
-    if set(["msg_type", "msg_version", "msg_body"]) != set(data.keys()):
-        return data
-
-    try:
-        msg_class = get_message_class(data.pop("msg_type"))
-        msg = msg_class(**data["msg_body"])
-    except Exception as exception:
-        raise RuntimeError("Failed to decode BECMessage") from exception
-
-    return msg
-
-
-def encode_bec_status(status):
-    if not isinstance(status, BECStatus):
-        return status
-    return status.value.to_bytes(1, "big")  # int.to_bytes
-
-
-def decode_bec_status(value):
-    return BECStatus(int.from_bytes(value, "big"))
-
-
-def encode_bec_status_json(status):
-    if not isinstance(status, BECStatus):
-        return status
-    return {"__becstatus__": status.value}  # int.to_bytes
-
-
-def decode_bec_status_json(value):
-    if "__becstatus__" not in value:
-        return value
-    return BECStatus(value["__becstatus__"])
-
-
-def encode_set(obj):
-    if isinstance(obj, set):
-        return {"__msgpack__": {"type": "set", "data": list(obj)}}
-    return obj
-
-
-def decode_set(obj):
-    if isinstance(obj, dict) and "__msgpack__" in obj and obj["__msgpack__"]["type"] == "set":
-        return set(obj["__msgpack__"]["data"])
-    return obj
-
-
-def encode_endpointInfo(obj):
-    if isinstance(obj, EndpointInfo):
-        return {
-            "__msgpack__": {
-                "type": "message_endpointinfo",
-                "data": {
-                    "endpoint": obj.endpoint,
-                    "message_type": obj.message_type.__name__,
-                    "message_op": obj.message_op,
-                },
-            }
-        }
-    return obj
-
-
-def decode_endpointinfo(obj):
-    if (
-        isinstance(obj, dict)
-        and "__msgpack__" in obj
-        and obj["__msgpack__"]["type"] == "message_endpointinfo"
-    ):
-        return EndpointInfo(
-            obj["__msgpack__"]["data"]["endpoint"],
-            getattr(messages_module, obj["__msgpack__"]["data"]["message_type"]),
-            obj["__msgpack__"]["data"]["message_op"],
-        )
-    return obj
-
-
-def encode_bec_type(msg):
-    if isinstance(msg, type):
-        return {"__msgpack__": {"type": "bec_type", "data": msg.__name__, "module": msg.__module__}}
-    return msg
-
-
-def decode_bec_type(obj):
-    if isinstance(obj, dict) and "__msgpack__" in obj and obj["__msgpack__"]["type"] == "bec_type":
-        if obj["__msgpack__"]["module"] == "bec_lib.messages":
-            return getattr(messages_module, obj["__msgpack__"]["data"])
-        if (
-            obj["__msgpack__"]["module"] == "builtins"
-            and obj["__msgpack__"]["data"] in __builtins__
-        ):
-            return __builtins__.get(obj["__msgpack__"]["data"])
-        raise ValueError("Unknown module")
-    return obj
-
-
-def encode_pydantic(obj):
-    if isinstance(obj, BECMessage):
-        # BECMessage is handled by the BECMessage codec
-        return obj
-    if isinstance(obj, BaseModel):
-        return obj.model_dump()
-    return obj
-
-
-def decode_pydantic(obj):
-    return obj
-
-
-def encode_bec_device(obj):
-    """
-    Encode a DeviceBase object into
-    a string representation of the device name.
-    """
-    if isinstance(obj, DeviceBase):
-        if hasattr(obj, "_compile_function_path"):
-            # pylint: disable=protected-access
-            return obj._compile_function_path()
-        return obj.name
-    return obj
-
-
-def decode_bec_device(obj):
-    """
-    DeviceBase objects are encoded as strings. No decoding is necessary.
-    """
-    return obj
-
-
-class SerializationRegistry:
-    """Registry for serialization codecs"""
-
-    use_json = False
-
-    def __init__(self):
-        self._encoder = []
-        self._ext_decoder = {}
-        self._object_hook_decoder = []
-
-    def register_ext_type(self, encoder, decoder):
-        """Register an encoder and a decoder
-
-        The order registrations are made counts, the encoding process is done
-        in the same order until a compatible encoder is found.
-
-        Args:
-            encoder: Function encoding a data into a serializable data.
-            decoder: Function decoding a serialized data into a usable data.
-        """
-        exttype = len(self._ext_decoder)
-        if exttype in self._ext_decoder:
-            raise ValueError("ExtType %d already used" % exttype)
-        self._encoder.append((encoder, exttype))
-        self._ext_decoder[exttype] = decoder
-
-    def register_object_hook(self, encoder, decoder):
-        """Register an encoder and a decoder that can convert a python object
-        into data which can be serialized by msgpack.
-
-        Args:
-            encoder: Function encoding a data into a data serializable by msgpack
-            decoder: Function decoding a python structure provided by msgpack
-            into an usable data.
-        """
-        self._encoder.append((encoder, None))
-        self._object_hook_decoder.append(decoder)
-
-    def register_numpy(self, use_list=False):
-        """
-        Register BEC custom numpy encoder as a codec.
-        """
-        if use_list:
-            self.register_object_hook(
-                numpy_encoder.numpy_encode_list, numpy_encoder.numpy_decode_list
-            )
-        else:
-            self.register_object_hook(numpy_encoder.numpy_encode, numpy_encoder.numpy_decode)
-
-    def register_bec_message(self):
-        """
-        Register codec for BECMessage
-        """
-        if not self.use_json:
-            # order matters
-            self.register_ext_type(encode_bec_status, decode_bec_status)
-            self.register_ext_type(encode_bec_message_v12, decode_bec_message_v12)
-        else:
-            self.register_object_hook(encode_bec_message_json, decode_bec_message_json)
-
-    def register_bec_status(self):
-        """
-        Register codec for BECStatus
-        """
-        self.register_object_hook(encode_bec_status_json, decode_bec_status_json)
-
-    def register_set_encoder(self):
-        """
-        Register codec for set
-        """
-        self.register_object_hook(encode_set, decode_set)
-
-    def register_message_endpoint(self):
-        """
-        Register codec for MessageEndpoints
-        """
-        self.register_object_hook(encode_endpointInfo, decode_endpointinfo)
-
-    def register_bec_message_type(self):
-        """
-        Register codec for BECMessage type
-        """
-        self.register_object_hook(encode_bec_type, decode_bec_type)
-
-    def register_pydantic(self):
-        """
-        Register codec for pydantic models
-        """
-        self.register_object_hook(encode_pydantic, decode_pydantic)
-
-    def register_bec_device(self):
-        """
-        Register codec for DeviceBase objects
-        """
-        self.register_object_hook(encode_bec_device, decode_bec_device)
-
-
-class MsgpackExt(SerializationRegistry):
-    """Encapsulates msgpack dumps/loads with extensions"""
-
-    def _default(self, obj):
-        for encoder, exttype in self._encoder:
-            result = encoder(obj)
-            if result is obj:
-                # Nothing was done, assume this encoder do not support this
-                # object kind
-                continue
-            if exttype is not None:
-                return msgpack_module.ExtType(exttype, result)
-            return result
-        raise TypeError("Unknown type: %r" % (obj,))
-
-    def _ext_hooks(self, code, data):
-        decoder = self._ext_decoder.get(code, None)
-        if decoder is not None:
-            obj = decoder(data)
-            return obj
-        return msgpack_module.ExtType(code, data)
-
-    def _object_hook(self, data):
-        for decoder in self._object_hook_decoder:
-            try:
-                result = decoder(data)
-            except TypeError:
-                continue
-            if data is not result:
-                # In case the input is not the same as the output,
-                # consider it found the good decoder and it worked
-                break
-        else:
-            return data
-
-        return result
-
-    def dumps(self, obj):
-        """Pack object `o` and return packed bytes."""
-        return msgpack_module.packb(obj, default=self._default)
-
-    def loads(self, raw_bytes, raw=False, strict_map_key=True):
-        return msgpack_module.unpackb(
-            raw_bytes,
-            object_hook=self._object_hook,
-            ext_hook=self._ext_hooks,
-            raw=raw,
-            strict_map_key=strict_map_key,
-        )
-
-
-class JsonExt(SerializationRegistry):
-    """Encapsulates JSON dumps/loads with extensions"""
-
-    use_json = True
-
-    def _default(self, obj):
-        for encoder, _ in self._encoder:
-            result = encoder(obj)
-            if result is obj:
-                # Nothing was done, assume this encoder does not support this
-                # object kind
-                continue
-            return result
-
-    def _ext_hooks(self, data):
-        for decoder in self._object_hook_decoder:
-            try:
-                result = decoder(data)
-            except TypeError:
-                continue
-            if data is not result:
-                # In case the input is not the same as the output,
-                # consider it found the good decoder and it worked
-                break
-        else:
-            return data
-        return result
-
-    def dumps(self, obj):
-        """Serialize object `obj` and return serialized JSON string."""
-        return json.dumps(obj, default=self._default)
-
-    def loads(self, json_str):
-        """Deserialize JSON string `json_str` and return the deserialized object."""
-        return json.loads(json_str, object_hook=self._ext_hooks)
-
-
-json_ext = JsonExt()
-json_ext.register_numpy(use_list=True)
-json_ext.register_bec_message()
-json_ext.register_bec_status()
-json_ext.register_set_encoder()
-json_ext.register_message_endpoint()
-json_ext.register_bec_message_type()
-json_ext.register_pydantic()
-json_ext.register_bec_device()
-
-msgpack = MsgpackExt()
-msgpack.register_numpy()
-msgpack.register_bec_message()
-msgpack.register_set_encoder()
-msgpack.register_message_endpoint()
-msgpack.register_bec_message_type()
-msgpack.register_pydantic()
-msgpack.register_bec_device()
 
 
 class SerializationInterface:
@@ -419,28 +32,36 @@ class SerializationInterface:
         """serialize a message"""
 
 
-def get_message_class(msg_type: str):
-    """Given a message type, tries to find the corresponding message class in the module"""
-    module = messages_module
-    # convert snake_style to CamelCase
-    class_name = "".join(part.title() for part in msg_type.split("_"))
-    try:
-        # maybe as easy as that...
-        klass = getattr(module, class_name)
-        # belts and braces
-        if getattr(klass, "msg_type") == msg_type:
-            return klass
-    except AttributeError:
-        # try better
-        module_classes = inspect.getmembers(module, inspect.isclass)
-        for class_name, klass in module_classes:
-            try:
-                klass_msg_type = getattr(klass, "msg_type")
-            except AttributeError:
-                continue
-            else:
-                if msg_type == klass_msg_type:
-                    return klass
+class BECMessagePack(SerializationRegistry):
+    """Encapsulates msgpack dumps/loads with extensions"""
+
+    def dumps(self, obj):
+        """Pack object `obj` and return packed bytes."""
+        return msgpack_module.packb(obj, default=self.encode)
+
+    def loads(self, raw_bytes):
+        """Unpack bytes and return the decoded object."""
+        out = msgpack_module.unpackb(
+            raw_bytes, raw=False, strict_map_key=True, object_hook=self.decode
+        )
+        if isinstance(out, msgpack_module.ExtType):
+            # unpacking did not work, try using the legacy msgpack decoder
+            return deprecated_msgpack.loads(raw_bytes)
+        return out
+
+
+class BECJson(SerializationRegistry):
+    """Encapsulates JSON dumps/loads with extensions"""
+
+    use_json = True
+
+    def dumps(self, obj):
+        """Pack object `obj` and return packed bytes."""
+        return json.dumps(obj, default=self.encode)
+
+    def loads(self, raw_bytes):
+        """Unpack bytes and return the decoded object."""
+        return json.loads(raw_bytes, object_hook=self.decode)
 
 
 @contextlib.contextmanager
@@ -486,3 +107,7 @@ class MsgpackSerialization(SerializationInterface):
         if version is None or version == 1.2:
             return msgpack.dumps(msg)
         raise RuntimeError(f"Unsupported BECMessage version {version}.")
+
+
+msgpack = BECMessagePack()
+json_ext = BECJson()

--- a/bec_lib/bec_lib/serialization_registry.py
+++ b/bec_lib/bec_lib/serialization_registry.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Callable, Type
+from warnings import warn
+
+from bec_lib import codecs as bec_codecs
+from bec_lib.logger import bec_logger
+
+logger = bec_logger.logger
+
+
+class SerializationRegistry:
+    """Registry for serialization codecs"""
+
+    use_json = False
+
+    def __init__(self):
+        self._registry: dict[str, tuple[Type, Callable, Callable]] = {}
+        self._legacy_codecs = []  # can be removed in future versions, see issue #516
+
+        self.register_codec(bec_codecs.BECMessageEncoder)
+        self.register_codec(bec_codecs.BECDeviceEncoder)
+        self.register_codec(bec_codecs.EndpointInfoEncoder)
+        self.register_codec(bec_codecs.SetEncoder)
+        self.register_codec(bec_codecs.BECTypeEncoder)
+        self.register_codec(bec_codecs.PydanticEncoder)
+        self.register_codec(bec_codecs.EnumEncoder)
+
+        if self.use_json:
+            self.register_codec(bec_codecs.NumpyEncoderList)
+        else:
+            self.register_codec(bec_codecs.NumpyEncoder)
+
+    def register_codec(self, codec: Type[bec_codecs.BECCodec]):
+        """
+        Register a codec for a specific BECCodec subclass.
+        This method allows for easy registration of custom encoders and decoders
+        for BECMessage and other types.
+
+        Args:
+            codec: A subclass of BECCodec that implements encode and decode methods.
+        Raises:
+            ValueError: If a codec for the specified type is already registered.
+        """
+        if isinstance(codec.obj_type, list):
+            for cls in codec.obj_type:
+                self.register(cls, codec.encode, codec.decode)
+        else:
+            self.register(codec.obj_type, codec.encode, codec.decode)
+
+    def register(self, cls: Type, encoder: Callable, decoder: Callable):
+        """Register a codec for a specific type."""
+
+        if cls.__name__ in self._registry:
+            raise ValueError(f"Codec for {cls} already registered.")
+        self._registry[cls.__name__] = (cls, encoder, decoder)
+
+    @lru_cache(maxsize=2000)
+    def get_codec(self, cls: Type) -> tuple[Type, Callable, Callable] | None:
+        """Get the codec for a specific type."""
+        codec = self._registry.get(cls.__name__)
+        if codec:
+            return codec
+        for _, (registered_cls, encoder, decoder) in self._registry.items():
+            if issubclass(cls, registered_cls):
+                return registered_cls, encoder, decoder
+        return None
+
+    def is_registered(self, cls: Type) -> bool:
+        """
+        Check if a codec is registered for a specific type.
+        Args:
+            cls: The class type to check for a registered codec.
+        Returns:
+            bool: True if a codec is registered for the type, False otherwise.
+        """
+        return self.get_codec(cls) is not None
+
+    def encode(self, obj):
+        """Encode an object using the registered codec."""
+        codec = self.get_codec(type(obj))
+        if not codec:
+            # TODO: Remove this legacy encoding in future versions, cf issue #516
+            obj = self._legacy_encoding(obj)
+            return obj  # No codec registered for this type
+        cls, encoder, _ = codec
+        try:
+            return {
+                "__bec_codec__": {
+                    "encoder_name": cls.__name__,
+                    "type_name": obj.__class__.__name__,
+                    "data": encoder(obj),
+                }
+            }
+        except Exception as e:
+            raise ValueError(
+                f"Serialization failed: Failed to encode {obj.__class__.__name__} with codec {encoder}: {e}"
+            ) from e
+
+    def decode(self, data):
+        """Decode an object using the registered codec."""
+        if not isinstance(data, dict) or "__bec_codec__" not in data:
+            # TODO: Remove this legacy decoding in future versions, cf issue #516
+            data = self._legacy_decoding(data)
+            return data
+        codec_info = data["__bec_codec__"]
+        codec_type = codec_info.pop("encoder_name")
+        if not codec_type or codec_type not in self._registry:
+            return data
+        _, _, decoder = self._registry[codec_type]
+        try:
+            return decoder(**codec_info)
+        except Exception as e:
+            raise ValueError(
+                f"Deserialization failed: Failed to decode {codec_type} with codec {decoder}: {e}"
+            ) from e
+
+    ##########################################################
+    ##### Backward compatibility properties and methods #####
+    ##########################################################
+    # See issue #516 for more details on the legacy codecs
+    @property
+    def _encoder(self) -> list:  # pragma: no cover
+        """
+        Backward compatibility property to access the encoder.
+        """
+        warn(
+            "The '_encoder' property is deprecated and will be removed in future versions. "
+            "If you want to check if a codec is registered, use 'is_registered' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        codecs = [(encoder, decoder) for _, encoder, decoder in self._registry.values()]
+        codecs.extend(self._legacy_codecs)
+        codecs = list(set(codecs))
+        return codecs
+
+    def register_object_hook(self, encode: Callable, decode: Callable):  # pragma: no cover
+        """
+        Register a custom object hook for encoding and decoding.
+        This is a legacy method for backward compatibility.
+        See issue #516 for more details.
+        """
+        warn(
+            "The 'register_object_hook' method is deprecated and will be removed in future versions. "
+            "Use 'register_codec' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self._legacy_codecs.append((encode, decode))
+
+    def _legacy_encoding(self, obj):  # pragma: no cover
+        """
+        Check if the object can be handled by a legacy codec.
+        If so, return the encoded object; otherwise, return the original object.
+        """
+        for encode, _ in self._legacy_codecs:
+            try:
+                new_obj = encode(obj)
+                if new_obj == obj:
+                    continue
+                return new_obj
+            except Exception as e:
+                logger.warning(f"Legacy codec failed for {type(obj).__name__}: {e}")
+        return obj
+
+    def _legacy_decoding(self, data):  # pragma: no cover
+        """
+        Check if the data can be handled by a legacy codec.
+        If so, return the decoded object; otherwise, return the original data.
+        """
+        for _, decode in self._legacy_codecs:
+            try:
+                new_data = decode(data)
+                if new_data == data:
+                    continue
+            except Exception as e:
+                logger.warning(f"Legacy codec failed for {data}: {e}")
+        return data

--- a/bec_lib/bec_lib/serialization_registry_v1.py
+++ b/bec_lib/bec_lib/serialization_registry_v1.py
@@ -1,0 +1,440 @@
+"""
+Deprecated serialization module for BEC messages. Can be removed in future versions, cf issue #516.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+
+import msgpack as msgpack_module
+from pydantic import BaseModel
+
+from bec_lib import messages as messages_module
+from bec_lib import numpy_encoder
+from bec_lib.device import DeviceBase
+from bec_lib.endpoints import EndpointInfo
+from bec_lib.logger import bec_logger
+from bec_lib.messages import BECMessage, BECStatus
+
+logger = bec_logger.logger
+
+
+def encode_bec_message_v2(msg):
+    if not isinstance(msg, BECMessage):
+        return msg
+    return msg.__dict__
+
+
+def decode_bec_message_v2(type_name: str, data: dict):
+    if not isinstance(data, dict):
+        return data
+    return getattr(messages_module, type_name)(**data)
+
+
+def encode_bec_message_v12(msg):
+    if not isinstance(msg, BECMessage):
+        return msg
+
+    msg_version = 1.2
+    msg_body = msgpack.dumps(msg.__dict__)
+    msg_header = json.dumps({"msg_type": msg.msg_type}).encode()
+    header = f"BECMSG_{msg_version}_{len(msg_header)}_{len(msg_body)}_EOH_".encode()
+    return header + msg_header + msg_body
+
+
+def decode_bec_message_v12(raw_bytes):
+    try:
+        # kept for the record:
+        # offset = MsgpackSerialization.ext_type_offset_to_data[raw_bytes[0]]
+        # (was not so easy to find from msgpack doc)
+        if raw_bytes.startswith(b"BECMSG"):
+            version = float(raw_bytes[7:10])
+            if version < 1.2:
+                raise RuntimeError(f"Unsupported BECMessage version {version}")
+    except Exception as exception:
+        raise RuntimeError("Failed to decode BECMessage") from exception
+
+    try:
+        declaration, msg_header_body = raw_bytes.split(b"_EOH_", maxsplit=1)
+        _, version, header_length, _ = declaration.split(b"_")
+        header = msg_header_body[: int(header_length)]
+        body = msg_header_body[int(header_length) :]
+        header = json.loads(header.decode())
+        msg_body = msgpack.loads(body)
+        msg_class = get_message_class(header.pop("msg_type"))
+        msg = msg_class(**header, **msg_body)
+    except Exception as exception:
+        raise RuntimeError("Failed to decode BECMessage") from exception
+
+    # shouldn't this be checked when the msg is used? or when the message is created?
+    return msg
+
+
+def encode_bec_message_json(msg):
+    if not isinstance(msg, BECMessage):
+        return msg
+
+    msg_version = 1.2
+    out = {"msg_type": msg.msg_type, "msg_version": msg_version, "msg_body": msg.__dict__}
+    return out
+
+
+def decode_bec_message_json(data):
+    if not isinstance(data, dict):
+        return data
+
+    if set(["msg_type", "msg_version", "msg_body"]) != set(data.keys()):
+        return data
+
+    try:
+        msg_class = get_message_class(data.pop("msg_type"))
+        msg = msg_class(**data["msg_body"])
+    except Exception as exception:
+        raise RuntimeError("Failed to decode BECMessage") from exception
+
+    return msg
+
+
+def encode_bec_status(status):
+    if not isinstance(status, BECStatus):
+        return status
+    return status.value.to_bytes(1, "big")  # int.to_bytes
+
+
+def decode_bec_status(value):
+    return BECStatus(int.from_bytes(value, "big"))
+
+
+def encode_bec_status_json(status):
+    if not isinstance(status, BECStatus):
+        return status
+    return {"__becstatus__": status.value}  # int.to_bytes
+
+
+def decode_bec_status_json(value):
+    if "__becstatus__" not in value:
+        return value
+    return BECStatus(value["__becstatus__"])
+
+
+def encode_set(obj):
+    if isinstance(obj, set):
+        return {"__msgpack__": {"type": "set", "data": list(obj)}}
+    return obj
+
+
+def decode_set(obj):
+    if isinstance(obj, dict) and "__msgpack__" in obj and obj["__msgpack__"]["type"] == "set":
+        return set(obj["__msgpack__"]["data"])
+    return obj
+
+
+def encode_endpointInfo(obj):
+    if isinstance(obj, EndpointInfo):
+        return {
+            "__msgpack__": {
+                "type": "message_endpointinfo",
+                "data": {
+                    "endpoint": obj.endpoint,
+                    "message_type": obj.message_type.__name__,
+                    "message_op": obj.message_op,
+                },
+            }
+        }
+    return obj
+
+
+def decode_endpointinfo(obj):
+    if (
+        isinstance(obj, dict)
+        and "__msgpack__" in obj
+        and obj["__msgpack__"]["type"] == "message_endpointinfo"
+    ):
+        return EndpointInfo(
+            obj["__msgpack__"]["data"]["endpoint"],
+            getattr(messages_module, obj["__msgpack__"]["data"]["message_type"]),
+            obj["__msgpack__"]["data"]["message_op"],
+        )
+    return obj
+
+
+def encode_bec_type(msg):
+    if isinstance(msg, type):
+        return {"__msgpack__": {"type": "bec_type", "data": msg.__name__, "module": msg.__module__}}
+    return msg
+
+
+def decode_bec_type(obj):
+    if isinstance(obj, dict) and "__msgpack__" in obj and obj["__msgpack__"]["type"] == "bec_type":
+        if obj["__msgpack__"]["module"] == "bec_lib.messages":
+            return getattr(messages_module, obj["__msgpack__"]["data"])
+        if (
+            obj["__msgpack__"]["module"] == "builtins"
+            and obj["__msgpack__"]["data"] in __builtins__
+        ):
+            return __builtins__.get(obj["__msgpack__"]["data"])
+        raise ValueError("Unknown module")
+    return obj
+
+
+def encode_pydantic(obj):
+    if isinstance(obj, BECMessage):
+        # BECMessage is handled by the BECMessage codec
+        return obj
+    if isinstance(obj, BaseModel):
+        return obj.model_dump()
+    return obj
+
+
+def decode_pydantic(obj):
+    return obj
+
+
+def encode_bec_device(obj):
+    """
+    Encode a DeviceBase object into
+    a string representation of the device name.
+    """
+    if isinstance(obj, DeviceBase):
+        if hasattr(obj, "_compile_function_path"):
+            # pylint: disable=protected-access
+            return obj._compile_function_path()
+        return obj.name
+    return obj
+
+
+def decode_bec_device(obj):
+    """
+    DeviceBase objects are encoded as strings. No decoding is necessary.
+    """
+    return obj
+
+
+class SerializationRegistry:
+    """Registry for serialization codecs"""
+
+    use_json = False
+
+    def __init__(self):
+        self._encoder = []
+        self._ext_decoder = {}
+        self._object_hook_decoder = []
+
+    def register_ext_type(self, encoder, decoder):
+        """Register an encoder and a decoder
+
+        The order registrations are made counts, the encoding process is done
+        in the same order until a compatible encoder is found.
+
+        Args:
+            encoder: Function encoding a data into a serializable data.
+            decoder: Function decoding a serialized data into a usable data.
+        """
+        exttype = len(self._ext_decoder)
+        if exttype in self._ext_decoder:
+            raise ValueError("ExtType %d already used" % exttype)
+        self._encoder.append((encoder, exttype))
+        self._ext_decoder[exttype] = decoder
+
+    def register_object_hook(self, encoder, decoder):
+        """Register an encoder and a decoder that can convert a python object
+        into data which can be serialized by msgpack.
+
+        Args:
+            encoder: Function encoding a data into a data serializable by msgpack
+            decoder: Function decoding a python structure provided by msgpack
+            into an usable data.
+        """
+        self._encoder.append((encoder, None))
+        self._object_hook_decoder.append(decoder)
+
+    def register_numpy(self, use_list=False):
+        """
+        Register BEC custom numpy encoder as a codec.
+        """
+        if use_list:
+            self.register_object_hook(
+                numpy_encoder.numpy_encode_list, numpy_encoder.numpy_decode_list
+            )
+        else:
+            self.register_object_hook(numpy_encoder.numpy_encode, numpy_encoder.numpy_decode)
+
+    def register_bec_message(self):
+        """
+        Register codec for BECMessage
+        """
+        if not self.use_json:
+            # order matters
+            self.register_ext_type(encode_bec_status, decode_bec_status)
+            self.register_ext_type(encode_bec_message_v12, decode_bec_message_v12)
+        else:
+            self.register_object_hook(encode_bec_message_json, decode_bec_message_json)
+
+    def register_bec_status(self):
+        """
+        Register codec for BECStatus
+        """
+        self.register_object_hook(encode_bec_status_json, decode_bec_status_json)
+
+    def register_set_encoder(self):
+        """
+        Register codec for set
+        """
+        self.register_object_hook(encode_set, decode_set)
+
+    def register_message_endpoint(self):
+        """
+        Register codec for MessageEndpoints
+        """
+        self.register_object_hook(encode_endpointInfo, decode_endpointinfo)
+
+    def register_bec_message_type(self):
+        """
+        Register codec for BECMessage type
+        """
+        self.register_object_hook(encode_bec_type, decode_bec_type)
+
+    def register_pydantic(self):
+        """
+        Register codec for pydantic models
+        """
+        self.register_object_hook(encode_pydantic, decode_pydantic)
+
+    def register_bec_device(self):
+        """
+        Register codec for DeviceBase objects
+        """
+        self.register_object_hook(encode_bec_device, decode_bec_device)
+
+
+class MsgpackExt(SerializationRegistry):
+    """Encapsulates msgpack dumps/loads with extensions"""
+
+    def _default(self, obj):
+        for encoder, exttype in self._encoder:
+            result = encoder(obj)
+            if result is obj:
+                # Nothing was done, assume this encoder do not support this
+                # object kind
+                continue
+            if exttype is not None:
+                return msgpack_module.ExtType(exttype, result)
+            return result
+        raise TypeError("Unknown type: %r" % (obj,))
+
+    def _ext_hooks(self, code, data):
+        decoder = self._ext_decoder.get(code, None)
+        if decoder is not None:
+            obj = decoder(data)
+            return obj
+        return msgpack_module.ExtType(code, data)
+
+    def _object_hook(self, data):
+        for decoder in self._object_hook_decoder:
+            try:
+                result = decoder(data)
+            except TypeError:
+                continue
+            if data is not result:
+                # In case the input is not the same as the output,
+                # consider it found the good decoder and it worked
+                break
+        else:
+            return data
+
+        return result
+
+    def dumps(self, obj):
+        """Pack object `o` and return packed bytes."""
+        return msgpack_module.packb(obj, default=self._default)
+
+    def loads(self, raw_bytes, raw=False, strict_map_key=True):
+        return msgpack_module.unpackb(
+            raw_bytes,
+            object_hook=self._object_hook,
+            ext_hook=self._ext_hooks,
+            raw=raw,
+            strict_map_key=strict_map_key,
+        )
+
+
+class JsonExt(SerializationRegistry):
+    """Encapsulates JSON dumps/loads with extensions"""
+
+    use_json = True
+
+    def _default(self, obj):
+        for encoder, _ in self._encoder:
+            result = encoder(obj)
+            if result is obj:
+                # Nothing was done, assume this encoder does not support this
+                # object kind
+                continue
+            return result
+
+    def _ext_hooks(self, data):
+        for decoder in self._object_hook_decoder:
+            try:
+                result = decoder(data)
+            except TypeError:
+                continue
+            if data is not result:
+                # In case the input is not the same as the output,
+                # consider it found the good decoder and it worked
+                break
+        else:
+            return data
+        return result
+
+    def dumps(self, obj):
+        """Serialize object `obj` and return serialized JSON string."""
+        return json.dumps(obj, default=self._default)
+
+    def loads(self, json_str):
+        """Deserialize JSON string `json_str` and return the deserialized object."""
+        return json.loads(json_str, object_hook=self._ext_hooks)
+
+
+json_ext = JsonExt()
+json_ext.register_numpy(use_list=True)
+json_ext.register_bec_message()
+json_ext.register_bec_status()
+json_ext.register_set_encoder()
+json_ext.register_message_endpoint()
+json_ext.register_bec_message_type()
+json_ext.register_pydantic()
+json_ext.register_bec_device()
+
+msgpack = MsgpackExt()
+msgpack.register_numpy()
+msgpack.register_bec_message()
+msgpack.register_set_encoder()
+msgpack.register_message_endpoint()
+msgpack.register_bec_message_type()
+msgpack.register_pydantic()
+msgpack.register_bec_device()
+
+
+def get_message_class(msg_type: str):
+    """Given a message type, tries to find the corresponding message class in the module"""
+    module = messages_module
+    # convert snake_style to CamelCase
+    class_name = "".join(part.title() for part in msg_type.split("_"))
+    try:
+        # maybe as easy as that...
+        klass = getattr(module, class_name)
+        # belts and braces
+        if getattr(klass, "msg_type") == msg_type:
+            return klass
+    except AttributeError:
+        # try better
+        module_classes = inspect.getmembers(module, inspect.isclass)
+        for class_name, klass in module_classes:
+            try:
+                klass_msg_type = getattr(klass, "msg_type")
+            except AttributeError:
+                continue
+            else:
+                if msg_type == klass_msg_type:
+                    return klass

--- a/bec_lib/tests/test_bec_messages.py
+++ b/bec_lib/tests/test_bec_messages.py
@@ -17,9 +17,8 @@ def test_bec_message_msgpack_serialization_version(version):
         assert "Unsupported BECMessage version" in str(exception.value)
     else:
         res = MsgpackSerialization.dumps(msg)
-        print(res)
-        v12res = b'\xc7z\x01BECMSG_1.2_34_67_EOH_{"msg_type": "device_instruction"}\x84\xa8metadata\x81\xa3RID\xa41234\xa6device\xa4samx\xa6action\xa3set\xa9parameter\x81\xa3set\xcb?\xe0\x00\x00\x00\x00\x00\x00'
-        assert res == v12res
+        res_expected = b"\x81\xad__bec_codec__\x83\xacencoder_name\xaaBECMessage\xa9type_name\xb8DeviceInstructionMessage\xa4data\x84\xa8metadata\x81\xa3RID\xa41234\xa6device\xa4samx\xa6action\xa3set\xa9parameter\x81\xa3set\xcb?\xe0\x00\x00\x00\x00\x00\x00"
+        assert res == res_expected
         res_loaded = MsgpackSerialization.loads(res)
         assert res_loaded == msg
 

--- a/bec_lib/tests/test_serializer.py
+++ b/bec_lib/tests/test_serializer.py
@@ -1,3 +1,4 @@
+import enum
 from unittest import mock
 
 import numpy as np
@@ -5,15 +6,22 @@ import pytest
 from pydantic import BaseModel
 
 from bec_lib import messages
+from bec_lib.codecs import BECCodec
 from bec_lib.device import DeviceBase
 from bec_lib.devicemanager import DeviceManagerBase
 from bec_lib.endpoints import MessageEndpoints
-from bec_lib.serialization import json_ext, msgpack
+from bec_lib.serialization import MsgpackSerialization, json_ext, msgpack
+from bec_lib.serialization_registry_v1 import msgpack as deprecated_msgpack
 
 
-@pytest.fixture(params=[json_ext, msgpack])
+@pytest.fixture(params=[json_ext, msgpack, MsgpackSerialization])
 def serializer(request):
     yield request.param
+
+
+class CustomEnum(enum.Enum):
+    VALUE1 = "value1"
+    VALUE2 = "value2"
 
 
 @pytest.mark.parametrize(
@@ -37,6 +45,25 @@ def serializer(request):
         float,
         messages.RawMessage(data={"a": 1, "b": 2}),
         messages.BECStatus.RUNNING,
+        np.uint32,
+        messages.DeviceMessage(
+            signals={
+                "hroz": {
+                    "value": np.random.rand(10).astype(np.uint32),
+                    "timestamp": 1708336264.5731058,
+                }
+            },
+            metadata={},
+        ),
+        messages.DeviceMessage(
+            metadata={
+                "readout_priority": "baseline",
+                "file_suffix": None,
+                "file_directory": None,
+                "user_metadata": {},
+            },
+            signals={"pseudo_signal1": {"value": np.uint32(80), "timestamp": 1749392743.0512588}},
+        ),
     ],
 )
 def test_serialize(serializer, data):
@@ -59,3 +86,94 @@ def test_device_serializer(serializer):
     device_manager = mock.MagicMock(spec=DeviceManagerBase)
     dummy = DeviceBase(name="dummy", parent=device_manager)
     assert serializer.loads(serializer.dumps(dummy)) == "dummy"
+
+
+def test_enum_serializer(serializer):
+    assert serializer.loads(serializer.dumps(CustomEnum.VALUE1)) == "value1"
+
+
+def test_serializer_encoding_on_failure():
+    """
+    Test that an exception raised during serialization is caught and the original object is returned.
+    """
+
+    class DummyModel:
+        def __init__(self, a, b):
+            self.a = a
+            self.b = b
+
+        def __eq__(self, other):
+            return isinstance(other, DummyModel) and self.a == other.a and self.b == other.b
+
+    class RaiseEncoder(BECCodec):
+        obj_type = DummyModel
+
+        @staticmethod
+        def encode(obj):
+            raise ValueError("Serialization failed")
+
+        @staticmethod
+        def decode(type_name: str, data: dict):
+            raise ValueError("Deserialization failed")
+
+    try:
+        msgpack.register_codec(RaiseEncoder)
+        data = DummyModel(a=1, b=2)
+        with pytest.raises(ValueError, match="Serialization failed"):
+            serialized_data = msgpack.dumps(data)
+
+        serialized_data = msgpack.dumps(
+            {"__bec_codec__": {"encoder_name": "DummyModel", "type_name": "DummyModel", "data": {}}}
+        )
+        with pytest.raises(ValueError, match="Deserialization failed"):
+            msgpack.loads(serialized_data)
+    finally:
+        # Unregister the codec to avoid side effects on other tests
+        msgpack._registry.pop("DummyModel")
+
+
+def test_legacy_serializer():
+    # Can be removed in the future, cf issue #516
+    msg = messages.DeviceMessage(
+        signals={"hroz": {"value": 0, "timestamp": 1708336264.5731058}}, metadata={}
+    )
+    raw = deprecated_msgpack.dumps(msg)
+    assert msgpack.loads(raw) == msg
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"a": 1, "b": 2},
+        "hello",
+        1,
+        1.0,
+        [1, 2, 3],
+        np.array([1, 2, 3]),
+        {1, 2, 3},
+        {
+            "hroz": {
+                "hroz": {"value": 0, "timestamp": 1708336264.5731058},
+                "hroz_setpoint": {"value": 0, "timestamp": 1708336264.573121},
+            }
+        },
+        MessageEndpoints.progress("test"),
+        messages.DeviceMessage,
+        float,
+        messages.RawMessage(data={"a": 1, "b": 2}),
+        messages.BECStatus.RUNNING,
+        messages.DeviceMessage(
+            signals={
+                "hroz": {
+                    "value": np.random.rand(10).astype(np.uint32),
+                    "timestamp": 1708336264.5731058,
+                }
+            },
+            metadata={},
+        ),
+    ],
+)
+def test_legacy_serialize(data):
+    # Can be removed in the future, cf issue #516
+    res = deprecated_msgpack.loads(deprecated_msgpack.dumps(data)) == data
+    assert all(res) if isinstance(data, np.ndarray) else res


### PR DESCRIPTION
This PR fixes a problem in the serialization that caused the encoder to take roughly 2.5 x longer than normal. Moreover, I used the opportunity to refactor the serialization and make the conversion less random: The serialization now uses BECEncoder classes to register encoding and decoding methods. These encoders also provide the type information of objects that the encoder can translate. Any object of the specified type or subclasses will use the encoder. 

For now, the old serialization is still in the code base (serialization_registry_v1) and is used for backward compatibility. Once we have migrated BEC Widgets and redeployed BEC at the beamlines, we can remove the legacy section in serialization_registry and the entire serialization_registry_v1 module. 