### PR TITLE
fix: increase timeout for requirements image to exist

### DIFF
--- a/bec_ipython_client/tests/end-2-end/_ensure_requirements_container.py
+++ b/bec_ipython_client/tests/end-2-end/_ensure_requirements_container.py
@@ -8,14 +8,14 @@ image_name = (
 )
 podman = PodmanCliUtils()
 
-for i in range(1, 4):
+for i in range(1, 6):
     try:
         output = podman._run_and_capture_error("podman", "pull", image_name)
         print("successfully pulled requirements image for current version")
         exit(0)
     except ProcedureWorkerError as e:
         print(e)
-        print("retrying in 2 minutes...")
-        sleep(120)
+        print("retrying in 5 minutes...")
+        sleep(5 * 60)
 print(f"No more retries. Check if {image_name} actually exists!")
 exit(1)


### PR DESCRIPTION
increases the timeout to 30 minutes (5 minutes * 6 tries) for the requirements container to be in the registry since the build can take 15 minutes.

this should only be important for the first half an hour after a new release, otherwise it should have no effect