### PR TITLE
fix: ensure container image exists before e2e tests

### DIFF
--- a/.github/actions/bec_e2e_install/action.yml
+++ b/.github/actions/bec_e2e_install/action.yml
@@ -63,5 +63,6 @@ runs:
         source ./bin/install_bec_dev.sh -t
         pip install -e ../ophyd_devices
         podman pod create --net host local_bec
+        python ./bec_ipython_client/tests/end-2-end/_ensure_requirements_container.py
         pytest -v --files-path ./ --start-servers --random-order  ./bec_ipython_client/tests/end-2-end/
         

--- a/bec_ipython_client/tests/end-2-end/_ensure_requirements_container.py
+++ b/bec_ipython_client/tests/end-2-end/_ensure_requirements_container.py
@@ -1,0 +1,21 @@
+from time import sleep
+
+from bec_server.scan_server.procedures.constants import PROCEDURE, ProcedureWorkerError
+from bec_server.scan_server.procedures.container_utils import PodmanCliUtils
+
+image_name = (
+    f"ghcr.io/bec-project/{PROCEDURE.CONTAINER.REQUIREMENTS_IMAGE_NAME}:v{PROCEDURE.BEC_VERSION}"
+)
+podman = PodmanCliUtils()
+
+for i in range(1, 4):
+    try:
+        output = podman._run_and_capture_error("podman", "pull", image_name)
+        print("successfully pulled requirements image for current version")
+        exit(0)
+    except ProcedureWorkerError as e:
+        print(e)
+        print("retrying in 2 minutes...")
+        sleep(120)
+print(f"No more retries. Check if {image_name} actually exists!")
+exit(1)

--- a/bec_server/bec_server/scan_server/procedures/container_utils.py
+++ b/bec_server/bec_server/scan_server/procedures/container_utils.py
@@ -155,7 +155,12 @@ class PodmanCliUtils(_PodmanUtilsBase):
         logger.debug(f"Running {args}")
         output = subprocess.run([*args], capture_output=True)
         if output.returncode != 0:
-            raise ProcedureWorkerError(f"Container failed to build with error {output.stderr}")
+            raise ProcedureWorkerError(
+                "Container shell command: \n"
+                f"    {args}"
+                "\n failed with output:"
+                f"{output.stderr}"
+            )
         return output
 
     def _podman_ls_json(self, subcom: Literal["image", "container"] = "container"):


### PR DESCRIPTION
retry pulling the image a couple of times, in case it hasn't made it to the registry by the time the e2e tests run