### PR TITLE
fix: pydantic pin

### DIFF
--- a/bec_lib/pyproject.toml
+++ b/bec_lib/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "msgpack~=1.0, >1.0.4",
     "numpy>=1.24, <3.0",
     "psutil~=5.9",
-    "pydantic~=2.8, !=2.12.0",
+    "pydantic~=2.8, <2.12.0",
     "pylint~=3.0",
     "pyyaml~=6.0",
     "redis~=6.2,>=6.2.0",


### PR DESCRIPTION
fix pydantic pin to `<2.12` because the newest release hasn't fixed all issues yet