### PR TITLE
fix(live progress update): fix progress update

### DIFF
--- a/bec_ipython_client/bec_ipython_client/callbacks/device_progress.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/device_progress.py
@@ -14,11 +14,16 @@ class LiveUpdatesDeviceProgress(LiveUpdatesTable):
 
     REPORT_TYPE = "device_progress"
 
-    def _run_update(self, device_names: str):
+    def core(self):
+        """core function to run the live updates for the table"""
+        self._wait_for_report_instructions()
+        self._run_update(self.report_instruction[self.REPORT_TYPE])
+
+    def _run_update(self, device_names: list[str]):
         """Run the update loop for the progress bar.
 
         Args:
-            device_names (str): The name of the device to monitor.
+            device_names (list[str]): The name of the device to monitor.
         """
         with ScanProgressBar(
             scan_number=self.scan_item.scan_number, clear_on_exit=False
@@ -29,7 +34,7 @@ class LiveUpdatesDeviceProgress(LiveUpdatesTable):
                 self._print_client_msgs_asap()
         self._print_client_msgs_all()
 
-    def _update_progressbar(self, progressbar: ScanProgressBar, device_names: str) -> bool:
+    def _update_progressbar(self, progressbar: ScanProgressBar, device_names: list[str]) -> bool:
         """Update the progressbar based on the device status message
 
         Args:

--- a/bec_ipython_client/bec_ipython_client/callbacks/live_table.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/live_table.py
@@ -171,6 +171,13 @@ class LiveUpdatesTable(LiveUpdatesBase):
 
     def core(self):
         """core function to run the live updates for the table"""
+        self._wait_for_report_instructions()
+        show_table = self.report_instruction[self.REPORT_TYPE].get("show_table", True)
+        self._print_table_data = show_table
+        self._run_update(self.report_instruction[self.REPORT_TYPE]["points"])
+
+    def _wait_for_report_instructions(self):
+        """wait until the report instructions are available"""
         req_ID = self.scan_queue_request.requestID
         while True:
             request_block = [
@@ -181,10 +188,6 @@ class LiveUpdatesTable(LiveUpdatesBase):
             if request_block["report_instructions"]:
                 break
             self.check_alarms()
-
-        show_table = self.report_instruction[self.REPORT_TYPE].get("show_table", True)
-        self._print_table_data = show_table
-        self._run_update(self.report_instruction[self.REPORT_TYPE]["points"])
 
     def _run_update(self, target_num_points: int):
         """run the update loop with the progress bar


### PR DESCRIPTION
This PR fixes a bug in the device progress update routine of the IPython client, see

closes #667 

To test it, you can checkout https://github.com/bec-project/ophyd_devices/pull/157

and add 

```python
    def scan_report_instructions(self):
        yield from self.stubs.scan_report_instruction({"device_progress": ["waveform"]})
```
to e.g. the grid scan. 


Once #668 is resolved, we can add proper e2e tests for bespoke simulation scans