### PR TITLE
fix(progress_signal): progress message must include scan id

### DIFF
--- a/bec_lib/bec_lib/bec_service.py
+++ b/bec_lib/bec_lib/bec_service.py
@@ -102,6 +102,7 @@ class BECService:
         self,
         config: str | ServiceConfig,
         connector_cls: type[RedisConnector],
+        connector: RedisConnector | None = None,
         unique_service=False,
         wait_for_server=False,
         name: str | None = None,
@@ -113,7 +114,9 @@ class BECService:
         self._connector_cls = connector_cls
         # Log the server address
         logger.info(f"Connecting to Redis server at {self.bootstrap_server}")
-        self.connector: RedisConnector = connector_cls(self.bootstrap_server)
+        self.connector: RedisConnector = (
+            connector_cls(self.bootstrap_server) if connector is None else connector
+        )
         self.acl = BECAccess(self.connector)
         self.acl._bec_service_login(prompt_for_acl, self._service_config.config.get("acl"))
 

--- a/bec_lib/bec_lib/logger.py
+++ b/bec_lib/bec_lib/logger.py
@@ -168,19 +168,17 @@ class BECLogger:
 
         # connector is already provided
         if connector is not None:
-            if not isinstance(connector, RedisConnector):
-                raise TypeError(
-                    f"connector must be an instance of RedisConnector, got {type(connector)}"
-                )
             return connector
 
         # connector_cls is provided
-        if connector_cls is None:
-            raise ValueError("connector_cls must be provided when using connector_cls")
-        if not issubclass(connector_cls, RedisConnector):
-            raise TypeError(
-                f"connector_cls must be a subclass of RedisConnector, got {connector_cls}"
-            )
+
+        # disabled for now, cf issue #522
+        # if connector_cls is None:
+        #     raise ValueError("connector_cls must be provided when using connector_cls")
+        # if not issubclass(connector_cls, RedisConnector):
+        #     raise TypeError(
+        #         f"connector_cls must be a subclass of RedisConnector, got {connector_cls}"
+        #     )
         if not bootstrap_server:
             raise ValueError("bootstrap_server must be provided when using connector_cls")
         return connector_cls(bootstrap=bootstrap_server)

--- a/bec_lib/tests/test_bec_service.py
+++ b/bec_lib/tests/test_bec_service.py
@@ -24,10 +24,15 @@ from bec_lib.service_config import ServiceConfig
 dir_path = os.path.dirname(bec_lib.__file__)
 
 
+class MagicMockConnector(RedisConnector):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, redis_cls=mock.MagicMock, **kwargs)
+
+
 @contextlib.contextmanager
 def bec_service(config, connector_cls=None, **kwargs):
     if connector_cls is None:
-        connector_cls = mock.MagicMock()
+        connector_cls = MagicMockConnector
     with mock.patch("bec_lib.bec_service.BECAccess") as mock_access:
         service = BECService(config=config, connector_cls=connector_cls, **kwargs)
         try:

--- a/bec_server/bec_server/device_server/bec_message_handler.py
+++ b/bec_server/bec_server/device_server/bec_message_handler.py
@@ -79,6 +79,18 @@ class BECMessageHandler:
             raise TypeError(f"Expected ProgressMessage, got {type(message)}")
 
         device_name = obj.root.name
+        metadata = self.devices[device_name].metadata
+        scan_id = metadata.get("scan_id")
+        if scan_id is None:
+            logger.warning(f"Scan ID is None for device {device_name}.")
+            return
+        if not isinstance(scan_id, str):
+            logger.warning(f"Scan ID is not a string for device {device_name}.")
+            return
+
+        if message.metadata is None:
+            message.metadata = {}
+        message.metadata.update({"scan_id": scan_id})
         self.connector.set_and_publish(MessageEndpoints.device_progress(device_name), message)
 
     def _handle_preview_signal(self, obj: bms.PreviewSignal, message: messages.BECMessage):

--- a/bec_server/tests/tests_device_server/test_device_manager_ds.py
+++ b/bec_server/tests/tests_device_server/test_device_manager_ds.py
@@ -327,16 +327,12 @@ def test_device_manager_ds_obj_callback_file_event_signal(dm_with_devices, value
 
 @pytest.mark.parametrize("device_manager_class", [DeviceManagerDS])
 @pytest.mark.parametrize(
-    "value",
-    [
-        None,
-        messages.ProgressMessage(value=1, max_value=2, done=False, metadata={"scan_id": "12345"}),
-        "some string",
-    ],
+    "value", [None, messages.ProgressMessage(value=1, max_value=2, done=False), "some string"]
 )
 def test_device_manager_ds_obj_callback_progress_signal(dm_with_devices, value):
     device_manager = dm_with_devices
     device = dm_with_devices.devices.bec_signals_device.obj
+    dm_with_devices.devices.bec_signals_device.metadata = {"scan_id": "12345"}
     with mock.patch.object(device_manager.connector, "set_and_publish") as mock_set_and_publish:
         device_manager._obj_callback_bec_message_signal(obj=device.progress, value=value)
 


### PR DESCRIPTION
This is just a quick fix to add the scan id to the progress message. Once we've migrated everything to use the bec signal, we can elevate the scan id to a proper pydantic field (cf #521). 


It also adds a fix for the initialization of the logger tests (introduced with #518).