### PR TITLE
fix(devicemanager): add support for nested resolution of auto monitors

### DIFF
--- a/bec_server/bec_server/device_server/devices/devicemanager.py
+++ b/bec_server/bec_server/device_server/devices/devicemanager.py
@@ -418,6 +418,9 @@ class DeviceManagerDS(DeviceManagerBase):
 
         for component_name in obj.component_names:
             component = getattr(obj, component_name)
+            if hasattr(component, "component_names"):
+                self._subscribe_to_auto_monitors(component)
+                continue
             if not getattr(component, "_auto_monitor", False):
                 continue
             if component.kind in (ophyd.Kind.normal, ophyd.Kind.hinted):


### PR DESCRIPTION
Nested components, such as the ones created through dynamic components may need an auto monitor. However, so far the subscription only took the top-level item into account. 