### PR TITLE
Improve DeviceServer device handling and logging

### DIFF
--- a/bec_server/bec_server/device_server/cli/launch.py
+++ b/bec_server/bec_server/device_server/cli/launch.py
@@ -23,7 +23,7 @@ from bec_lib.redis_connector import RedisConnector
 from bec_server.device_server.device_server import DeviceServer
 
 logger = bec_logger.logger
-bec_logger.level = bec_logger.LOGLEVEL.DEBUG
+bec_logger.level = bec_logger.LOGLEVEL.INFO
 
 
 # ---- Forward ophyd logs to bec_logger.logger ----

--- a/bec_server/bec_server/device_server/devices/devicemanager.py
+++ b/bec_server/bec_server/device_server/devices/devicemanager.py
@@ -139,6 +139,8 @@ class DeviceManagerDS(DeviceManagerBase):
                     self.initialize_device(dev, config, obj)
                 # pylint: disable=broad-except
                 except Exception:
+                    if name not in self.devices:
+                        raise
                     msg = traceback.format_exc()
                     logger.warning(f"Failed to initialize device {name}: {msg}")
                     self.failed_devices[name] = msg

--- a/bec_server/tests/tests_device_server/test_device_manager_ds.py
+++ b/bec_server/tests/tests_device_server/test_device_manager_ds.py
@@ -7,7 +7,7 @@ import pytest
 
 from bec_lib import messages
 from bec_lib.endpoints import MessageEndpoints
-from bec_server.device_server.devices.devicemanager import DeviceManagerDS
+from bec_server.device_server.devices.devicemanager import DeviceConfigError, DeviceManagerDS
 
 # pylint: disable=missing-function-docstring
 # pylint: disable=protected-access

--- a/bec_server/tests/tests_device_server/test_device_serializer.py
+++ b/bec_server/tests/tests_device_server/test_device_serializer.py
@@ -66,6 +66,13 @@ class DummyDeviceWithConflictingSubDevice(Device):
     sub_device = Cpt(DummyDeviceWithConflictingSignalNames)
 
 
+class DummyDeviceWithConflictingDuplicateSignalNames(Device):
+    """This device will be assigned a protected name"""
+
+    signal = Cpt(MyDevice, "signal", lazy=True)
+    signal_custom = Cpt(MyDevice, "custom", lazy=True)
+
+
 @pytest.mark.parametrize(
     "obj",
     [
@@ -98,3 +105,10 @@ def test_get_device_info_lazy_signal():
     _ = get_device_info(device, connect=False)
     assert device.lazy_sub_device_no_lazy.lazy_wait_for_connection is False
     assert device.lazy_sub_device.lazy_wait_for_connection is True
+
+
+def test_get_device_info_USER_ACCESS():
+    device = DummyDeviceWithConflictingDuplicateSignalNames(name="test")
+    _ = get_device_info(device, connect=False)
+    with pytest.raises(DeviceConfigError):
+        _ = get_device_info(device, connect=True)

--- a/bec_server/tests/tests_device_server/test_device_serializer.py
+++ b/bec_server/tests/tests_device_server/test_device_serializer.py
@@ -72,6 +72,11 @@ class DummyDeviceWithConflictingDuplicateSignalNames(Device):
     signal = Cpt(MyDevice, "signal", lazy=True)
     signal_custom = Cpt(MyDevice, "custom", lazy=True)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Imitate Positioner behavior with conflicting signal names
+        self.signal_custom.custom.name = self.signal_custom.name
+
 
 @pytest.mark.parametrize(
     "obj",


### PR DESCRIPTION
This PR improves 2 things:

(A)
It introduces a change for log message that will intercept any loggings from the 'ophyd' package and forwards them to the bec_logger. This will help identifying issues directly linked to ophyd where exceptions are not always properly attached to status objects, but only logged. One example for this is a failed move due to an alarm state (https://github.com/bluesky/ophyd/blob/main/ophyd/epics_motor.py#L304).

(B)
It fixes handling of the device serialization. Thereby, it checks that all signal_names are unique which is linked to issue #564. In addition, in case the device serialization fails for `connect=True` and `connect=False`, we now forward the proper error message
