### PR TITLE
fix(device): update default cached behavior for read methods to False

### DIFF
--- a/bec_ipython_client/tests/end-2-end/test_scans_lib_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_scans_lib_e2e.py
@@ -108,12 +108,10 @@ def test_config_updates(bec_client_lib):
     assert dev.rt_controller.limits == [-50, 50]
 
     dev.rt_controller.velocity.set(10).wait()
+    assert dev.rt_controller.velocity.read(cached=True)["rt_controller_velocity"]["value"] == 10
     assert dev.rt_controller.velocity.read()["rt_controller_velocity"]["value"] == 10
-    assert dev.rt_controller.velocity.read(cached=False)["rt_controller_velocity"]["value"] == 10
     assert dev.rt_controller.read_configuration()["rt_controller_velocity"]["value"] == 10
-    assert (
-        dev.rt_controller.read_configuration(cached=False)["rt_controller_velocity"]["value"] == 10
-    )
+    assert dev.rt_controller.read_configuration()["rt_controller_velocity"]["value"] == 10
 
     dev.rt_controller.velocity.put(5)
     assert dev.rt_controller.velocity.get() == 5
@@ -454,7 +452,7 @@ def test_computed_signal(bec_client_lib):
     dev.pseudo_signal1.set_compute_method(compute_signal1)
     dev.pseudo_signal1.set_input_signals()
 
-    assert dev.pseudo_signal1.read(cached=False)["pseudo_signal1"]["value"] == 5
+    assert dev.pseudo_signal1.read()["pseudo_signal1"]["value"] == 5
 
 
 def test_cached_device_readout(bec_client_lib):
@@ -476,13 +474,13 @@ def test_cached_device_readout(bec_client_lib):
 
     dev.samx.velocity.put(orig_velocity)
 
-    data = dev.hexapod.x.readback.read(cached=False)
+    data = dev.hexapod.x.readback.read()
     timestamp = data["hexapod_x"]["timestamp"]
     data = dev.hexapod.x.readback.read(cached=True)
     assert data["hexapod_x"]["timestamp"] == timestamp
 
     # check that .get also updates the cache
-    dev.hexapod.x.readback.get(cached=False)
+    dev.hexapod.x.readback.get()
     timestamp_2 = dev.hexapod.x.readback.read(cached=True)["hexapod_x"]["timestamp"]
     assert timestamp_2 != timestamp
 

--- a/bec_lib/bec_lib/device.py
+++ b/bec_lib/bec_lib/device.py
@@ -705,13 +705,13 @@ class OphydInterfaceBase(DeviceBaseWithConfig):
         """
 
     def read(
-        self, cached=True, use_readback=True, filter_to_hints=False
+        self, cached=False, use_readback=True, filter_to_hints=False
     ) -> dict[str, dict[str, Any]] | None:
         """
         Reads the device.
 
         Args:
-            cached (bool, optional): If True, the cached value is returned. Defaults to True.
+            cached (bool, optional): If True, the cached value is returned. Defaults to False.
             use_readback (bool, optional): If True, the readback value is returned, otherwise the read value. Defaults to True.
             filter_to_hints (bool, optional): If True, the readback value is filtered to the hinted values. Defaults to False.
 
@@ -739,12 +739,12 @@ class OphydInterfaceBase(DeviceBaseWithConfig):
             signals = {key: val for key, val in signals.items() if key in self._hints}
         return self._filter_rpc_signals(signals)
 
-    def read_configuration(self, cached=True) -> dict[str, dict[str, Any]] | None:
+    def read_configuration(self, cached=False) -> dict[str, dict[str, Any]] | None:
         """
         Reads the device configuration.
 
         Args:
-            cached (bool, optional): If True, the cached value is returned. Defaults to True.
+            cached (bool, optional): If True, the cached value is returned. Defaults to False.
         """
 
         is_signal, is_config_signal, cached = self._get_rpc_signal_info(cached)
@@ -793,9 +793,12 @@ class OphydInterfaceBase(DeviceBaseWithConfig):
         """Describes the device configuration."""
         return self._info.get("describe_configuration", {})
 
-    def get(self, cached=True):
+    def get(self, cached=False) -> Any:
         """
         Gets the device value.
+
+        Args:
+            cached (bool, optional): If True, the cached value is returned. Defaults to False
         """
 
         is_signal = self._signal_info is not None
@@ -806,7 +809,7 @@ class OphydInterfaceBase(DeviceBaseWithConfig):
                 return par(**res.get("values"))
             return res
 
-        ret = self.read()
+        ret = self.read(cached=cached)
         if ret is None:
             return None
         return ret.get(self._signal_info.get("obj_name"), {}).get("value")

--- a/bec_lib/tests/test_devices.py
+++ b/bec_lib/tests/test_devices.py
@@ -49,7 +49,7 @@ def test_read(dev: Any):
             },
             metadata={"scan_id": "scan_id", "scan_type": "scan_type"},
         )
-        res = dev.samx.read()
+        res = dev.samx.read(cached=True)
         mock_get.assert_called_once_with(MessageEndpoints.device_readback("samx"))
         assert res == {
             "samx": {"value": 0, "timestamp": 1701105880.1711318},
@@ -68,7 +68,7 @@ def test_read_filtered_hints(dev: Any):
             },
             metadata={"scan_id": "scan_id", "scan_type": "scan_type"},
         )
-        res = dev.samx.read(filter_to_hints=True)
+        res = dev.samx.read(cached=True, filter_to_hints=True)
         mock_get.assert_called_once_with(MessageEndpoints.device_readback("samx"))
         assert res == {"samx": {"value": 0, "timestamp": 1701105880.1711318}}
 
@@ -83,7 +83,7 @@ def test_read_use_read(dev: Any):
         mock_get.return_value = messages.DeviceMessage(
             signals=data, metadata={"scan_id": "scan_id", "scan_type": "scan_type"}
         )
-        res = dev.samx.read(use_readback=False)
+        res = dev.samx.read(cached=True, use_readback=False)
         mock_get.assert_called_once_with(MessageEndpoints.device_read("samx"))
         assert res == data
 
@@ -100,7 +100,7 @@ def test_read_nested_device(dev: Any):
         mock_get.return_value = messages.DeviceMessage(
             signals=data, metadata={"scan_id": "scan_id", "scan_type": "scan_type"}
         )
-        res = dev.dyn_signals.messages.read()
+        res = dev.dyn_signals.messages.read(cached=True)
         mock_get.assert_called_once_with(MessageEndpoints.device_readback("dyn_signals"))
         assert res == data
 

--- a/docs/source/user/command_line_interface.md
+++ b/docs/source/user/command_line_interface.md
@@ -113,8 +113,8 @@ In both cases, a nested dictionary is returned with value/timestamp pairs for ea
 The current position of `samx` is accessed `dev.samx.read()['samx']['value']`.
 
 ```{note}
-The default behaviour for `.read` and `.read_configuration` is to read the last recorded value from redis, i.e. `cached=True`.
-However, we can force an update by using `dev.samx.read(cached=False)` which will introduce additional overhead. 
+The default behaviour of `.read` and `.read_configuration` is to read the last recorded value directly from the device, i.e. `cached=False`.
+However, depending on the device and the underlying hardware, frequent polling may be detrimental or even put the device in an unresponsive state. For this reason, cached can be set to `True` to read the last recorded value from redis. Especially for devices that have EPICS auto-monitor enabled, this is much faster and more efficient without missing any updates.
 Signals of type `omitted` are currently not stored in redis, nor are they read from the device using e.g.`dev.samx.read()` and therefore must
 be read out directly using e.g. `dev.samx.my_omitted_signal.read()`.
 ```


### PR DESCRIPTION
Now that read operations can bypass the queue, we can set the default to cached=False. 


https://github.com/bec-project/bec_widgets/pull/869 needs to be merged first