### PR TITLE
Fix basepath for filewriter logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,11 @@ jobs:
     needs: [check_pr_status, formatter]
     if: needs.check_pr_status.outputs.branch-pr == ''
     uses: ./.github/workflows/end2end.yml
+    with:
+      BEC_WIDGETS_BRANCH: ${{ inputs.BEC_WIDGETS_BRANCH || 'main' }}
+      BEC_CORE_BRANCH: ${{ inputs.BEC_CORE_BRANCH || github.head_ref || github.sha}}
+      OPHYD_DEVICES_BRANCH: ${{ inputs.OPHYD_DEVICES_BRANCH || 'main' }}
+      PYTHON_VERSION: '3.11'
 
   child-repos:
     needs: [check_pr_status, formatter]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       OPHYD_DEVICES_BRANCH: ${{ inputs.OPHYD_DEVICES_BRANCH || 'main' }}
 
   plugin-repos:
-    needs: [check_pr_status, formatter]
+    needs: [check_pr_status, formatter, unit-test, unit-test-matrix]
     if: needs.check_pr_status.outputs.branch-pr == ''
     uses: ./.github/workflows/plugin_repos.yml
     with:

--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -17,6 +17,11 @@ on:
         required: false
         default: 'main'
         type: string
+      PYTHON_VERSION:
+        description: 'Python version to use'
+        required: false
+        default: '3.11'
+        type: string
 
 jobs:
   pytest:
@@ -30,5 +35,5 @@ jobs:
           BEC_CORE_BRANCH: ${{ inputs.BEC_CORE_BRANCH }}
           OPHYD_DEVICES_BRANCH: ${{ inputs.OPHYD_DEVICES_BRANCH }}
           BEC_WIDGETS_BRANCH: ${{ inputs.BEC_WIDGETS_BRANCH }}
-          PYTHON_VERSION: '3.11'
+          PYTHON_VERSION: ${{ inputs.PYTHON_VERSION }}
           

--- a/bec_ipython_client/tests/end-2-end/test_scans_lib_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_scans_lib_e2e.py
@@ -1,14 +1,10 @@
-import os
-import subprocess
 import threading
 import time
-from pathlib import Path
 
 import numpy as np
 import pytest
 import yaml
 
-import bec_lib
 from bec_lib import messages
 from bec_lib.alarm_handler import AlarmBase
 from bec_lib.devicemanager import DeviceConfigError
@@ -543,24 +539,3 @@ def test_image_analysis(bec_client_lib):
     assert (np.isclose(fit_res[1]["stats"]["mean"], 3.3, atol=0.5)).all()
     # Center of mass is not in the middle due to hot (fluctuating) pixels
     assert (np.isclose(fit_res[1]["stats"]["center_of_mass"], [49.5, 40.8], atol=2)).all()
-
-
-def test_change_account_script(bec_client_lib):
-    bec = bec_client_lib
-    bec.metadata.update({"unit_test": "test_change_account_script"})
-    dev = bec.device_manager.devices
-    account = bec.active_account
-    redis_host, port = bec._service_config.redis.split(":")
-    pgroup = "p12345"
-    try:
-        base_dir = Path(bec_lib.__file__).parent.parent.parent
-        set_account_dir = os.path.join(base_dir, "bin", "bec_set_account")
-        cmd = f"{set_account_dir}/bec-set-account"
-        subprocess.run(
-            [cmd, "--redis-host", redis_host, "--pgroup", pgroup, "--force", "true"], check=True
-        )
-        assert bec.active_account == pgroup
-    finally:
-        bec.connector.delete(MessageEndpoints.account())
-
-    assert bec.active_account == ""

--- a/bec_lib/bec_lib/file_utils.py
+++ b/bec_lib/bec_lib/file_utils.py
@@ -65,8 +65,7 @@ class LogWriter:
         """
         self.service_config_parser = ServiceConfigParser(service_config)
         self._base_path = self.service_config_parser.get_base_path()
-        self._directory = os.path.join(self._base_path, "logs")
-        self.create_directory(self.directory)
+        self.create_directory(self._base_path)
 
     def create_directory(self, fname: str = None) -> None:
         """Create the log directory."""
@@ -79,7 +78,7 @@ class LogWriter:
         Returns:
             str: String representation of log directory
         """
-        return self._directory
+        return self._base_path
 
 
 class DeviceConfigWriter:

--- a/bec_lib/bec_lib/service_config.py
+++ b/bec_lib/bec_lib/service_config.py
@@ -2,6 +2,7 @@
 This module provides a class to handle the service configuration.
 """
 
+import copy
 import json
 import os
 from pathlib import Path
@@ -78,7 +79,7 @@ class ServiceConfig:
             return
 
         if not self.config_path:
-            self.config = DEFAULT_SERVICE_CONFIG
+            self.config = copy.deepcopy(DEFAULT_SERVICE_CONFIG)
             return
 
     def _load_urls(self, entry: str, required: bool = True):

--- a/bec_lib/bec_lib/service_config.py
+++ b/bec_lib/bec_lib/service_config.py
@@ -19,8 +19,11 @@ DEFAULT_BASE_PATH = (
 DEFAULT_SERVICE_CONFIG = {
     "redis": {"host": os.environ.get("BEC_REDIS_HOST", "localhost"), "port": 6379},
     "service_config": {
-        "file_writer": {"plugin": "default_NeXus_format", "base_path": DEFAULT_BASE_PATH},
-        "log_writer": {"base_path": DEFAULT_BASE_PATH},
+        "file_writer": {
+            "plugin": "default_NeXus_format",
+            "base_path": os.path.join(DEFAULT_BASE_PATH, "data"),
+        },
+        "log_writer": {"base_path": os.path.join(DEFAULT_BASE_PATH, "logs")},
     },
     "acl": DEFAULT_BASE_PATH + "/.bec_acl.env",
 }

--- a/bec_lib/tests/test_bec_logger.py
+++ b/bec_lib/tests/test_bec_logger.py
@@ -36,7 +36,7 @@ def test_configure(logger, tmp_path):
 
 
 def test_update_base_path_correct_config(logger):
-    config = {"log_writer": {"base_path": "./"}}
+    config = {"log_writer": {"base_path": "./logs"}}
     assert logger._base_path is None
     logger._update_base_path(config)
     assert logger._base_path == os.path.join(str(Path("./").resolve()), "logs")

--- a/bec_lib/tests/test_bec_service.py
+++ b/bec_lib/tests/test_bec_service.py
@@ -170,10 +170,9 @@ def test_bec_service_default_config():
     with bec_service(config=config, unique_service=True) as service:
         bec_lib_path = str(Path(bec_lib.service_config.__file__).resolve().parent.parent.parent)
         if "nox" not in bec_lib_path:
-            assert (
-                os.path.abspath(service._service_config.service_config["file_writer"]["base_path"])
-                == bec_lib_path
-            )
+            assert os.path.abspath(
+                service._service_config.service_config["file_writer"]["base_path"]
+            ) == os.path.join(bec_lib_path, "data")
 
 
 def test_bec_service_show_global_vars(capsys):

--- a/bec_lib/tests/test_file_utils.py
+++ b/bec_lib/tests/test_file_utils.py
@@ -60,7 +60,7 @@ def test_log_writer():
     """Device config writer fixture and ServiceConfigParser class"""
     with mock.patch("os.makedirs") as mock_make_dirs:
         with mock.patch("os.chmod") as mock_chmod:
-            lw = LogWriter(service_config={"base_path": "/tmp"})
+            lw = LogWriter(service_config={"base_path": "/tmp/logs"})
             assert mock_make_dirs.call_count == 1
             assert lw.directory == "/tmp/logs"
             mock_chmod.assert_called_once_with("/tmp/logs", int("0o771", 8))

--- a/bec_server/bec_server/scan_server/scan_worker.py
+++ b/bec_server/bec_server/scan_server/scan_worker.py
@@ -282,7 +282,7 @@ class ScanWorker(threading.Thread):
             if current_account:
                 return os.path.abspath(os.path.join(file_base_path, current_account))
             # if there is no account, we return the base path with the data folder
-            return os.path.abspath(os.path.join(file_base_path, "data"))
+            return os.path.abspath(file_base_path)
 
         # we deal with a string template
         file_base_path = Template(file_base_path)

--- a/bec_server/tests/tests_scan_server/test_scan_worker.py
+++ b/bec_server/tests/tests_scan_server/test_scan_worker.py
@@ -306,7 +306,7 @@ def test_initialize_scan_info(scan_worker_mock, msg):
                 file_dir = "S00000-00999/S00002"
             else:
                 file_dir = f"S00000-00999/S00002_{suffix}"
-        file_components = os.path.abspath(os.path.join(base_path, "data", file_dir, "S00002")), "h5"
+        file_components = os.path.abspath(os.path.join(base_path, file_dir, "S00002")), "h5"
         assert worker.current_scan_info["file_components"] == file_components
 
 
@@ -744,7 +744,7 @@ def test_worker_update_instr_with_scan_report_update(msg, scan_worker_mock):
             "/data/raw/test_account",
             False,
         ),
-        ("/data/raw", None, "/data/raw/data", False),
+        ("/data/raw", None, "/data/raw", False),
         (
             "/data/$account/$sub_dir/raw",
             messages.VariableMessage(value="test_account"),


### PR DESCRIPTION
This PR fixes the hardcoded 'data' and 'logs' structure for file and log writing. Instead, we will now directly use the basepath as specified in the config. Relies on https://git.psi.ch/psd_deployments/roles/psi.bec/-/merge_requests/4 to be merged together for the deployments.