### PR TITLE
Fix/redis connector conn

### DIFF
--- a/bec_lib/bec_lib/redis_connector.py
+++ b/bec_lib/bec_lib/redis_connector.py
@@ -271,7 +271,9 @@ class RedisConnector:
         """
         if password is None:
             password = "null"
-        old_kwargs = copy.deepcopy(self._redis_conn.connection_pool.connection_kwargs)
+        conn_kwargs = self._redis_conn.connection_pool.connection_kwargs.copy()
+        conn_kwargs.pop("server", None)  # server is not serializable
+        old_kwargs = copy.deepcopy(conn_kwargs)
         try:
             self._close_pubsub()
             self._redis_conn.connection_pool.reset()
@@ -281,7 +283,7 @@ class RedisConnector:
             self._restart_pubsub()
         except redis.exceptions.RedisError as exc:
             self._redis_conn.connection_pool.reset()
-            self._redis_conn.connection_pool.connection_kwargs = old_kwargs
+            self._redis_conn.connection_pool.connection_kwargs.update(old_kwargs)
             raise exc
 
     def _close_pubsub(self):


### PR DESCRIPTION
Fixing two problems in the redis connector:
* The try/except for unauthenticated endpoint access expected an EndpointInfo object. Now it also supports just strings
* The auth method would fail for test instances when a fake backend server was provided. 