### PR TITLE
fix: bug in device serialization

### DIFF
--- a/bec_lib/bec_lib/bec_service.py
+++ b/bec_lib/bec_lib/bec_service.py
@@ -179,7 +179,7 @@ class BECService:
             return False
         except RuntimeError as service_error:
             if elapsed_time > timeout_time:
-                raise RuntimeError from service_error
+                raise service_error
         return True
 
     def _initialize_logger(self) -> None:

--- a/bec_server/bec_server/device_server/devices/device_serializer.py
+++ b/bec_server/bec_server/device_server/devices/device_serializer.py
@@ -192,13 +192,15 @@ def get_device_info(
     if isinstance(obj, Signal):
         # needed because ophyd signals have empty hints
         hints = {"fields": [obj.name]}
-    else:
+    elif connect:  # only works if PVs are connected
         device_dict = get_lazy_wait_for_connection(obj)
         for _, info in device_dict.items():  # Set all to False
             info[0].lazy_wait_for_connection = False
         hints = obj.hints
         for _, info in device_dict.items():  # Set back to initial value
             info[0].lazy_wait_for_connection = info[1]
+    else:
+        hints = {}
 
     if connect:
         describe = obj.describe()


### PR DESCRIPTION
The PR fixes a bug and improves the error message if a bec_service is not unique: 

- 1. The method `get_lazy_wait_for_connection(obj)` needs PVs to be connected. This PR ensures that
- 2. If a bec_service is already running, it raises the Runtime Error with proper message directly now