### PR TITLE
Fix make_all_fields_optional

### DIFF
--- a/bec_lib/bec_lib/atlas_models.py
+++ b/bec_lib/bec_lib/atlas_models.py
@@ -23,7 +23,11 @@ def make_all_fields_optional(model: type[_BM], model_name: str) -> type[_BM]:
     for name, field in model.model_fields.items():
         field_info = field._attributes_set
         field_info.pop("annotation", None)
-        field_info["default"] = field.default if field.default is not PydanticUndefined else None
+        if "default_factory" not in field_info:
+            # default_factory and default are mutually exclusive
+            field_info["default"] = (
+                field.default if field.default is not PydanticUndefined else None
+            )
         fields[name] = (field.annotation | None, Field(**field_info))
     new_model = create_model(model_name, **fields, __config__=model.model_config)
     return new_model


### PR DESCRIPTION
specifying the default_factory is mutually exclusive to the default field. The make_all_fields_optional utility function did not respect it though. This PR fixes it. 