### PR TITLE
feat(ci): build and push requirements image

### DIFF
--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -9,8 +9,6 @@ on:
 permissions:
   contents: read
 
-
-
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -89,7 +87,51 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pip install python-semantic-release==9.* wheel build twine
-          semantic-release -vv --config ./ci/semantic_release.toml version
+          semantic-release --config ./ci/semantic_release.toml version
           if [ ! -d dist ]; then echo No release will be made; exit 0; fi
           twine upload dist/* -u __token__ -p ${{ secrets.CI_PYPI_TOKEN }} --skip-existing
           semantic-release publish
+
+  build-and-push:
+    name: Build and push requirements image
+    runs-on: ubuntu-latest
+    needs: release
+    permissions:
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Get version
+      id: version
+      run: |
+        git checkout main && git pull --tags
+        [ -z $(git describe --tags) ] && echo "Must have a version tag!" && exit 1
+        echo "setting version $(git describe --tags) as image tag" 
+        echo "bec_version=$(git describe --tags)" >> $GITHUB_OUTPUT
+
+    - name: Buildah build
+      id: container-build
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: bec_requirements
+        tags: ${{ steps.version.outputs.bec_version }} ${{ github.sha }}
+        containerfiles: |
+          ./bec_server/bec_server/scan_server/procedures/Containerfile.requirements
+        build-args: |
+          BEC_VERSION=${{ steps.version.outputs.bec_version }}
+        extra-args: |
+          -v ${{ github.workspace }}:/bec:ro
+  
+    - name: Push to registry
+      id: container-push
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.container-build.outputs.image }}
+        tags: ${{ steps.container-build.outputs.tags }}
+        registry: ghcr.io/bec-project
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Print image url
+      run: echo "Image pushed to ${{ steps.container-push.outputs.registry-paths }}"

--- a/bec_server/bec_server/scan_server/procedures/Containerfile.requirements
+++ b/bec_server/bec_server/scan_server/procedures/Containerfile.requirements
@@ -1,0 +1,24 @@
+# Base image
+FROM python:3.11-slim AS base
+
+# This image should be built and pushed to the container repo on release
+# The result is used in Containerfile.worker to create the local worker image 
+# for any given deployment
+
+# Set working directory - BEC deployment should be mounted here
+WORKDIR /bec
+
+FROM base AS bec_requirements
+# Install dependencies - BEC release workflow should build this stage and deploy
+# it to the internal container registry
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    tmux \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --upgrade pip wheel
+RUN pip install uv
+RUN uv pip install --system -r /bec/bec_lib/pyproject.toml 
+RUN uv pip install --system -r /bec/bec_server/pyproject.toml
+RUN uv pip install --system -r /bec/bec_ipython_client/pyproject.toml

--- a/bec_server/bec_server/scan_server/procedures/Containerfile.worker
+++ b/bec_server/bec_server/scan_server/procedures/Containerfile.worker
@@ -1,0 +1,14 @@
+ARG BEC_VERSION
+FROM ghcr.io/bec-project/bec_requirements:${BEC_VERSION} AS bec_procedure_worker
+
+# deployment directory should be mounted at /bec
+
+# Install bec components
+RUN uv pip install  --system -e /bec/bec_lib[dev]
+RUN uv pip install  --system -e /bec/bec_server[dev]
+RUN uv pip install  --system -e /bec/bec_ipython_client[dev]
+
+# Get plugin and ophyd devices
+# ...
+
+# No entrypoint, just run the command you want


### PR DESCRIPTION
Add a step following the release to build an image containing a python env with the requirements for bec, and push it to ghcr

(I know there's a CI commit tag, but I would like there to be a release made with merging this)