### PR TITLE
kwarg for timeout and "force" connection test

### DIFF
--- a/bec_server/bec_server/device_server/devices/devicemanager.py
+++ b/bec_server/bec_server/device_server/devices/devicemanager.py
@@ -466,19 +466,37 @@ class DeviceManagerDS(DeviceManagerBase):
         obj.initialized = False
 
     @staticmethod
-    def connect_device(obj, wait_for_all=False):
-        """establish a connection to a device"""
+    def connect_device(
+        obj: ophyd.OphydObject, wait_for_all: bool = False, timeout: float = 30, force: bool = False
+    ):
+        """
+        Establish a connection to a device.
+
+        Args:
+            obj (OphydObject): The device object to connect to.
+            wait_for_all (bool): Whether to wait for all signals to connect.
+                                 Default is False
+            timeout (float): Timeout in seconds for the connection attempt to all signals.
+                             Default is 30 seconds.
+            force (bool): If True, forces reconnection even if already connected.
+                          Relevant for devices inheriting from ADBase as they are always connected.
+                          Default is False.
+
+        Raises:
+            ConnectionError: If the connection could not be established.
+        """
+
         try:
-            if obj.connected:
+            if not force and obj.connected:
                 return
             if hasattr(obj, "controller"):
                 obj.controller.on()
                 return
             if hasattr(obj, "wait_for_connection"):
                 try:
-                    obj.wait_for_connection(all_signals=wait_for_all, timeout=30)
+                    obj.wait_for_connection(all_signals=wait_for_all, timeout=timeout)
                 except TypeError:
-                    obj.wait_for_connection(timeout=30)
+                    obj.wait_for_connection(timeout=timeout)
                 return
             logger.error(
                 f"Device {obj.name} does not implement the socket controller interface nor"

--- a/bec_server/tests/tests_device_server/test_device_manager_ds.py
+++ b/bec_server/tests/tests_device_server/test_device_manager_ds.py
@@ -95,6 +95,25 @@ def test_connect_device(dm_with_devices, obj, raises_error):
 
 
 @pytest.mark.parametrize("device_manager_class", [DeviceManagerDS])
+def test_connect_device_with_kwargs(dm_with_devices):
+    """Test connect with timeout, wait_for_all and force"""
+    device_manager = dm_with_devices
+    obj = EpicsDeviceMock()
+
+    with mock.patch.object(obj, "wait_for_connection") as mock_wait_for_connection:
+        device_manager.connect_device(obj, wait_for_all=True)
+        mock_wait_for_connection.assert_called_once_with(all_signals=True, timeout=30)
+        mock_wait_for_connection.reset_mock()
+        assert obj.connected is False
+        obj._connected = True
+        device_manager.connect_device(obj, wait_for_all=True, timeout=10, force=False)
+        mock_wait_for_connection.assert_not_called()
+        assert obj.connected is True
+        device_manager.connect_device(obj, wait_for_all=True, timeout=10, force=True)
+        mock_wait_for_connection.assert_called_once_with(all_signals=True, timeout=10)
+
+
+@pytest.mark.parametrize("device_manager_class", [DeviceManagerDS])
 def test_disable_unreachable_devices(device_manager, session_from_test_config):
     def get_config_from_mock():
         device_manager._session = copy.deepcopy(session_from_test_config)


### PR DESCRIPTION
Little PR to extend the "connect" method, allowing to bypass the obj.connected test through a 'force' kwarg and the ability to set the timeout while testing for the Device.