### PR TITLE
Add child pipeline for ophyd_devices

### DIFF
--- a/.github/actions/bec_e2e_install/action.yml
+++ b/.github/actions/bec_e2e_install/action.yml
@@ -1,0 +1,66 @@
+name: "BEC e2e Install"
+description: "Install BEC and related os dependencies"
+inputs:
+  BEC_CORE_BRANCH: # id of input
+    required: false
+    default: "main"
+    description: "Branch of BEC Core to install"
+  OPHYD_DEVICES_BRANCH: # id of input
+    required: false
+    default: "main"
+    description: "Branch of Ophyd Devices to install"
+  BEC_WIDGETS_BRANCH: # id of input
+    required: false
+    default: "main"
+    description: "Branch of BEC Widgets to install"
+  PYTHON_VERSION: # id of input
+    required: false
+    default: "3.11"
+    description: "Python version to use"
+
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up environment
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        auto-update-conda: true
+        auto-activate-base: true
+        python-version: ${{ inputs.PYTHON_VERSION }}
+
+    - name: Install dependencies
+      shell: bash -el {0}
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y tmux
+
+    - name: Create subdirectory for e2e tests
+      shell: bash -el {0}
+      run: |
+        mkdir -p ./_e2e_test_checkout_/
+        echo -e "\033[35;1m Installing dependencies for branch ${{ inputs.BEC_CORE_BRANCH }} for BEC Core. \033[0;m";
+        echo -e "\033[35;1m Installing dependencies for branch ${{ inputs.OPHYD_DEVICES_BRANCH }} for ophyd_devices. \033[0;m"; 
+
+    - name: Checkout BEC Core
+      uses: actions/checkout@v4
+      with:
+        repository: bec-project/bec
+        ref: ${{ inputs.BEC_CORE_BRANCH }}
+        path: ./_e2e_test_checkout_/bec
+
+    - name: Checkout Ophyd Devices
+      uses: actions/checkout@v4
+      with:
+        repository: bec-project/ophyd_devices
+        ref: ${{ inputs.OPHYD_DEVICES_BRANCH }}
+        path: ./_e2e_test_checkout_/ophyd_devices
+
+    - name: Install Depdendencies & run Pytest
+      shell: bash -el {0} # Needs to be bash -el {0} to work with conda
+      run: |
+        cd ./_e2e_test_checkout_/bec
+        source ./bin/install_bec_dev.sh -t
+        pip install -e ../ophyd_devices
+        pytest -v --files-path ./ --start-servers --random-order  ./bec_ipython_client/tests/end-2-end
+        

--- a/.github/actions/bec_install/action.yml
+++ b/.github/actions/bec_install/action.yml
@@ -1,5 +1,5 @@
-name: "BEC Widgets Install"
-description: "Install BEC Widgets and related os dependencies"
+name: "BEC Install"
+description: "Install BEC and related os dependencies"
 inputs:
   BEC_CORE_BRANCH: # id of input
     required: false

--- a/.github/actions/plugin_repo_tests/action.yml
+++ b/.github/actions/plugin_repo_tests/action.yml
@@ -1,0 +1,117 @@
+name: "BEC Plugin Repo Tests"
+description: "Install and test a BEC plugin repository"
+inputs:
+  BEC_CORE_BRANCH: # id of input
+    required: false
+    default: "main"
+    description: "Branch of BEC Core to install"
+  OPHYD_DEVICES_BRANCH: # id of input
+    required: false
+    default: "main"
+    description: "Branch of Ophyd Devices to install"
+  BEC_WIDGETS_BRANCH: # id of input
+    required: false
+    default: "main"
+    description: "Branch of BEC Widgets to install"
+  BEC_PLUGIN_REPO_URL: # id of input
+    required: true
+    description: "URL of the BEC plugin repository to install"
+  BEC_PLUGIN_REPO_BRANCH: # id of input
+    required: false
+    default: "main"
+    description: "Branch of the BEC plugin repository to install"
+  PYTHON_VERSION: # id of input
+    required: false
+    default: "3.11"
+    description: "Python version to use"
+  GITLAB_TOKEN: # id of input
+    required: false
+    default: ""
+    description: "GitHub token to use for authentication (if needed)"
+
+runs:
+  using: "composite"
+  steps: # FULL_URL="https://oauth2:${{ inputs.GITLAB_TOKEN }}@${URL_CLEANED}"
+    - name: Checkout BEC Plugin Repository
+      shell: bash
+      id: plugin_checkout 
+      run: |
+        # Create a temporary directory for the plugin repository
+        mkdir -p ./_checkout_plugin_/
+        cd ./_checkout_plugin_/
+        git clone --depth 1 --branch ${{ inputs.BEC_PLUGIN_REPO_BRANCH }} https://oauth2:${{ inputs.GITLAB_TOKEN }}@${{ inputs.BEC_PLUGIN_REPO_URL }}
+        
+        cd ../
+        # get the plugin repository name from the installed directory
+        PLUGIN_REPO_NAME=$(basename ${{ inputs.BEC_PLUGIN_REPO_URL }} .git)
+        echo "PLUGIN_REPO_NAME=${PLUGIN_REPO_NAME}" >> $GITHUB_ENV
+        echo "Plugin repository name: $PLUGIN_REPO_NAME"
+
+        if ! find ./_checkout_plugin_/${PLUGIN_REPO_NAME}/tests -mindepth 1 -type f -name '*.py' | grep -q .; then
+            echo "No tests found. Skipping pytest."
+            echo "skip_tests=true" >> $GITHUB_OUTPUT
+        else
+            echo "Tests found. Proceeding with pytest."
+            echo "skip_tests=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      if: ( steps.plugin_checkout.outputs.skip_tests != 'true' )
+      with:
+        python-version: ${{ inputs.PYTHON_VERSION }}
+
+    - name: Checkout BEC Core
+      uses: actions/checkout@v4
+      if: ( steps.plugin_checkout.outputs.skip_tests != 'true' )
+      with:
+        repository: bec-project/bec
+        ref: ${{ inputs.BEC_CORE_BRANCH }}
+        path: ./_checkout_plugin_/bec
+
+    - name: Checkout Ophyd Devices
+      uses: actions/checkout@v4
+      if: ( steps.plugin_checkout.outputs.skip_tests != 'true' )
+      with:
+        repository: bec-project/ophyd_devices
+        ref: ${{ inputs.OPHYD_DEVICES_BRANCH }}
+        path: ./_checkout_plugin_/ophyd_devices
+
+    - name: Checkout BEC Widgets
+      uses: actions/checkout@v4
+      if: ( steps.plugin_checkout.outputs.skip_tests != 'true' )
+      with:
+        repository: bec-project/bec_widgets
+        ref: ${{ inputs.BEC_WIDGETS_BRANCH }}
+        path: ./_checkout_plugin_/bec_widgets
+
+    - name: Install dependencies # Do we have this somewhere as an action?
+      shell: bash
+      if: ( steps.plugin_checkout.outputs.skip_tests != 'true' )
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libgl1 libegl1 x11-utils libxkbcommon-x11-0 libdbus-1-3 xvfb
+        sudo apt-get -y install libnss3 libxdamage1 libasound2t64 libatomic1 libxcursor1
+
+    - name: Install Python dependencies
+      shell: bash
+      if: ( steps.plugin_checkout.outputs.skip_tests != 'true' )
+      run: |
+        pip install uv
+        # print the current directory to verify the structure
+        echo "Current directory: $(pwd)"
+        echo "Available directories: $(ls _checkout_plugin_)"
+        uv pip install --system -e ./_checkout_plugin_/ophyd_devices[dev]
+        uv pip install --system -e ./_checkout_plugin_/bec/bec_lib[dev]
+        uv pip install --system -e ./_checkout_plugin_/bec/bec_ipython_client[dev]
+        uv pip install --system -e ./_checkout_plugin_/bec/bec_server[dev]
+        uv pip install --system -e ./_checkout_plugin_/bec_widgets[dev]
+        uv pip install --system -e ./_checkout_plugin_/${PLUGIN_REPO_NAME}[dev]
+
+    - name: Run Pytest
+      shell: bash
+      if: ( steps.plugin_checkout.outputs.skip_tests != 'true' )
+      run: |
+        cd ./_checkout_plugin_/${PLUGIN_REPO_NAME}
+        echo -e "\033[35;1m Running pytest for plugin repository ${PLUGIN_REPO_NAME} \033[0;m"
+        pytest -v --maxfail=2 --random-order ./tests

--- a/.github/actions/plugin_repo_tests/action.yml
+++ b/.github/actions/plugin_repo_tests/action.yml
@@ -24,14 +24,10 @@ inputs:
     required: false
     default: "3.11"
     description: "Python version to use"
-  GITLAB_TOKEN: # id of input
-    required: false
-    default: ""
-    description: "GitHub token to use for authentication (if needed)"
 
 runs:
   using: "composite"
-  steps: # FULL_URL="https://oauth2:${{ inputs.GITLAB_TOKEN }}@${URL_CLEANED}"
+  steps:
     - name: Checkout BEC Plugin Repository
       shell: bash
       id: plugin_checkout 
@@ -39,7 +35,7 @@ runs:
         # Create a temporary directory for the plugin repository
         mkdir -p ./_checkout_plugin_/
         cd ./_checkout_plugin_/
-        git clone --depth 1 --branch ${{ inputs.BEC_PLUGIN_REPO_BRANCH }} https://oauth2:${{ inputs.GITLAB_TOKEN }}@${{ inputs.BEC_PLUGIN_REPO_URL }}
+        git clone --depth 1 --branch ${{ inputs.BEC_PLUGIN_REPO_BRANCH }} ${{ inputs.BEC_PLUGIN_REPO_URL }}
         
         cd ../
         # get the plugin repository name from the installed directory

--- a/.github/actions/plugin_repo_tests/action.yml
+++ b/.github/actions/plugin_repo_tests/action.yml
@@ -16,6 +16,9 @@ inputs:
   BEC_PLUGIN_REPO_URL: # id of input
     required: true
     description: "URL of the BEC plugin repository to install"
+  BEC_PLUGIN_REPO_NAME:
+    required: true
+    description: "Name of the BEC plugin repository to install"
   BEC_PLUGIN_REPO_BRANCH: # id of input
     required: false
     default: "main"
@@ -24,6 +27,9 @@ inputs:
     required: false
     default: "3.11"
     description: "Python version to use"
+  GH_READ_TOKEN: # id of input
+    required: true
+    description: "GitHub Read Token for accessing private repositories"
 
 runs:
   using: "composite"
@@ -35,11 +41,11 @@ runs:
         # Create a temporary directory for the plugin repository
         mkdir -p ./_checkout_plugin_/
         cd ./_checkout_plugin_/
-        git clone --depth 1 --branch ${{ inputs.BEC_PLUGIN_REPO_BRANCH }} ${{ inputs.BEC_PLUGIN_REPO_URL }}
-        
+        echo "Checking out BEC plugin repository from ${{ inputs.BEC_PLUGIN_REPO_URL }} on branch ${{ inputs.BEC_PLUGIN_REPO_BRANCH }}"
+        git clone --depth 1 --branch ${{ inputs.BEC_PLUGIN_REPO_BRANCH }} https://oauth2:${{ inputs.GH_READ_TOKEN }}@${{ inputs.BEC_PLUGIN_REPO_URL }}
         cd ../
         # get the plugin repository name from the installed directory
-        PLUGIN_REPO_NAME=$(basename ${{ inputs.BEC_PLUGIN_REPO_URL }} .git)
+        PLUGIN_REPO_NAME=${{ inputs.BEC_PLUGIN_REPO_NAME }}
         echo "PLUGIN_REPO_NAME=${PLUGIN_REPO_NAME}" >> $GITHUB_ENV
         echo "Plugin repository name: $PLUGIN_REPO_NAME"
 

--- a/.github/workflows/child_repos.yml
+++ b/.github/workflows/child_repos.yml
@@ -47,6 +47,29 @@ jobs:
         run: |
           pip install pytest pytest-random-order
           pytest -v --maxfail=2 --junitxml=report.xml --random-order ./tests/unit_tests
+  ophyd_devices:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -el {0}
+
+    steps:
+      - name: Checkout Ophyd Devices
+        uses: actions/checkout@v4
+        with:
+          repository: bec-project/ophyd_devices
+          ref: ${{ inputs.OPHYD_DEVICES_BRANCH }}
+
+      - name: Install Ophyd Devices and dependencies
+        uses: ./.github/actions/ophyd_devices_install
+        with:
+          OPHYD_DEVICES_BRANCH: ${{ inputs.OPHYD_DEVICES_BRANCH }}
+          BEC_CORE_BRANCH: ${{ inputs.BEC_CORE_BRANCH }}
+          PYTHON_VERSION: '3.11'
+      - name: Run Pytest
+        run: |
+          pip install pytest pytest-random-order
+          pytest -v --maxfail=2 --junitxml=report.xml --random-order ./tests
 
       
 

--- a/.github/workflows/child_repos.yml
+++ b/.github/workflows/child_repos.yml
@@ -18,11 +18,6 @@ on:
         default: 'main'
         type: string
 
-    secrets:
-      GITLAB_TOKEN:
-        description: 'GitLab token for CSAXS read access'
-        required: false
-
 
 
 jobs:
@@ -91,18 +86,18 @@ jobs:
     strategy:
       matrix:
         beamline_repo: [
-          {url: 'gitlab.psi.ch/bec/addams_bec.git', 'name': 'addams_bec'},
-          {url: 'gitlab.psi.ch/bec/csaxs_bec.git', 'name': 'csaxs_bec'},
-          {url: 'gitlab.psi.ch/bec/debye_bec.git', 'name': 'debye_bec'},
-          {url: 'gitlab.psi.ch/bec/detector_group_bec.git', 'name': 'detector_group_bec'},
-          {url: 'gitlab.psi.ch/bec/microxas_bec.git', 'name': 'microxas_bec'},
-          {url: 'gitlab.psi.ch/bec/phoenix_bec.git', 'name': 'phoenix_bec'},
-          {url: 'gitlab.psi.ch/bec/pxi_bec.git', 'name': 'pxi_bec'},
-          {url: 'gitlab.psi.ch/bec/pxii_bec.git', 'name': 'pxii_bec'},
-          {url: 'gitlab.psi.ch/bec/sim_bec.git', 'name': 'sim_bec'},
-          {url: 'gitlab.psi.ch/bec/superxas_bec.git', 'name': 'superxas_bec'},
-          {url: 'gitlab.psi.ch/bec/tomcat_bec.git', 'name': 'tomcat_bec'},
-          {url: 'gitlab.psi.ch/bec/xtreme_bec.git', 'name': 'xtreme_bec'},
+          {url: 'https://github.com/bec-project/bec/addams_bec.git', 'name': 'addams_bec'},
+          {url: 'https://github.com/bec-project/bec/csaxs_bec.git', 'name': 'csaxs_bec'},
+          {url: 'https://github.com/bec-project/bec/debye_bec.git', 'name': 'debye_bec'},
+          {url: 'https://github.com/bec-project/bec/detector_group_bec.git', 'name': 'detector_group_bec'},
+          {url: 'https://github.com/bec-project/bec/microxas_bec.git', 'name': 'microxas_bec'},
+          {url: 'https://github.com/bec-project/bec/phoenix_bec.git', 'name': 'phoenix_bec'},
+          {url: 'https://github.com/bec-project/bec/pxi_bec.git', 'name': 'pxi_bec'},
+          {url: 'https://github.com/bec-project/bec/pxii_bec.git', 'name': 'pxii_bec'},
+          {url: 'https://github.com/bec-project/bec/sim_bec.git', 'name': 'sim_bec'},
+          {url: 'https://github.com/bec-project/bec/superxas_bec.git', 'name': 'superxas_bec'},
+          {url: 'https://github.com/bec-project/bec/tomcat_bec.git', 'name': 'tomcat_bec'},
+          {url: 'https://github.com/bec-project/bec/xtreme_bec.git', 'name': 'xtreme_bec'},
         ]
 
     name: Plugin ${{ matrix.beamline_repo.name }}
@@ -122,7 +117,6 @@ jobs:
           OPHYD_DEVICES_BRANCH: ${{ inputs.OPHYD_DEVICES_BRANCH }}
           BEC_PLUGIN_REPO_URL: ${{ matrix.beamline_repo.url }}
           PYTHON_VERSION: '3.11'
-          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
 
       
 

--- a/.github/workflows/child_repos.yml
+++ b/.github/workflows/child_repos.yml
@@ -18,6 +18,12 @@ on:
         default: 'main'
         type: string
 
+    secrets:
+      GITLAB_TOKEN:
+        description: 'GitLab token for CSAXS read access'
+        required: false
+
+
 
 jobs:
   bec-widgets:
@@ -70,6 +76,53 @@ jobs:
         run: |
           pip install pytest pytest-random-order
           pytest -v --maxfail=2 --junitxml=report.xml --random-order ./tests
+
+  plugin_repos:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    defaults:
+      run:
+        shell: bash -el {0}
+
+    env: 
+      QTWEBENGINE_DISABLE_SANDBOX: 1
+      QT_QPA_PLATFORM: "offscreen"
+
+    strategy:
+      matrix:
+        beamline_repo: [
+          {url: 'gitlab.psi.ch/bec/addams_bec.git', 'name': 'addams_bec'},
+          {url: 'gitlab.psi.ch/bec/csaxs_bec.git', 'name': 'csaxs_bec'},
+          {url: 'gitlab.psi.ch/bec/debye_bec.git', 'name': 'debye_bec'},
+          {url: 'gitlab.psi.ch/bec/detector_group_bec.git', 'name': 'detector_group_bec'},
+          {url: 'gitlab.psi.ch/bec/microxas_bec.git', 'name': 'microxas_bec'},
+          {url: 'gitlab.psi.ch/bec/phoenix_bec.git', 'name': 'phoenix_bec'},
+          {url: 'gitlab.psi.ch/bec/pxi_bec.git', 'name': 'pxi_bec'},
+          {url: 'gitlab.psi.ch/bec/pxii_bec.git', 'name': 'pxii_bec'},
+          {url: 'gitlab.psi.ch/bec/sim_bec.git', 'name': 'sim_bec'},
+          {url: 'gitlab.psi.ch/bec/superxas_bec.git', 'name': 'superxas_bec'},
+          {url: 'gitlab.psi.ch/bec/tomcat_bec.git', 'name': 'tomcat_bec'},
+          {url: 'gitlab.psi.ch/bec/xtreme_bec.git', 'name': 'xtreme_bec'},
+        ]
+
+    name: Plugin ${{ matrix.beamline_repo.name }}
+
+    steps:
+      - name: Checkout BEC Core
+        uses: actions/checkout@v4
+        with:
+          repository: bec-project/bec
+          ref: ${{ inputs.BEC_CORE_BRANCH }}
+
+      - name: Install and test a BEC plugin repository
+        uses: ./.github/actions/plugin_repo_tests
+        with:
+          BEC_CORE_BRANCH: ${{ inputs.BEC_CORE_BRANCH }}
+          BEC_WIDGETS_BRANCH: ${{ inputs.BEC_WIDGETS_BRANCH }}
+          OPHYD_DEVICES_BRANCH: ${{ inputs.OPHYD_DEVICES_BRANCH }}
+          BEC_PLUGIN_REPO_URL: ${{ matrix.beamline_repo.url }}
+          PYTHON_VERSION: '3.11'
+          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
 
       
 

--- a/.github/workflows/child_repos.yml
+++ b/.github/workflows/child_repos.yml
@@ -17,6 +17,10 @@ on:
         required: false
         default: 'main'
         type: string
+      
+    secrets:
+      GH_READ_TOKEN:
+        required: true
 
 
 
@@ -86,18 +90,18 @@ jobs:
     strategy:
       matrix:
         beamline_repo: [
-          {url: 'https://github.com/bec-project/addams_bec.git', 'name': 'addams_bec'},
-          {url: 'https://github.com/bec-project/csaxs_bec.git', 'name': 'csaxs_bec'},
-          {url: 'https://github.com/bec-project/debye_bec.git', 'name': 'debye_bec'},
-          {url: 'https://github.com/bec-project/detector_group_bec.git', 'name': 'detector_group_bec'},
-          {url: 'https://github.com/bec-project/microxas_bec.git', 'name': 'microxas_bec'},
-          {url: 'https://github.com/bec-project/phoenix_bec.git', 'name': 'phoenix_bec'},
-          {url: 'https://github.com/bec-project/pxi_bec.git', 'name': 'pxi_bec'},
-          {url: 'https://github.com/bec-project/pxii_bec.git', 'name': 'pxii_bec'},
-          {url: 'https://github.com/bec-project/sim_bec.git', 'name': 'sim_bec'},
-          {url: 'https://github.com/bec-project/superxas_bec.git', 'name': 'superxas_bec'},
-          {url: 'https://github.com/bec-project/tomcat_bec.git', 'name': 'tomcat_bec'},
-          {url: 'https://github.com/bec-project/xtreme_bec.git', 'name': 'xtreme_bec'},
+          {url: 'github.com/bec-project/addams_bec.git', 'name': 'addams_bec'},
+          {url: 'github.com/bec-project/csaxs_bec.git', 'name': 'csaxs_bec'},
+          {url: 'github.com/bec-project/debye_bec.git', 'name': 'debye_bec'},
+          {url: 'github.com/bec-project/detector_group_bec.git', 'name': 'detector_group_bec'},
+          {url: 'github.com/bec-project/microxas_bec.git', 'name': 'microxas_bec'},
+          {url: 'github.com/bec-project/phoenix_bec.git', 'name': 'phoenix_bec'},
+          {url: 'github.com/bec-project/pxi_bec.git', 'name': 'pxi_bec'},
+          {url: 'github.com/bec-project/pxii_bec.git', 'name': 'pxii_bec'},
+          {url: 'github.com/bec-project/sim_bec.git', 'name': 'sim_bec'},
+          {url: 'github.com/bec-project/superxas_bec.git', 'name': 'superxas_bec'},
+          {url: 'github.com/bec-project/tomcat_bec.git', 'name': 'tomcat_bec'},
+          {url: 'github.com/bec-project/xtreme_bec.git', 'name': 'xtreme_bec'},
         ]
 
     name: Plugin ${{ matrix.beamline_repo.name }}
@@ -116,6 +120,8 @@ jobs:
           BEC_WIDGETS_BRANCH: ${{ inputs.BEC_WIDGETS_BRANCH }}
           OPHYD_DEVICES_BRANCH: ${{ inputs.OPHYD_DEVICES_BRANCH }}
           BEC_PLUGIN_REPO_URL: ${{ matrix.beamline_repo.url }}
+          BEC_PLUGIN_REPO_NAME: ${{ matrix.beamline_repo.name }}
+          GH_READ_TOKEN: ${{ secrets.GH_READ_TOKEN }}
           PYTHON_VERSION: '3.11'
 
       

--- a/.github/workflows/child_repos.yml
+++ b/.github/workflows/child_repos.yml
@@ -86,18 +86,18 @@ jobs:
     strategy:
       matrix:
         beamline_repo: [
-          {url: 'https://github.com/bec-project/bec/addams_bec.git', 'name': 'addams_bec'},
-          {url: 'https://github.com/bec-project/bec/csaxs_bec.git', 'name': 'csaxs_bec'},
-          {url: 'https://github.com/bec-project/bec/debye_bec.git', 'name': 'debye_bec'},
-          {url: 'https://github.com/bec-project/bec/detector_group_bec.git', 'name': 'detector_group_bec'},
-          {url: 'https://github.com/bec-project/bec/microxas_bec.git', 'name': 'microxas_bec'},
-          {url: 'https://github.com/bec-project/bec/phoenix_bec.git', 'name': 'phoenix_bec'},
-          {url: 'https://github.com/bec-project/bec/pxi_bec.git', 'name': 'pxi_bec'},
-          {url: 'https://github.com/bec-project/bec/pxii_bec.git', 'name': 'pxii_bec'},
-          {url: 'https://github.com/bec-project/bec/sim_bec.git', 'name': 'sim_bec'},
-          {url: 'https://github.com/bec-project/bec/superxas_bec.git', 'name': 'superxas_bec'},
-          {url: 'https://github.com/bec-project/bec/tomcat_bec.git', 'name': 'tomcat_bec'},
-          {url: 'https://github.com/bec-project/bec/xtreme_bec.git', 'name': 'xtreme_bec'},
+          {url: 'https://github.com/bec-project/addams_bec.git', 'name': 'addams_bec'},
+          {url: 'https://github.com/bec-project/csaxs_bec.git', 'name': 'csaxs_bec'},
+          {url: 'https://github.com/bec-project/debye_bec.git', 'name': 'debye_bec'},
+          {url: 'https://github.com/bec-project/detector_group_bec.git', 'name': 'detector_group_bec'},
+          {url: 'https://github.com/bec-project/microxas_bec.git', 'name': 'microxas_bec'},
+          {url: 'https://github.com/bec-project/phoenix_bec.git', 'name': 'phoenix_bec'},
+          {url: 'https://github.com/bec-project/pxi_bec.git', 'name': 'pxi_bec'},
+          {url: 'https://github.com/bec-project/pxii_bec.git', 'name': 'pxii_bec'},
+          {url: 'https://github.com/bec-project/sim_bec.git', 'name': 'sim_bec'},
+          {url: 'https://github.com/bec-project/superxas_bec.git', 'name': 'superxas_bec'},
+          {url: 'https://github.com/bec-project/tomcat_bec.git', 'name': 'tomcat_bec'},
+          {url: 'https://github.com/bec-project/xtreme_bec.git', 'name': 'xtreme_bec'},
         ]
 
     name: Plugin ${{ matrix.beamline_repo.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,5 +62,3 @@ jobs:
       BEC_WIDGETS_BRANCH: ${{ inputs.BEC_WIDGETS_BRANCH || 'main' }}
       BEC_CORE_BRANCH: ${{ inputs.BEC_CORE_BRANCH || github.head_ref || github.sha}}
       OPHYD_DEVICES_BRANCH: ${{ inputs.OPHYD_DEVICES_BRANCH || 'main' }}
-    secrets:
-      GITLAB_TOKEN: ${{ secrets.GITLAB_READ_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,5 @@ jobs:
       BEC_WIDGETS_BRANCH: ${{ inputs.BEC_WIDGETS_BRANCH || 'main' }}
       BEC_CORE_BRANCH: ${{ inputs.BEC_CORE_BRANCH || github.head_ref || github.sha}}
       OPHYD_DEVICES_BRANCH: ${{ inputs.OPHYD_DEVICES_BRANCH || 'main' }}
+    secrets:
+      GITLAB_TOKEN: ${{ secrets.GITLAB_READ_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,5 @@ jobs:
       BEC_WIDGETS_BRANCH: ${{ inputs.BEC_WIDGETS_BRANCH || 'main' }}
       BEC_CORE_BRANCH: ${{ inputs.BEC_CORE_BRANCH || github.head_ref || github.sha}}
       OPHYD_DEVICES_BRANCH: ${{ inputs.OPHYD_DEVICES_BRANCH || 'main' }}
+    secrets:
+      GH_READ_TOKEN: ${{ secrets.GH_READ_TOKEN }}

--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -1,39 +1,34 @@
 name: Run Pytest with Coverage
-on: [workflow_call]
+on: 
+  workflow_call:
+    inputs:
+      BEC_CORE_BRANCH:
+        description: 'Branch of BEC Core to install'
+        required: false
+        default: 'main'
+        type: string
+      OPHYD_DEVICES_BRANCH:
+        description: 'Branch of Ophyd Devices to install'
+        required: false
+        default: 'main'
+        type: string
+      BEC_WIDGETS_BRANCH:
+        description: 'Branch of BEC Widgets to install'
+        required: false
+        default: 'main'
+        type: string
 
 jobs:
   pytest:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -el {0}
-
-    env:
-      CHILD_PIPELINE_BRANCH: main  # Set the branch you want for ophyd_devices
-      BEC_CORE_BRANCH: main        # Set the branch you want for bec
-      OPHYD_DEVICES_BRANCH: main   # Set the branch you want for ophyd_devices
-      PROJECT_PATH: ${{ github.repository }}
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v3
+      - name: Run E2E Tests
+        uses: ./.github/actions/bec_e2e_install
         with:
-            auto-update-conda: true
-            auto-activate-base: true
-            python-version: '3.11'
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y tmux
-
-      - name: Conda install and run pytest
-        run: |
-          echo -e "\033[35;1m Using branch $OPHYD_DEVICES_BRANCH of OPHYD_DEVICES \033[0;m";
-          git clone --branch $OPHYD_DEVICES_BRANCH https://github.com/bec-project/ophyd_devices.git
-          export OHPYD_DEVICES_PATH=$PWD/ophyd_devices
-          source ./bin/install_bec_dev.sh -t
-          pip install -e ./ophyd_devices
-          pytest -v --files-path ./ --start-servers --random-order  ./bec_ipython_client/tests/end-2-end
+          BEC_CORE_BRANCH: ${{ inputs.BEC_CORE_BRANCH }}
+          OPHYD_DEVICES_BRANCH: ${{ inputs.OPHYD_DEVICES_BRANCH }}
+          BEC_WIDGETS_BRANCH: ${{ inputs.BEC_WIDGETS_BRANCH }}
+          PYTHON_VERSION: '3.11'
+          


### PR DESCRIPTION
This PR adds a child pipeline improves the CI pipeline for BEC.

It adds:
- child pipeline for ophyd_devices
- child pipelines for plugin repositories (allowed to fail)
- moves e2e test into independent action. Can be reused by other repositories 

Note, which tests should be mandatory to pass for BEC. At the moment, child_repos are allowed to fail. Should this remain like this?

PS: Even with GITLAB Token, gitlab.psi.ch sometimes rejects the cloning of the plugin repository.