### PR TITLE
perf: split container build into linux base and reqs

### DIFF
--- a/.github/workflows/update_base_image.yml
+++ b/.github/workflows/update_base_image.yml
@@ -1,0 +1,40 @@
+name: Update base linux container image
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * 0" # Weekly on Sunday morning
+
+jobs:
+  update_base_image:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+    
+      - name: Setup tools
+        run: sudo apt update && sudo apt install qemu-user-static
+
+      - name: Buildah build
+        id: container-build
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: bec_linux_base
+          tags: ${{ github.sha }} latest
+          containerfiles: |
+            ./bec_server/bec_server/scan_server/procedures/Containerfile.bec_linux_base
+          archs: amd64, aarch64
+
+      - name: Push to registry
+        id: container-push
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.container-build.outputs.image }}
+          tags: ${{ steps.container-build.outputs.tags }}
+          registry: ghcr.io/bec-project
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}

--- a/bec_server/bec_server/scan_server/procedures/Containerfile.bec_linux_base
+++ b/bec_server/bec_server/scan_server/procedures/Containerfile.bec_linux_base
@@ -1,0 +1,16 @@
+FROM python:3.11-slim AS bec_linux_base
+
+# This image should be built and pushed to the container repo on release
+# The result is used in Containerfile.worker to create the local worker image 
+# for any given deployment
+
+# Set working directory - BEC deployment should be mounted here
+WORKDIR /bec
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    tmux \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --upgrade pip wheel
+RUN pip install uv

--- a/bec_server/bec_server/scan_server/procedures/Containerfile.requirements
+++ b/bec_server/bec_server/scan_server/procedures/Containerfile.requirements
@@ -1,21 +1,6 @@
-# Base image
-FROM python:3.11-slim AS base
-
-# This image should be built and pushed to the container repo on release
-# The result is used in Containerfile.worker to create the local worker image 
-# for any given deployment
-
-# Set working directory - BEC deployment should be mounted here
-WORKDIR /bec
-
-FROM base AS bec_requirements
+FROM ghcr.io/bec-project/bec_linux_base AS bec_requirements
 # Install dependencies - BEC release workflow should build this stage and deploy
 # it to the internal container registry
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    tmux \
-    && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --upgrade pip wheel
 RUN pip install uv


### PR DESCRIPTION
The installation of the base linux dependencies for both `arm64` and `aarch64` takes almost 10 minutes, but should not be necessary for every build. This splits this part out of the release workflow and into a weekly workflow which runs on Sunday morning and can also be manually triggered, creating a new package `bec_linux_base` to start the requirements image build from.