### PR TITLE
feat: change account to redis stream

### DIFF
--- a/bec_ipython_client/bec_ipython_client/main.py
+++ b/bec_ipython_client/bec_ipython_client/main.py
@@ -220,9 +220,14 @@ class BECClientPrompt(Prompts):
             next_scan_number = str(self.client.queue.next_scan_number)
         except Exception:
             next_scan_number = "?"
+
+        if self.client.active_account:
+            username = f"{self.client.active_account} | {self.username}"
+        else:
+            username = self.username
         return [
             (status_led, "\u2022"),
-            (Token.Prompt, " " + self.username),
+            (Token.Prompt, " " + username),  # BEC ACL username and pgroup
             (Token.Prompt, "@" + self.session_name),
             (Token.Prompt, " ["),
             (Token.PromptNum, str(self.shell.execution_count)),

--- a/bec_ipython_client/tests/client_tests/test_bec_client.py
+++ b/bec_ipython_client/tests/client_tests/test_bec_client.py
@@ -204,7 +204,7 @@ def test_bec_ipython_client_property_access(ipython_client):
                 client.start()
 
                 with mock.patch.object(client._client, "connector") as mock_connector:
-                    mock_connector.get.return_value = messages.VariableMessage(value="account")
+                    mock_connector.get_last.return_value = messages.VariableMessage(value="account")
                     assert client._client.active_account == "account"
 
                     with pytest.raises(AttributeError):

--- a/bec_lib/bec_lib/client.py
+++ b/bec_lib/bec_lib/client.py
@@ -173,7 +173,7 @@ class BECClient(BECService):
     @property
     def active_account(self) -> str:
         """get the currently active target (e)account"""
-        msg = self.connector.get(MessageEndpoints.account())
+        msg = self.connector.get_last(MessageEndpoints.account(), "data")
         if msg:
             return msg.value
         return ""

--- a/bec_lib/bec_lib/endpoints.py
+++ b/bec_lib/bec_lib/endpoints.py
@@ -1231,7 +1231,7 @@ class MessageEndpoints:
         """
         endpoint = f"{EndpointType.INFO.value}/account"
         return EndpointInfo(
-            endpoint=endpoint, message_type=messages.VariableMessage, message_op=MessageOp.KEY_VALUE
+            endpoint=endpoint, message_type=messages.VariableMessage, message_op=MessageOp.STREAM
         )
 
     # data processing

--- a/bec_lib/bec_lib/logbook_connector.py
+++ b/bec_lib/bec_lib/logbook_connector.py
@@ -41,7 +41,7 @@ class LogbookConnector:
             return
         scilog_creds = msg.credentials
 
-        account_msg = self.connector.get(MessageEndpoints.account())
+        account_msg = self.connector.get_last(MessageEndpoints.account(), "data")
         if not account_msg:
             return
         account = account_msg.value

--- a/bec_lib/bec_lib/scan_number_container.py
+++ b/bec_lib/bec_lib/scan_number_container.py
@@ -20,7 +20,7 @@ class ScanNumberContainer:
 
     def _current_account(self) -> str:
         """Get the current account from the redis connector."""
-        account = self.connector.get(MessageEndpoints.account())
+        account = self.connector.get_last(MessageEndpoints.account(), "data")
         if account is None:
             return ""
         return account.value if isinstance(account.value, str) else ""

--- a/bec_lib/bec_lib/tests/utils.py
+++ b/bec_lib/bec_lib/tests/utils.py
@@ -815,3 +815,6 @@ class ConnectorMock(RedisConnector):  # pragma: no cover
 
     def redis_server_is_running(self):
         return True
+
+    def get_last(self, topic, key):
+        return None

--- a/bec_server/bec_server/scan_server/scan_worker.py
+++ b/bec_server/bec_server/scan_server/scan_worker.py
@@ -259,7 +259,7 @@ class ScanWorker(threading.Thread):
         The account name is retrieved from the current account message.
         If the account name is not found, an empty string will be used.
         """
-        current_account_msg = self.connector.get(MessageEndpoints.account())
+        current_account_msg = self.connector.get_last(MessageEndpoints.account(), "data")
         if current_account_msg:
             current_account = current_account_msg.value
             if not isinstance(current_account, str):

--- a/bec_server/tests/tests_scan_server/test_scan_worker.py
+++ b/bec_server/tests/tests_scan_server/test_scan_worker.py
@@ -761,14 +761,16 @@ def test_worker_get_file_base_path(
     file_writer_base_path_orig = worker.parent._service_config.config["file_writer"]["base_path"]
     try:
         worker.parent._service_config.config["file_writer"]["base_path"] = base_path
-        with mock.patch.object(worker.connector, "get", return_value=current_account_msg):
+        with mock.patch.object(worker.connector, "get_last", return_value=current_account_msg):
             if raises_error:
                 with pytest.raises(ValueError) as exc_info:
                     worker._get_file_base_path()
             else:
                 file_path = worker._get_file_base_path()
                 assert file_path == expected_path
-                worker.connector.get.assert_called_once_with(MessageEndpoints.account())
+                worker.connector.get_last.assert_called_once_with(
+                    MessageEndpoints.account(), "data"
+                )
     finally:
         worker.parent._service_config.config["file_writer"][
             "base_path"

--- a/bin/bec_set_account/main.go
+++ b/bin/bec_set_account/main.go
@@ -14,19 +14,74 @@ import (
 )
 
 type BECCodecWrapper struct {
-    BecCodec BecCodecData `msgpack:"__bec_codec__" json:"__bec_codec__"`
+	BecCodec BecCodecData `msgpack:"__bec_codec__" json:"__bec_codec__"`
 }
 
 type BecCodecData struct {
-    EncoderName string                 `msgpack:"encoder_name" json:"encoder_name"`
-    TypeName    string                 `msgpack:"type_name" json:"type_name"`
-    Data        VariableMessagePayload `msgpack:"data" json:"data"`
+	EncoderName string                 `msgpack:"encoder_name" json:"encoder_name"`
+	TypeName    string                 `msgpack:"type_name" json:"type_name"`
+	Data        VariableMessagePayload `msgpack:"data" json:"data"`
 }
 
 type VariableMessagePayload struct {
-    MsgType  string            `msgpack:"msg_type" json:"msg_type"`
-    Value    interface{}       `msgpack:"value" json:"value"`
-    Metadata map[string]string `msgpack:"metadata" json:"metadata"`
+	MsgType  string            `msgpack:"msg_type" json:"msg_type"`
+	Value    interface{}       `msgpack:"value" json:"value"`
+	Metadata map[string]string `msgpack:"metadata" json:"metadata"`
+}
+
+func handleExistingData(data []byte, force bool) bool {
+	var decoded BECCodecWrapper
+	if err := msgpack.Unmarshal(data, &decoded); err != nil {
+		fmt.Printf("Warning: Failed to decode existing message: %v\n", err)
+		return true
+	}
+
+	// Show current account
+	fmt.Printf("Current active account: %v\n", decoded.BecCodec.Data.Value)
+	for k, v := range decoded.BecCodec.Data.Metadata {
+		fmt.Printf("%s: %s\n", k, v)
+	}
+
+	if force {
+		return true
+	}
+
+	// Ask for confirmation
+	var input string
+	fmt.Print("Are you sure you want to overwrite it? [y/N]: ")
+	fmt.Scanln(&input)
+	if input != "y" && input != "Y" {
+		fmt.Println("Aborted, old account", decoded.BecCodec.Data.Value, "remains active.")
+		return false
+	}
+
+	return true
+}
+
+func checkExistingAccount(rdb *redis.Client, ctx context.Context, key string, force bool) bool {
+	// Check for existing stream data
+	existing, err := rdb.XRange(ctx, key, "-", "+").Result()
+
+	// Handle actual errors (not just "key not found")
+	if err != nil && err != redis.Nil {
+		fmt.Printf("Failed to check existing account: %v\n", err)
+		panic(fmt.Sprintf("Redis access failed: %v", err))
+	}
+
+	// No existing stream data, proceed
+	if err == redis.Nil || len(existing) == 0 {
+		return true
+	}
+
+	// Extract and handle stream data - XRange returns []redis.XMessage directly
+	msgData := existing[0].Values["data"]
+	msgBytes, ok := msgData.(string)
+	if !ok {
+		fmt.Println("Warning: Unexpected data format in existing stream message")
+		return true
+	}
+
+	return handleExistingData([]byte(msgBytes), force)
 }
 
 func main() {
@@ -50,55 +105,38 @@ func main() {
 	rdb := redis.NewClient(&redis.Options{
 		Addr: *redisHost + ":6379",
 	})
+
+	// Test the connection
+	_, err := rdb.Ping(ctx).Result()
+	if err != nil {
+		fmt.Printf("Failed to connect to Redis: %v\n", err)
+		os.Exit(1)
+	}
+
 	key := "info/account"
 
-	// Check existing account
-	existing, err := rdb.Get(ctx, key).Bytes()
-	if err == nil {
-		var decoded BECCodecWrapper
-		if err := msgpack.Unmarshal(existing, &decoded); err != nil {
-			fmt.Println("Warning: Failed to decode existing message:", err)
-		} else {
-			fmt.Println("Current active account", decoded.BecCodec.Data.Value)
-			for k, v := range decoded.BecCodec.Data.Metadata {
-				fmt.Printf("%s: %s\n", k, v)
-		}
-		
-		if !*force {
-			var input string
-			fmt.Print("Are you sure you want to overwrite it? [y/N]: ")
-			fmt.Scanln(&input)
-			if input != "y" && input != "Y" {
-				fmt.Println("Aborted, old account", decoded.BecCodec.Data.Value, "remains active.")
-				os.Exit(0)
-			}
-		}
+	// Check existing account and get user confirmation if needed
+	if !checkExistingAccount(rdb, ctx, key, *force) {
+		os.Exit(0)
 	}
-	} else if err != redis.Nil {
-		// An actual error (not just "key not found")
-		fmt.Println("Failed to set account")
-		panic(err)
-	}
-
-
 
 	// Prepare message
 	currentUser, _ := user.Current()
 	now := time.Now().Format(time.RFC3339)
 
 	msg := BECCodecWrapper{
-        BecCodec: BecCodecData{
-            EncoderName: "BECMessage",
-            TypeName:    "VariableMessage",
-            Data: VariableMessagePayload{
-                MsgType: "var_message",
-                Value:   *pgroup,
-                Metadata: map[string]string{
-                    "timestamp": now,
-			"user":      currentUser.Username,
-                },
-            },
-        },
+		BecCodec: BecCodecData{
+			EncoderName: "BECMessage",
+			TypeName:    "VariableMessage",
+			Data: VariableMessagePayload{
+				MsgType: "var_message",
+				Value:   *pgroup,
+				Metadata: map[string]string{
+					"timestamp": now,
+					"user":      currentUser.Username,
+				},
+			},
+		},
 	}
 	// Encode as msgpack
 	packed, err := msgpack.Marshal(msg)
@@ -107,10 +145,13 @@ func main() {
 		panic(err)
 	}
 
-	
-
 	// Set key
-	if err := rdb.Set(ctx, key, packed, 0).Err(); err != nil {
+	if err := rdb.XAdd(ctx, &redis.XAddArgs{
+		Stream: key,
+		Values: map[string]interface{}{"data": packed},
+		MaxLen: 1,     // Keep only the latest entry
+		Approx: false, // Exact trimming
+	}).Err(); err != nil {
 		fmt.Println("Failed to set account")
 		panic(err)
 	}


### PR DESCRIPTION
Changing the account endpoint to a stream to better support subscriptions and ACL separation. We will upgrade the beamlines that already use it manually (only 2). 