### PR TITLE
Feat/add scan history update callback

### DIFF
--- a/bec_lib/bec_lib/callback_handler.py
+++ b/bec_lib/bec_lib/callback_handler.py
@@ -19,12 +19,16 @@ logger = bec_logger.logger
 
 
 class EventType(str, enum.Enum):
-    """Event types"""
+    """Event types
+
+    SCAN_HISTORY_UPDATE: Update of the scan history, emits ScanhistoryMessages for history_msg arg.
+    """
 
     SCAN_SEGMENT = "scan_segment"
     SCAN_STATUS = "scan_status"
     NAMESPACE_UPDATE = "namespace_update"
     DEVICE_UPDATE = "device_update"
+    SCAN_HISTORY_UPDATE = "scan_history_update"
 
 
 class CallbackEntry:

--- a/bec_lib/bec_lib/client.py
+++ b/bec_lib/bec_lib/client.py
@@ -214,7 +214,7 @@ class BECClient(BECService, UserScriptsMixin):
         self._start_alarm_handler()
         self.load_all_user_scripts()
         self.config = self.device_manager.config_helper
-        self.history = ScanHistory(self.connector)
+        self.history = ScanHistory(client=self)
         self.dap = DAPPlugins(self)
         self.bl_checks = BeamlineChecks(self)
         self.bl_checks.start()


### PR DESCRIPTION
PR to add a callback mechanism for updates of the scan-history. Required to be merged before https://github.com/bec-project/bec_widgets/pull/754 can be merged