### PR TITLE
Fix/signal update fix

### DIFF
--- a/bec_server/bec_server/device_server/bec_message_handler.py
+++ b/bec_server/bec_server/device_server/bec_message_handler.py
@@ -123,10 +123,22 @@ class BECMessageHandler:
         device_name = obj.root.name
         signal_name = obj.name
 
-        scan_id = self._get_current_scan_id()
+        scan_status_msg = self._get_scan_status_message()
+        if scan_status_msg is None:
+            logger.warning(
+                f"Scan status message is None for device {device_name} and async signal {signal_name}."
+            )
+            return
+        scan_id = scan_status_msg.scan_id
         if scan_id is None:
             logger.warning(
-                f"Scan ID is None for device {device_name} and signal {signal_name}. Cannot emit async signal."
+                f"Scan ID is None for device {device_name} and async signal {signal_name}."
+            )
+            return
+        status = scan_status_msg.status
+        if status in ["closed", "aborted", "halted", None]:
+            logger.warning(
+                f"Cannot emit async signal {signal_name} for device {device_name} with status {status}."
             )
             return
 

--- a/bec_server/bec_server/scan_bundler/scan_bundler.py
+++ b/bec_server/bec_server/scan_bundler/scan_bundler.py
@@ -110,9 +110,9 @@ class ScanBundler(BECService):
             self._initialize_scan_container(msg)
             if scan_id not in self.scan_id_history:
                 self.scan_id_history.append(scan_id)
-        self.run_emitter("on_scan_status_update", msg)
         if msg.content.get("status") != "open":
             self._scan_status_modification(msg)
+        self.run_emitter("on_scan_status_update", msg)
 
     def _scan_status_modification(self, msg: messages.ScanStatusMessage):
         status = msg.content.get("status")


### PR DESCRIPTION
This PR should fix two related problems:
* Scan progress messages were set to 100 % whenever the scan finishes, even if it was aborted. In addition, the scan status was added to simplify the logic within UI components. 
* The message handler used to fetch metadata, such as the scan id directly from the device's metadata. This can lead to unexpected behavior and should rather be avoided. Instead, the data is now fetched directly from the DeviceManager's scan_info object. 

closes #509