### PR TITLE
fix(live table): fix check for monitored devices

### DIFF
--- a/bec_ipython_client/bec_ipython_client/callbacks/live_table.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/live_table.py
@@ -221,7 +221,14 @@ class LiveUpdatesTable(LiveUpdatesBase):
                     break
                 if self.point_id > self.scan_item.num_points:
                     raise RuntimeError("Received more points than expected.")
+
                 if len(self.scan_item.live_data) == 0 and self.scan_item.status == "closed":
+                    msg = self.scan_item.status_message
+                    if not msg:
+                        continue
+                    if msg.readout_priority.get("monitored", []):
+                        continue
+
                     logger.warning(
                         f"\n Scan {self.scan_item.scan_number} finished. No monitored devices enabled, please check your config."
                     )

--- a/bec_ipython_client/tests/client_tests/test_live_table.py
+++ b/bec_ipython_client/tests/client_tests/test_live_table.py
@@ -146,7 +146,41 @@ class TestLiveTable:
             live_update._run_update(1)
             assert mock_print_table_data.called
         scan_item.num_points = 2
+        scan_item.live_data = {0: data, 1: data}
+        scan_item.status = "closed"
+        with mock.patch.object(live_update, "print_table_data") as mock_print_table_data:
+            live_update._run_update(2)
+            assert mock_print_table_data.called
+
+    @pytest.mark.timeout(20)
+    def test_run_update_without_monitored_devices(self, bec_client_mock, scan_item):
+        request_msg = messages.ScanQueueMessage(
+            scan_type="grid_scan",
+            parameter={"args": {"samx": (-5, 5, 3)}, "kwargs": {}},
+            queue="primary",
+            metadata={"RID": "something"},
+        )
+        client = bec_client_mock
+        client.start()
+        data = messages.ScanMessage(point_id=0, scan_id="", data={}, metadata={})
+        live_update = LiveUpdatesTable(client, {"scan_progress": 10}, request_msg)
+        live_update.scan_item = scan_item
+        scan_item.num_points = 2
+        scan_item.live_data = {0: data}
+        with mock.patch.object(live_update, "print_table_data") as mock_print_table_data:
+            live_update._run_update(1)
+            assert mock_print_table_data.called
+        scan_item.num_points = 2
         scan_item.live_data = {}
+        scan_item.status_message = messages.ScanStatusMessage(
+            readout_priority={"monitored": [], "baseline": ["samx"]},
+            scan_id="scan_id",
+            scan_number=1,
+            scan_type="step",
+            scan_report_devices=[],
+            status="closed",
+            info={},
+        )
         scan_item.status = "closed"
         with mock.patch.object(live_update, "print_table_data") as mock_print_table_data:
             live_update._run_update(2)


### PR DESCRIPTION
A check in the live table allowed exiting the live updates if the live data has no entries and the scan is closed. However, it falsely claimed that this was due to missing monitored devices without actually checking. 

Fast scans, such as a simple acquire, could therefore finish before ever receiving the first scan segment and thus warn the user about a wrongly configured device configuration. 

This PR fixes the issue by actively checking the readout priority. 