### PR TITLE
feat(script executor): improve message interface for aborted scripts

### DIFF
--- a/bec_lib/bec_lib/messages.py
+++ b/bec_lib/bec_lib/messages.py
@@ -1188,11 +1188,13 @@ class ScriptExecutionInfoMessage(BECMessage):
 
     Args:
         script_id (str): Unique identifier for the script
-        status (Literal["running", "completed", "failed"]): Execution status
-        result (Any, optional): Execution result. Defaults to None.
+        status (Literal["running", "completed", "failed", "aborted"]): Execution status
+        current_lines (list[int], optional): Current line numbers being executed. Defaults to None.
+        traceback (str, optional): Traceback information. Defaults to None.
     """
 
     msg_type: ClassVar[str] = "script_execution_message"
     script_id: str
-    status: Literal["running", "completed", "failed"]
+    status: Literal["running", "completed", "failed", "aborted"]
     current_lines: list[int] | None = None
+    traceback: str | None = None

--- a/bec_lib/tests/test_script_executor.py
+++ b/bec_lib/tests/test_script_executor.py
@@ -1,11 +1,10 @@
-import sys
-from unittest import mock
+import time
 
 import pytest
 
 from bec_lib.client import BECClient
 from bec_lib.endpoints import MessageEndpoints
-from bec_lib.script_executor import ScriptExecutor, upload_script
+from bec_lib.script_executor import upload_script
 
 
 def test_upload_script(connected_connector):
@@ -31,3 +30,34 @@ def test_script_executor(connected_connector, capsys):
     assert "2" in output
 
     assert a == 1  # The script should not modify the local variable
+
+
+@pytest.mark.timeout(5)
+def test_script_executor_failure(connected_connector):
+    script_content = "print(unknown_variable)"
+    script_id = upload_script(connected_connector, script_content)
+
+    received_data = []
+
+    def update_received_data(msg):
+        msg = msg.value
+        if msg.status == "failed":
+            received_data.append(msg)
+
+    client = BECClient()
+    client.connector = connected_connector
+    client.connector.register(
+        MessageEndpoints.script_execution_info(script_id), cb=update_received_data
+    )
+
+    try:
+        client._run_script(script_id)
+    except Exception as e:
+        pass
+
+    while not received_data:
+        time.sleep(0.1)
+
+    assert received_data[0].status == "failed"
+    assert "NameError" in received_data[0].traceback
+    assert "exec" not in received_data[0].traceback


### PR DESCRIPTION
This PR includes minor improvements to the script executor:

* Add default ttl for scripts. Previously, scripts were automatically cleaned up after execution but for development it is better to clean up after some time. 
* Add traceback info to `ScriptExecutionInfoMessage`. This will allows us to send error messages to the IDE. The traceback frames are trimmed to the actual execution. 
* Add "aborted" exit status and fix KeyboardInterrupt handling