### PR TITLE
feat(redis connector): retry with exp backoff

### DIFF
--- a/bec_lib/bec_lib/bec_service.py
+++ b/bec_lib/bec_lib/bec_service.py
@@ -170,6 +170,8 @@ class BECService:
         self._start_metrics_emitter()
         self._wait_for_server()
         self._version = None
+        if self.connector.can_connect():
+            self.connector.set_retry_enabled(True)
 
     @property
     def _service_name(self):

--- a/bec_lib/bec_lib/client.py
+++ b/bec_lib/bec_lib/client.py
@@ -173,10 +173,14 @@ class BECClient(BECService):
     @property
     def active_account(self) -> str:
         """get the currently active target (e)account"""
-        msg = self.connector.get_last(MessageEndpoints.account(), "data")
-        if msg:
-            return msg.value
-        return ""
+        try:
+            # We wrap this in a try-except to avoid issues on startup if Redis is not reachable
+            msg = self.connector.get_last(MessageEndpoints.account(), "data")
+            if msg:
+                return msg.value
+            return ""
+        except Exception:
+            return ""
 
     def start(self):
         """start the client"""

--- a/bec_lib/bec_lib/tests/utils.py
+++ b/bec_lib/bec_lib/tests/utils.py
@@ -729,6 +729,8 @@ class SignalMock:  # pragma: no cover
 
 
 class ConnectorMock(RedisConnector):  # pragma: no cover
+    RETRY_ON_TIMEOUT = 0
+
     def __init__(self, bootstrap_server: list[str] | str = "localhost:0000", store_data=True):
         if isinstance(bootstrap_server, list):
             bootstrap_server = bootstrap_server[0]

--- a/bec_lib/tests/conftest.py
+++ b/bec_lib/tests/conftest.py
@@ -27,13 +27,14 @@ def bec_client_singleton_reset():
     BECClient._reset_singleton()
 
 
-def fake_redis_server(host, port):
+def fake_redis_server(host, port, **kwargs):
     redis = fakeredis.FakeRedis()
     return redis
 
 
 @pytest.fixture
 def connected_connector():
+    RedisConnector.RETRY_ON_TIMEOUT = 0
     connector = RedisConnector("localhost:1", redis_cls=fake_redis_server)
     connector._redis_conn.flushall()
     try:

--- a/bec_server/tests/tests_device_server/conftest.py
+++ b/bec_server/tests/tests_device_server/conftest.py
@@ -20,7 +20,7 @@ from bec_lib.redis_connector import RedisConnector
 ### THREADS FOR DEVICE SERVER TESTS (LIKE BEFORE...)
 
 
-def fake_redis_server(host, port):
+def fake_redis_server(host, port, **kwargs):
     redis = fakeredis.FakeRedis()
     return redis
 

--- a/bec_server/tests/tests_device_server/test_device_instructions.py
+++ b/bec_server/tests/tests_device_server/test_device_instructions.py
@@ -36,7 +36,8 @@ def _convert_to_db_config(yaml_config: dict) -> None:
 
 
 @pytest.fixture
-def fakeredis_connector(connected_connector):
+def fakeredis_connector(connected_connector, **kwargs):
+    connected_connector.set_retry_enabled(False)
     return lambda x: connected_connector
 
 

--- a/bec_server/tests/tests_file_writer/conftest.py
+++ b/bec_server/tests/tests_file_writer/conftest.py
@@ -8,7 +8,7 @@ from bec_lib.redis_connector import RedisConnector
 # to have it in autouse
 
 
-def fake_redis_server(host, port):
+def fake_redis_server(host, port, **kwargs):
     redis = fakeredis.FakeRedis()
     return redis
 

--- a/bec_server/tests/tests_scan_server/conftest.py
+++ b/bec_server/tests/tests_scan_server/conftest.py
@@ -14,7 +14,7 @@ def threads_check(threads_check):
     bec_logger.logger.remove()
 
 
-def fake_redis_server(host, port):
+def fake_redis_server(host, port, **kwargs):
     redis = fakeredis.FakeRedis()
     return redis
 

--- a/bec_server/tests/tests_scihub/conftest.py
+++ b/bec_server/tests/tests_scihub/conftest.py
@@ -49,7 +49,7 @@ def SciHubMock():
     scihub_mocked.shutdown()
 
 
-def fake_redis_server(host, port):
+def fake_redis_server(host, port, **kwargs):
     redis = fakeredis.FakeRedis()
     return redis
 


### PR DESCRIPTION
This PR adds support for retrying redis commands with exponential backoff. The retry option is automatically enabled after the bec service has been successfully initialized and redis is available. The delayed enabling ensures that the user is still prompted that redis is not running rather than getting stuck in the connection loop. 

The additional args sadly also mean that we have to adapt the fakeredis fixtures in all conftests. I've updated everything in BEC with this PR. ~~There are some plugin repos that need to be updated and of course also BEC Widgets~~.

---
If you want to test it:
* Restart client and server with the new version
* Start a scan in the client, ideally with a longer exp. time to give you some time 
* ctrl-c redis
* Check that no errors show up
* After a few seconds, restart redis
* The scan should continue normally