### PR TITLE
Feature/config reset

### DIFF
--- a/bec_lib/bec_lib/devicemanager.py
+++ b/bec_lib/bec_lib/devicemanager.py
@@ -696,8 +696,10 @@ class DeviceManagerBase:
             msg (DeviceConfigMessage): Config message
 
         """
-        if msg.content["action"] not in ["update", "add", "remove", "reload", "set"]:
-            raise DeviceConfigError("Action must be either add, remove, update, set or reload.")
+        if msg.content["action"] not in ["update", "add", "remove", "reload", "set", "reset"]:
+            raise DeviceConfigError(
+                "Action must be either add, remove, update, set, reload or reset."
+            )
         if msg.content["action"] in ["update", "add", "remove", "set"]:
             if not msg.content["config"]:
                 raise DeviceConfigError(

--- a/bec_lib/bec_lib/messages.py
+++ b/bec_lib/bec_lib/messages.py
@@ -714,15 +714,15 @@ class ScanBaselineMessage(BECMessage):
     data: dict
 
 
-ConfigAction = Literal["add", "set", "update", "reload", "remove"]
+ConfigAction = Literal["add", "set", "update", "reload", "remove", "reset"]
 
 
 class DeviceConfigMessage(BECMessage):
     """Message type for sending device config updates
 
     Args:
-        action (Literal['add', 'set', 'update', 'reload', or 'remove'] : Update of the device config.
-        config (dict, or None): Device config (add, set, update) or None (reload).
+        action (Literal['add', 'set', 'update', 'reload', 'reset' or 'remove'] : Update of the device config.
+        config (dict, or None): Device config (add, set, update) or None (reload, reset).
         metadata (dict, optional): Additional metadata.
 
     """

--- a/bec_server/bec_server/scihub/atlas/config_handler.py
+++ b/bec_server/bec_server/scihub/atlas/config_handler.py
@@ -52,6 +52,8 @@ class ConfigHandler:
                 self._add_to_config(msg)
             if msg.content["action"] == "remove":
                 self._remove_from_config(msg)
+            if msg.content["action"] == "reset":
+                self._reset_config(msg)
 
         except Exception:
             content = traceback.format_exc()
@@ -120,6 +122,16 @@ class ConfigHandler:
     def _reload_config(self, msg: messages.DeviceConfigMessage):
         self.send_config_request_reply(accepted=True, error_msg=None, metadata=msg.metadata)
         self.send_config(msg)
+
+    def _reset_config(self, msg: messages.DeviceConfigMessage):
+        # set the config in redis to empty
+        self.set_config_in_redis([])
+
+        self.send_config_request_reply(accepted=True, error_msg=None, metadata=msg.metadata)
+
+        # tell all services to reload the config
+        reload_msg = messages.DeviceConfigMessage(action="reload", config={}, metadata=msg.metadata)
+        self.send_config(reload_msg)
 
     def _add_to_config(self, msg: messages.DeviceConfigMessage):
         dev_configs = msg.content["config"]


### PR DESCRIPTION
This PR adds the option to reset the config through

```python 
bec.config.reset_config()
```

closes #640 

I don't understand why codecov is not showing the coverage for config_handler but I checked locally that it is covering the new lines. 