### PR TITLE
Feature/atlas account update

### DIFF
--- a/bec_lib/bec_lib/endpoints.py
+++ b/bec_lib/bec_lib/endpoints.py
@@ -1632,3 +1632,30 @@ class MessageEndpoints:
         return EndpointInfo(
             endpoint=endpoint, message_type=messages.VariableMessage, message_op=MessageOp.KEY_VALUE
         )
+
+    @staticmethod
+    def atlas_websocket_state(deployment_name: str, host_id: str):
+        """
+        Endpoint for the websocket state information, containing the users and their subscriptions
+        per backend host.
+
+        Returns:
+            EndpointInfo: Endpoint for websocket state.
+        """
+        endpoint = f"{EndpointType.INTERNAL.value}/deployment/{deployment_name}/{host_id}/state"
+        return EndpointInfo(
+            endpoint=endpoint, message_type=messages.RawMessage, message_op=MessageOp.SET_PUBLISH
+        )
+
+    @staticmethod
+    def atlas_deployment_request(deployment_name: str):
+        """
+        Endpoint for receiving requests for a particular deployment to perform redis operations.
+
+        Returns:
+            EndpointInfo: Endpoint for deployment request.
+        """
+        endpoint = f"{EndpointType.INTERNAL.value}/deployment/{deployment_name}/request"
+        return EndpointInfo(
+            endpoint=endpoint, message_type=messages.RawMessage, message_op=MessageOp.SET_PUBLISH
+        )

--- a/bec_lib/bec_lib/redis_connector.py
+++ b/bec_lib/bec_lib/redis_connector.py
@@ -500,7 +500,7 @@ class RedisConnector:
     def register(
         self,
         topics: str | list[str] | EndpointInfo | list[EndpointInfo] | None = None,
-        patterns: str | list[str] | None = None,
+        patterns: str | list[str] | EndpointInfo | list[EndpointInfo] | None = None,
         cb: Callable | None = None,
         start_thread: bool = True,
         from_start: bool = False,
@@ -512,7 +512,7 @@ class RedisConnector:
 
         Args:
             topics (str, list, EndpointInfo, list[EndpointInfo], optional): topic or list of topics. Defaults to None. The topic should be a valid message endpoint in BEC and can be a string or an EndpointInfo object.
-            patterns (str, list, optional): pattern or list of patterns. Defaults to None. In contrast to topics, patterns may contain "*" wildcards. The evaluated patterns should be a valid pub/sub message endpoint in BEC
+            patterns (str, list, EndpointInfo, list[EndpointInfo], optional): pattern or list of patterns. Defaults to None. In contrast to topics, patterns may contain "*" wildcards. The evaluated patterns should be a valid pub/sub message endpoint in BEC
             cb (callable, optional): callback. Defaults to None.
             start_thread (bool, optional): start the dispatcher thread. Defaults to True.
             from_start (bool, optional): for streams only: return data from start on first reading. Defaults to False.

--- a/bec_server/tests/tests_scihub/test_atlas_forwarder.py
+++ b/bec_server/tests/tests_scihub/test_atlas_forwarder.py
@@ -13,6 +13,7 @@ def forwarder(atlas_connector):
 
 def test_atlas_forwarder_registers_state_and_request(forwarder):
     assert list(forwarder.atlas_connector.redis_atlas._topics_cb) == [
+        "internal/deployment/test-deployment/deployment_info",
         "internal/deployment/test-deployment/*/state",
         "internal/deployment/test-deployment/request",
     ]

--- a/bec_server/tests/tests_scihub/test_atlas_metadata_handler.py
+++ b/bec_server/tests/tests_scihub/test_atlas_metadata_handler.py
@@ -25,9 +25,80 @@ def test_atlas_metadata_handler(atlas_connector):
         mock_ingest_data.assert_called_once_with({"scan_status": msg})
 
     with mock.patch.object(
-        atlas_connector.metadata_handler, "update_scan_status", side_effect=ValueError
+        atlas_connector.metadata_handler, "send_atlas_update", side_effect=ValueError
     ):
         atlas_connector.metadata_handler._handle_scan_status(
             msg_obj, parent=atlas_connector.metadata_handler
         )
         assert True
+
+
+def test_handle_atlas_account_update_valid(atlas_connector):
+    msg = {"data": messages.VariableMessage(value="account1")}
+    with mock.patch.object(
+        atlas_connector.metadata_handler, "_update_local_account"
+    ) as mock_update_local_account:
+        atlas_connector.metadata_handler._handle_atlas_account_update(
+            msg, parent=atlas_connector.metadata_handler
+        )
+        mock_update_local_account.assert_called_once_with("account1")
+
+
+def test_handle_atlas_account_update_invalid(atlas_connector):
+    msg = {"invalid": "data"}
+    with mock.patch("bec_lib.logger.bec_logger.logger.error") as mock_logger_error:
+        atlas_connector.metadata_handler._handle_atlas_account_update(
+            msg, parent=atlas_connector.metadata_handler
+        )
+        mock_logger_error.assert_called()
+
+
+def test_handle_account_info_valid(atlas_connector):
+    msg = {"data": messages.VariableMessage(value="account2")}
+    with mock.patch.object(
+        atlas_connector.metadata_handler, "send_atlas_update"
+    ) as mock_send_update:
+        atlas_connector.metadata_handler._handle_account_info(
+            msg, parent=atlas_connector.metadata_handler
+        )
+        mock_send_update.assert_called_once()
+
+
+def test_handle_account_info_invalid(atlas_connector):
+    msg = {"invalid": "data"}
+    with mock.patch("bec_lib.logger.bec_logger.logger.error") as mock_logger_error:
+        atlas_connector.metadata_handler._handle_account_info(
+            msg, parent=atlas_connector.metadata_handler
+        )
+        mock_logger_error.assert_called()
+
+
+def test_handle_scan_history(atlas_connector):
+    msg = {"data": {"history": "test"}}
+    with mock.patch.object(
+        atlas_connector.metadata_handler, "send_atlas_update"
+    ) as mock_send_update:
+        atlas_connector.metadata_handler._handle_scan_history(
+            msg, parent=atlas_connector.metadata_handler
+        )
+        mock_send_update.assert_called_once_with({"scan_history": {"history": "test"}})
+
+
+def test_update_local_account(atlas_connector):
+    handler = atlas_connector.metadata_handler
+    handler._account = "old_account"
+    with mock.patch.object(handler.atlas_connector.connector, "xadd") as mock_xadd:
+        handler._update_local_account("new_account")
+
+        expected_msg = messages.VariableMessage(value="new_account")
+        assert any(
+            c.args[1] == {"data": expected_msg} and c.kwargs.get("max_size", 1) == 1
+            for c in mock_xadd.call_args_list
+        )
+
+
+def test_send_atlas_update(atlas_connector):
+    handler = atlas_connector.metadata_handler
+    with mock.patch.object(handler.atlas_connector, "ingest_data") as mock_ingest_data:
+        handler.send_atlas_update({"key": "value"})
+        mock_ingest_data.assert_called_once_with({"key": "value"})


### PR DESCRIPTION
This PR is an incremental step towards a deeper integration with BEC Atlas. While it doesn't fetch account information from atlas, with this PR it forwards the change of an active account. Moreover, it forwards the bec history message to the ingestor, such that the database can be extended to store additional information that is otherwise not present by simply ingesting the scan status message. An example would be the NeXuS file name. 