### PR TITLE
Add go script for account management CLI

### DIFF
--- a/bin/bec_set_account/go.mod
+++ b/bin/bec_set_account/go.mod
@@ -1,0 +1,11 @@
+module bec_set_account
+
+go 1.24.4
+
+require (
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/redis/go-redis/v9 v9.11.0 // indirect
+	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+)

--- a/bin/bec_set_account/go.sum
+++ b/bin/bec_set_account/go.sum
@@ -1,0 +1,10 @@
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/redis/go-redis/v9 v9.11.0 h1:E3S08Gl/nJNn5vkxd2i78wZxWAPNZgUNTp8WIJUAiIs=
+github.com/redis/go-redis/v9 v9.11.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
+github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
+github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=

--- a/bin/bec_set_account/main.go
+++ b/bin/bec_set_account/main.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/user"
+	"regexp"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+type BECCodecWrapper struct {
+    BecCodec BecCodecData `msgpack:"__bec_codec__" json:"__bec_codec__"`
+}
+
+type BecCodecData struct {
+    EncoderName string                 `msgpack:"encoder_name" json:"encoder_name"`
+    TypeName    string                 `msgpack:"type_name" json:"type_name"`
+    Data        VariableMessagePayload `msgpack:"data" json:"data"`
+}
+
+type VariableMessagePayload struct {
+    MsgType  string            `msgpack:"msg_type" json:"msg_type"`
+    Value    interface{}       `msgpack:"value" json:"value"`
+    Metadata map[string]string `msgpack:"metadata" json:"metadata"`
+}
+
+func main() {
+	// CLI flags
+	redisHost := flag.String("redis-host", "", "Redis host (e.g. awi-bec-001)")
+	pgroup := flag.String("pgroup", "", "Process group (e.g. p16602 )")
+	flag.Parse()
+
+	if *redisHost == "" {
+		fmt.Println("Missing required argument: --redis-host")
+		os.Exit(1)
+	}
+	if matched, _ := regexp.MatchString(`^p\d{5}$`, *pgroup); !matched {
+		fmt.Println("Invalid --pgroup format. It must start with 'p' followed by exactly 5 digits (e.g. p12345).")
+		os.Exit(1)
+	}
+
+	// Connect to Redis (default port)
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{
+		Addr: *redisHost + ":6379",
+	})
+	key := "info/account"
+
+	// Check existing account
+	existing, err := rdb.Get(ctx, key).Bytes()
+	if err == nil {
+		var decoded BECCodecWrapper
+		if err := msgpack.Unmarshal(existing, &decoded); err != nil {
+			fmt.Println("Warning: Failed to decode existing message:", err)
+		} else {
+			fmt.Println("Current active account", decoded.BecCodec.Data.Value)
+			for k, v := range decoded.BecCodec.Data.Metadata {
+				fmt.Printf("%s: %s\n", k, v)
+		}
+
+		var input string
+		fmt.Print("Are you sure you want to overwrite it? [y/N]: ")
+		fmt.Scanln(&input)
+		if input != "y" && input != "Y" {
+			fmt.Println("Aborted, old account", decoded.BecCodec.Data.Value, "remains active.")
+			os.Exit(0)
+		}
+	}
+	} else if err != redis.Nil {
+		// An actual error (not just "key not found")
+		fmt.Println("Failed to set account")
+		panic(err)
+	}
+
+
+
+	// Prepare message
+	currentUser, _ := user.Current()
+	now := time.Now().Format(time.RFC3339)
+
+	msg := BECCodecWrapper{
+        BecCodec: BecCodecData{
+            EncoderName: "BECMessage",
+            TypeName:    "VariableMessage",
+            Data: VariableMessagePayload{
+                MsgType: "var_message",
+                Value:   *pgroup,
+                Metadata: map[string]string{
+                    "timestamp": now,
+			"user":      currentUser.Username,
+                },
+            },
+        },
+	}
+	// Encode as msgpack
+	packed, err := msgpack.Marshal(msg)
+	if err != nil {
+		fmt.Println("Failed to set account")
+		panic(err)
+	}
+
+	
+
+	// Set key
+	if err := rdb.Set(ctx, key, packed, 0).Err(); err != nil {
+		fmt.Println("Failed to set account")
+		panic(err)
+	}
+
+	fmt.Println("Account", *pgroup, "has been set successfully.")
+}

--- a/bin/bec_set_account/main.go
+++ b/bin/bec_set_account/main.go
@@ -33,6 +33,7 @@ func main() {
 	// CLI flags
 	redisHost := flag.String("redis-host", "", "Redis host (e.g. awi-bec-001)")
 	pgroup := flag.String("pgroup", "", "Process group (e.g. p16602 )")
+	force := flag.Bool("force", false, "Force overwrite existing account without confirmation")
 	flag.Parse()
 
 	if *redisHost == "" {
@@ -62,13 +63,15 @@ func main() {
 			for k, v := range decoded.BecCodec.Data.Metadata {
 				fmt.Printf("%s: %s\n", k, v)
 		}
-
-		var input string
-		fmt.Print("Are you sure you want to overwrite it? [y/N]: ")
-		fmt.Scanln(&input)
-		if input != "y" && input != "Y" {
-			fmt.Println("Aborted, old account", decoded.BecCodec.Data.Value, "remains active.")
-			os.Exit(0)
+		
+		if !*force {
+			var input string
+			fmt.Print("Are you sure you want to overwrite it? [y/N]: ")
+			fmt.Scanln(&input)
+			if input != "y" && input != "Y" {
+				fmt.Println("Aborted, old account", decoded.BecCodec.Data.Value, "remains active.")
+				os.Exit(0)
+			}
 		}
 	}
 	} else if err != redis.Nil {


### PR DESCRIPTION
This PR adds a CLI tool to change the account endpoint within redis. For the deployments, this should be used to change the account endpoint in redis. The compiled script is bec-set-account and can be called via:

``` {bash}
./bec-set-account --help
Usage of ./bec-set-account:
  -pgroup string
    	Process group (e.g. p16602 )
  -redis-host string
    	Redis host (e.g. awi-bec-001)
    	
    	
./bec-set-account -pgroup p10101 -redis-host localhost
```

Please note:

When an account change is requested, user input is needed to confirm the change. The default response is N, however, this can be changed if needed.

For beamlines, an additional wrapper should exist that sets the redis-host based on deployments, i.e. 'production'(should be default) or 'test'. and also limits the access to allow only specific groups to execute this script (i.e. unx-bec_core & beamline group). 