### PR TITLE
fix(macro_update_handler): avoid shadowing the imported module

### DIFF
--- a/bec_lib/bec_lib/macro_update_handler.py
+++ b/bec_lib/bec_lib/macro_update_handler.py
@@ -10,6 +10,8 @@ import inspect
 import os
 from typing import TYPE_CHECKING, Any, Literal
 
+import slugify
+
 from bec_lib import messages
 from bec_lib.callback_handler import EventType
 from bec_lib.endpoints import MessageEndpoints
@@ -164,7 +166,9 @@ class MacroUpdateHandler:
             return []
 
         # If safe, load the module
-        module_spec = importlib.util.spec_from_file_location("macros", file)
+        module_suffix = os.path.basename(file)
+        module_suffix = slugify.slugify(module_suffix, separator="_")
+        module_spec = importlib.util.spec_from_file_location(f"macros_{module_suffix}", file)
         if module_spec is None or module_spec.loader is None:
             logger.error(f"Failed to create module spec for {file}")
             return []
@@ -265,7 +269,7 @@ class MacroUpdateHandler:
             if not callable(cls):
                 continue
             # ignore imported classes
-            if cls.__module__ != "macros":
+            if not cls.__module__.startswith("macros_"):
                 continue
             macros_in_file[name] = {
                 "cls": cls,

--- a/bec_lib/pyproject.toml
+++ b/bec_lib/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "h5py~=3.10",
     "hdf5plugin >=4.3, < 6.0",
     "python-dotenv~=1.0",
+    "python-slugify~=8.0",
 ]
 
 

--- a/bec_lib/tests/test_user_macros.py
+++ b/bec_lib/tests/test_user_macros.py
@@ -56,7 +56,7 @@ def test_user_macro_forget(macros):
 def test_load_user_macro(macros):
     mock_run = macros._client.callbacks.run
     builtins.__dict__["dev"] = macros
-    dummy_func.__module__ = "macros"
+    dummy_func.__module__ = "macros_dummy_file"
     with mock.patch.object(
         macros._update_handler,
         "load_macro_module",


### PR DESCRIPTION
Fix to support reloading single macros from a module without shadowing already imported modules. I'm not a big fan of the solution, so if anyone has a better idea, I'd be open for it. 