### PR TITLE
fix(scan queue): remove stopped items from the queue

### DIFF
--- a/bec_server/bec_server/scan_server/scan_queue.py
+++ b/bec_server/bec_server/scan_server/scan_queue.py
@@ -20,7 +20,6 @@ from bec_lib.logger import bec_logger
 from .errors import LimitError, ScanAbortion
 from .instruction_handler import InstructionHandler
 from .scan_assembler import ScanAssembler
-from .scans import ScanBase
 
 logger = bec_logger.logger
 
@@ -552,6 +551,12 @@ class ScanQueue:
                         # we don't need to pause if there is no scan enqueued
                         self.status = ScanQueueStatus.RUNNING
                         logger.info("resetting queue status to running")
+                    if (
+                        len(self.queue) > 0
+                        and self.queue[0].status == InstructionQueueStatus.STOPPED
+                    ):
+                        # The next instruction queue is stopped, we can remove it
+                        break
                     self.signal_event.wait(0.1)
 
                 self.active_instruction_queue = self.queue[0]

--- a/bec_server/tests/tests_scan_server/test_scan_server_queue.py
+++ b/bec_server/tests/tests_scan_server/test_scan_server_queue.py
@@ -449,6 +449,24 @@ def test_scan_queue_next_instruction_queue_does_not_pop(queuemanager_mock):
     assert len(queue.queue) == 1
 
 
+def test_scan_queue_next_instruction_queue_pops_stopped_elements(queuemanager_mock):
+    """
+    Test that the scan queue pops the stopped elements from the queue.
+    """
+    queue_manager = queuemanager_mock()
+    queue = ScanQueue(queue_manager, InstructionQueueMock)
+    queue.queue.append(InstructionQueueItem(queue, mock.MagicMock(), mock.MagicMock()))
+    queue.queue.append(InstructionQueueItem(queue, mock.MagicMock(), mock.MagicMock()))
+    queue.queue[0].status = InstructionQueueStatus.STOPPED
+    queue.queue[1].status = InstructionQueueStatus.STOPPED
+    queue.status = ScanQueueStatus.PAUSED
+    queue.active_instruction_queue = queue.queue[0]
+    assert queue._next_instruction_queue() is True
+    assert len(queue.queue) == 1
+    assert queue._next_instruction_queue() is False
+    assert len(queue.queue) == 0
+
+
 def test_queue_manager_wait_for_queue_to_appear_in_history_raises_timeout(queuemanager_mock):
     queue_manager = queuemanager_mock()
     with pytest.raises(TimeoutError):


### PR DESCRIPTION
This PR ensures that stopped elements are removed from the queue. 

A bit of background: While in the past, only the first element could be stopped from the cli as only currently running scans could be halted, the GUI allows much more freedom, revealing a bug in the cleanup. If the queue item is set to stopped during the cleanup procedure, any subsequent insert of a new scan will block the entire server as it waits for the stopped element to be removed. 

Since we are not bombarding the backend with abort requests from a GUI, it is no surprise that we haven't observed the bug in our e2e tests. 