### PR TITLE
Device server catch exception in stop

### DIFF
--- a/bec_server/bec_server/device_server/device_server.py
+++ b/bec_server/bec_server/device_server/device_server.py
@@ -319,6 +319,7 @@ class DeviceServer(RPCMixin, BECService):
                         source={"device": dev.obj.name, "method": "stop"},
                         msg=content,
                         alarm_type=exc.__class__.__name__,
+                        metadata=self._get_metadata_for_alarm(None),
                     )
         self.status = BECStatus.RUNNING
 


### PR DESCRIPTION
The device server did not properly handle exceptions in a `stop()` call on a device. If the device would raise, it would remain in a BUSY state, and thereby become unresponsive. This PR fixes this