### PR TITLE
refactor: move error info to pydantic

### DIFF
--- a/bec_ipython_client/bec_ipython_client/main.py
+++ b/bec_ipython_client/bec_ipython_client/main.py
@@ -213,16 +213,16 @@ class BECIPythonClient:
         header.append("Alarm Raised\n", style="bold red")
         header.append(f"Severity: {alarm.severity.name}\n", style="bold")
         header.append(f"Type: {alarm.alarm_type}\n", style="bold")
-        if alarm.alarm.source.get("device"):
-            header.append(f"Device: {alarm.alarm.source['device']}\n", style="bold")
+        if alarm.alarm.info.device:
+            header.append(f"Device: {alarm.alarm.info.device}\n", style="bold")
 
         console.print(Panel(header, title="Alarm Info", border_style="red", expand=False))
 
         # --- SHOW SUMMARY
-        if alarm.alarm.compact_msg:
+        if alarm.alarm.info.compact_error_message:
             console.print(
                 Panel(
-                    Text(alarm.alarm.compact_msg, style="yellow"),
+                    Text(alarm.alarm.info.compact_error_message, style="yellow"),
                     title="Summary",
                     border_style="yellow",
                     expand=False,
@@ -230,7 +230,7 @@ class BECIPythonClient:
             )
 
         # --- SHOW FULL TRACEBACK
-        tb_str = alarm.alarm.msg
+        tb_str = alarm.alarm.info.error_message
         if tb_str:
             try:
                 console.print(tb_str)

--- a/bec_ipython_client/tests/client_tests/test_bec_client.py
+++ b/bec_ipython_client/tests/client_tests/test_bec_client.py
@@ -216,13 +216,13 @@ def test_bec_ipython_client_property_access(ipython_client):
 
 def test_bec_ipython_client_show_last_alarm(ipython_client, capsys):
     client = ipython_client
-    alarm_msg = messages.AlarmMessage(
-        severity=Alarms.MAJOR,
-        alarm_type="TestAlarm",
-        source={},
-        msg="This is a test alarm",
-        compact_msg="Test alarm",
+    error_info = messages.ErrorInfo(
+        error_message="This is a test alarm",
+        compact_error_message="Test alarm",
+        exception_type="TestAlarm",
+        device=None,
     )
+    alarm_msg = messages.AlarmMessage(severity=Alarms.MAJOR, info=error_info)
     client.alarm_handler = AlarmHandler(connector=mock.MagicMock())
     client.alarm_handler.add_alarm(alarm_msg)
     client._alarm_history.append(

--- a/bec_lib/bec_lib/messages.py
+++ b/bec_lib/bec_lib/messages.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import time
+import uuid
 import warnings
 from copy import deepcopy
 from enum import Enum, auto
@@ -9,7 +10,6 @@ from typing import Any, ClassVar, Literal
 
 import numpy as np
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
-from typing_extensions import TypedDict
 
 from bec_lib.metadata_schema import get_metadata_schema_for_scan
 
@@ -424,11 +424,12 @@ class DeviceInstructionMessage(BECMessage):
     parameter: dict
 
 
-class ErrorInfo(TypedDict):
+class ErrorInfo(BaseModel):
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     error_message: str
     compact_error_message: str | None
     exception_type: str
-    device: str | None
+    device: str | list[str] | None = None
 
 
 class DeviceInstructionResponse(BECMessage):
@@ -862,20 +863,14 @@ class AlarmMessage(BECMessage):
 
     Args:
         severity (Alarms, Literal[0,1,2]): Severity level (0-2). ALARMS.WARNING = 0, ALARMS.MINOR = 1, ALARMS.MAJOR = 2
-        alarm_type (str): Type of alarm.
-        source (dict): Source of the problem.
-        msg (str): Problem description.
-        compact_msg (str, optional): Optional compact message for quick display.
+        info (ErrorInfo): Error information.
         metadata (dict, optional): Additional metadata.
 
     """
 
     msg_type: ClassVar[str] = "alarm_message"
     severity: int  # TODO change once enums moved to a separate class
-    alarm_type: str
-    source: dict
-    msg: str
-    compact_msg: str | None = None
+    info: ErrorInfo
 
 
 class StatusMessage(BECMessage):

--- a/bec_lib/bec_lib/tests/utils.py
+++ b/bec_lib/bec_lib/tests/utils.py
@@ -741,23 +741,8 @@ class ConnectorMock(RedisConnector):  # pragma: no cover
         self._get_buffer = {}
         self.store_data = store_data
 
-    def raise_alarm(
-        self,
-        severity: Alarms,
-        alarm_type: str,
-        source: str,
-        msg: str,
-        compact_msg: str,
-        metadata: dict,
-    ):
-        messages.AlarmMessage(
-            severity=severity,
-            alarm_type=alarm_type,
-            source=source,
-            msg=msg,
-            compact_msg=compact_msg,
-            metadata=metadata,
-        )
+    def raise_alarm(self, severity: Alarms, info: messages.ErrorInfo, metadata: dict | None = None):
+        messages.AlarmMessage(severity=severity, info=info, metadata=metadata)
 
     def log_error(self, *args, **kwargs):
         pass

--- a/bec_lib/tests/test_alarm_handler.py
+++ b/bec_lib/tests/test_alarm_handler.py
@@ -1,22 +1,39 @@
+import pytest
+
 from bec_lib import messages
 from bec_lib.alarm_handler import AlarmBase, Alarms
 
 
-def test_alarm_base_printing():
-    msg = messages.AlarmMessage(
-        severity=Alarms.MAJOR,
-        alarm_type="TestAlarmType",
-        source={"source": "test"},
-        msg="Test alarm content",
-        compact_msg="Compact alarm content",
-        metadata={"metadata": "metadata1"},
-    )
-    alarm_msg = AlarmBase(alarm=msg, alarm_type="TestAlarmType", severity=Alarms.MAJOR)
+@pytest.mark.parametrize(
+    "msg",
+    [
+        messages.AlarmMessage(
+            severity=Alarms.MAJOR,
+            info=messages.ErrorInfo(
+                error_message="This is a test alarm message for testing purposes.",
+                compact_error_message="Compact alarm content",
+                exception_type="TestAlarmType",
+                device="TestDevice",
+            ),
+            metadata={"metadata": "metadata1"},
+        ),
+        messages.AlarmMessage(
+            severity=Alarms.MAJOR,
+            info=messages.ErrorInfo(
+                error_message="Another test alarm message with different content.",
+                compact_error_message="Another compact alarm content",
+                exception_type="AnotherTestAlarmType",
+                device=None,
+            ),
+            metadata={"metadata": "metadata2"},
+        ),
+    ],
+)
+def test_alarm_base_printing(msg):
+    alarm_msg = AlarmBase(alarm=msg, severity=Alarms.MAJOR)
 
     # Test __str__ method
-    expected_str = (
-        "An alarm has occured. Severity: MAJOR.\n" "TestAlarmType.\n\t Compact alarm content"
-    )
+    expected_str = f"An alarm has occured. Severity: MAJOR.\n{msg.info.exception_type}.\n\t {msg.info.compact_error_message}"
     assert str(alarm_msg) == expected_str
 
     # Test pretty_print method (just ensure it runs without error)

--- a/bec_lib/tests/test_bec_messages.py
+++ b/bec_lib/tests/test_bec_messages.py
@@ -210,9 +210,12 @@ def test_LogMessage():
 def test_AlarmMessage():
     msg = messages.AlarmMessage(
         severity=2,
-        alarm_type="major",
-        source={"system": "samx"},
-        msg="An error occurred",
+        info=messages.ErrorInfo(
+            error_message="This is an alarm message.",
+            compact_error_message="Alarm content",
+            exception_type="AlarmType",
+            device="AlarmDevice",
+        ),
         metadata={"RID": "1234"},
     )
     res = MsgpackSerialization.dumps(msg)

--- a/bec_lib/tests/test_redis_connector.py
+++ b/bec_lib/tests/test_redis_connector.py
@@ -63,50 +63,22 @@ def test_redis_connector_send_client_info(connector):
 
 
 @pytest.mark.parametrize(
-    "severity, alarm_type, source, msg, compact_msg, metadata",
+    "severity, alarm_type, msg, compact_msg, metadata",
     [
-        [
-            Alarms.MAJOR,
-            "alarm",
-            {"source": "test"},
-            "content1",
-            "compact_msg",
-            {"metadata": "metadata1"},
-        ],
-        [
-            Alarms.MINOR,
-            "alarm",
-            {"source": "test"},
-            "content1",
-            "compact_msg",
-            {"metadata": "metadata1"},
-        ],
-        [
-            Alarms.WARNING,
-            "alarm",
-            {"source": "test"},
-            "content1",
-            "compact_msg",
-            {"metadata": "metadata1"},
-        ],
+        [Alarms.MAJOR, "alarm", "content1", "compact_msg", {"metadata": "metadata1"}],
+        [Alarms.MINOR, "alarm", "content1", "compact_msg", {"metadata": "metadata1"}],
+        [Alarms.WARNING, "alarm", "content1", "compact_msg", {"metadata": "metadata1"}],
     ],
 )
-def test_redis_connector_raise_alarm(
-    connector, severity, alarm_type, source, msg, compact_msg, metadata
-):
+def test_redis_connector_raise_alarm(connector, severity, alarm_type, msg, compact_msg, metadata):
     with mock.patch.object(connector, "set_and_publish", return_value=None):
-        connector.raise_alarm(severity, alarm_type, source, msg, compact_msg, metadata)
+        info = messages.ErrorInfo(
+            error_message=msg, compact_error_message=compact_msg, exception_type=alarm_type
+        )
+        connector.raise_alarm(severity, info, metadata)
 
         connector.set_and_publish.assert_called_once_with(
-            MessageEndpoints.alarm(),
-            AlarmMessage(
-                severity=severity,
-                alarm_type=alarm_type,
-                source=source,
-                msg=msg,
-                compact_msg=compact_msg,
-                metadata=metadata,
-            ),
+            MessageEndpoints.alarm(), AlarmMessage(severity=severity, info=info, metadata=metadata)
         )
 
 

--- a/bec_server/bec_server/file_writer/async_writer.py
+++ b/bec_server/bec_server/file_writer/async_writer.py
@@ -180,12 +180,14 @@ class AsyncWriter(threading.Thread):
             content = traceback.format_exc()
             # self.send_file_message(done=True, successful=False)
             logger.error(f"Error writing async data file {self.tmp_file_path}: {content}")
+            error_info = messages.ErrorInfo(
+                error_message=f"Error writing async data file {self.tmp_file_path}",
+                compact_error_message=traceback.format_exc(limit=0),
+                exception_type="AsyncWriterError",
+            )
             self.connector.raise_alarm(
                 severity=Alarms.WARNING,
-                alarm_type="AsyncWriterError",
-                source={"file_path": self.tmp_file_path},
-                msg=f"Error writing async data file {self.tmp_file_path}: {content}",
-                compact_msg=traceback.format_exc(limit=0),
+                info=error_info,
                 metadata={"scan_id": self.scan_id, "scan_number": self.scan_number},
             )
 
@@ -268,12 +270,15 @@ class AsyncWriter(threading.Thread):
                         else:  # pragma: no cover
                             # this should never happen as the keys are fixed in the pydantic model
                             msg = f"Unknown key: {key}. Data will not be written."
+                            error_info = messages.ErrorInfo(
+                                error_message=msg,
+                                compact_error_message=msg,
+                                exception_type="ValueError",
+                                device=device_name,
+                            )
                             self.connector.raise_alarm(
                                 severity=Alarms.WARNING,
-                                alarm_type="ValueError",
-                                source={"device": device_name},
-                                msg=msg,
-                                compact_msg=msg,
+                                info=error_info,
                                 metadata={"scan_id": self.scan_id, "scan_number": self.scan_number},
                             )
 
@@ -316,10 +321,12 @@ class AsyncWriter(threading.Thread):
             msg = f"Unknown async update type: {update_type}. Data will not be written."
             self.connector.raise_alarm(
                 severity=Alarms.WARNING,
-                alarm_type="ValueError",
-                source={"device": signal_group.name},
-                msg=msg,
-                compact_msg=msg,
+                info=messages.ErrorInfo(
+                    error_message=msg,
+                    compact_error_message=msg,
+                    exception_type="ValueError",
+                    device=signal_group.name,
+                ),
                 metadata={"scan_id": self.scan_id, "scan_number": self.scan_number},
             )
 
@@ -375,10 +382,12 @@ class AsyncWriter(threading.Thread):
                 msg = f"Data for {signal_group.name} exceeds the defined max_shape {max_shape}. Data will not be written."
                 self.connector.raise_alarm(
                     severity=Alarms.WARNING,
-                    alarm_type="ValueError",
-                    source={"device": signal_group.name},
-                    msg=msg,
-                    compact_msg=msg,
+                    info=messages.ErrorInfo(
+                        error_message=msg,
+                        compact_error_message=msg,
+                        exception_type="ValueError",
+                        device=signal_group.name,
+                    ),
                     metadata={"scan_id": self.scan_id, "scan_number": self.scan_number},
                 )
                 return
@@ -402,10 +411,12 @@ class AsyncWriter(threading.Thread):
             msg = f"Invalid max_shape for async update type 'add_slice': {max_shape}. max_shape cannot exceed two dimensions. Data will not be written."
             self.connector.raise_alarm(
                 severity=Alarms.WARNING,
-                alarm_type="ValueError",
-                source={"device": signal_group.name},
-                msg=msg,
-                compact_msg=msg,
+                info=messages.ErrorInfo(
+                    error_message=msg,
+                    compact_error_message=msg,
+                    exception_type="ValueError",
+                    device=signal_group.name,
+                ),
                 metadata={"scan_id": self.scan_id, "scan_number": self.scan_number},
             )
             return
@@ -432,10 +443,12 @@ class AsyncWriter(threading.Thread):
                     msg = f"Data for {signal_group.name} exceeds the defined max_shape {max_shape}. Data will be truncated."
                     self.connector.raise_alarm(
                         severity=Alarms.WARNING,
-                        alarm_type="ValueError",
-                        source={"device": signal_group.name, "slice": row_index},
-                        msg=msg,
-                        compact_msg=msg,
+                        info=messages.ErrorInfo(
+                            error_message=msg,
+                            compact_error_message=msg,
+                            exception_type="ValueError",
+                            device=signal_group.name,
+                        ),
                         metadata={"scan_id": self.scan_id, "scan_number": self.scan_number},
                     )
                     value = value[:, : max_shape[1]]
@@ -460,10 +473,12 @@ class AsyncWriter(threading.Thread):
                 msg = f"Added data slice for {signal_group.name} exceeds the defined max_shape {max_shape}. Data will be truncated."
                 self.connector.raise_alarm(
                     severity=Alarms.WARNING,
-                    alarm_type="ValueError",
-                    source={"device": signal_group.name, "slice": row_index},
-                    msg=msg,
-                    compact_msg=msg,
+                    info=messages.ErrorInfo(
+                        error_message=msg,
+                        compact_error_message=msg,
+                        exception_type="ValueError",
+                        device=signal_group.name,
+                    ),
                     metadata={"scan_id": self.scan_id, "scan_number": self.scan_number},
                 )
                 value = value[: max_shape[1] - col_index]

--- a/bec_server/bec_server/file_writer/file_writer_manager.py
+++ b/bec_server/bec_server/file_writer/file_writer_manager.py
@@ -348,16 +348,17 @@ class FileWriterManager(BECService):
             )
         # pylint: disable=broad-except
         # pylint: disable=unused-variable
-        except Exception:
+        except Exception as exc:
             content = traceback.format_exc()
             logger.error(f"Failed to write to file {file_path}. Error: {content}")
+            error_info = messages.ErrorInfo(
+                error_message=content,
+                compact_error_message=traceback.format_exc(limit=0),
+                exception_type=exc.__class__.__name__,
+                device=None,
+            )
             self.connector.raise_alarm(
-                severity=Alarms.MINOR,
-                alarm_type="FileWriterError",
-                source={"file_writer_manager": content},
-                msg=f"Failed to write to file {file_path}. Error: {content}",
-                compact_msg=traceback.format_exc(limit=0),
-                metadata=self.scan_storage[scan_id].metadata,
+                severity=Alarms.MINOR, info=error_info, metadata=self.scan_storage[scan_id].metadata
             )
             successful = False
         finally:

--- a/bec_server/bec_server/scan_server/errors.py
+++ b/bec_server/bec_server/scan_server/errors.py
@@ -11,7 +11,10 @@ class ScanAbortion(Exception):
 
 
 class LimitError(Exception):
-    pass
+    def __init__(self, message, device: str | None = None):
+        super().__init__(message)
+        self.message = message
+        self.device = device
 
 
 class DeviceMessageError(Exception):
@@ -22,13 +25,7 @@ class DeviceInstructionError(Exception):
     def __init__(self, message):
         super().__init__(message)
         self.message = message
-        self.traceback = None
-        self.compact_message = None
-        self.exception_type = None
-        self.device = None
+        self.error_info: ErrorInfo | None = None
 
-    def set_info(self, error_info: ErrorInfo | dict):
-        self.traceback = error_info.get("error_message") if error_info else None
-        self.compact_message = error_info.get("compact_error_message") if error_info else None
-        self.exception_type = error_info.get("exception_type") if error_info else None
-        self.device = error_info.get("device") if error_info else None
+    def set_info(self, error_info: ErrorInfo):
+        self.error_info = error_info

--- a/bec_server/bec_server/scan_server/scan_stubs.py
+++ b/bec_server/bec_server/scan_server/scan_stubs.py
@@ -141,9 +141,9 @@ class ScanStubStatus:
             error_info (messages.ErrorInfo, optional): Error information. Defaults to None.
         """
         self.done = True
-        info = error_info if error_info is not None else {}
-        exc = DeviceInstructionError(info.get("compact_error_message") if info else None)
-        exc.set_info(info)
+        exc = DeviceInstructionError(error_info.compact_error_message if error_info else None)
+        if error_info:
+            exc.set_info(error_info)
         self._future.set_exception(exc)
 
     def set_running(self):

--- a/bec_server/tests/tests_device_server/test_device_instructions.py
+++ b/bec_server/tests/tests_device_server/test_device_instructions.py
@@ -92,12 +92,13 @@ def test_device_server_init(device_server):
                 metadata={"device_instr_id": "test"},
                 device="samx",
                 status="error",
-                error_info={
-                    "error_message": "position=-5000 not within limits (-50, 50)",
-                    "compact_error_message": "position=-5000 not within limits (-50, 50)",
-                    "exception_type": "DeviceInstructionError",
-                    "device": "samx",
-                },
+                error_info=messages.ErrorInfo(
+                    id="uuid",
+                    error_message="position=-5000 not within limits (-50, 50)",
+                    compact_error_message="position=-5000 not within limits (-50, 50)",
+                    exception_type="DeviceInstructionError",
+                    device="samx",
+                ),
                 instruction=messages.DeviceInstructionMessage(
                     device="samx",
                     action="set",
@@ -138,4 +139,4 @@ def test_device_server_set(device_server, msg, response):
 
     # Now compare the error_info separately
     if out.status == "error":
-        assert original_error_info["error_message"] in created_error_info["error_message"]
+        assert original_error_info.error_message in created_error_info.error_message

--- a/bec_server/tests/tests_device_server/test_device_server.py
+++ b/bec_server/tests/tests_device_server/test_device_server.py
@@ -112,12 +112,7 @@ def test_stop_devices(device_server_mock):
             stop.assert_called_once()
             assert raise_alarm.call_count == 1
             assert raise_alarm.call_args == mock.call(
-                severity=Alarms.WARNING,
-                source={"device": "samy", "method": "stop"},
-                msg=mock.ANY,
-                compact_msg=mock.ANY,
-                alarm_type=mock.ANY,
-                metadata=mock.ANY,
+                severity=Alarms.WARNING, info=mock.ANY, metadata=mock.ANY
             )
             # If stop raises an exception, the device server must get back to running state
             assert device_server.status == BECStatus.RUNNING
@@ -266,14 +261,7 @@ def test_handle_device_instruction_raises_alarm(device_server_mock):
     with mock.patch.object(device_server, "assert_device_is_enabled", side_effect=RuntimeError):
         with mock.patch.object(device_server.connector, "raise_alarm") as raise_alarm:
             device_server.handle_device_instructions(mock.MagicMock())
-            raise_alarm.assert_called_once_with(
-                severity=Alarms.MAJOR,
-                source=ANY,
-                msg=ANY,
-                compact_msg=ANY,
-                alarm_type=ANY,
-                metadata=ANY,
-            )
+            raise_alarm.assert_called_once_with(severity=Alarms.MAJOR, info=ANY, metadata=ANY)
 
 
 @pytest.mark.parametrize(
@@ -297,12 +285,7 @@ def test_handle_device_instructions_limit_error(device_server_mock, instructions
             device_server.handle_device_instructions(instructions)
 
             alarm_mock.assert_called_once_with(
-                severity=Alarms.MAJOR,
-                source={"device": None, "instruction": instructions.content},
-                msg=ANY,
-                compact_msg=ANY,
-                alarm_type="LimitError",
-                metadata=instructions.metadata,
+                severity=Alarms.MAJOR, info=ANY, metadata=instructions.metadata
             )
 
 

--- a/bec_server/tests/tests_scan_server/test_scan_stub_status.py
+++ b/bec_server/tests/tests_scan_server/test_scan_stub_status.py
@@ -124,14 +124,13 @@ def test_scan_stub_status_set_done(scan_stub_status):
 
 
 def test_scan_stub_status_set_failed(scan_stub_status):
-    scan_stub_status.set_failed(
-        {
-            "error_message": "Error occurred",
-            "compact_error_message": "Error occurred",
-            "exception_type": "ValueError",
-            "device": "samx",
-        }
+    error_info = messages.ErrorInfo(
+        error_message="Error occurred",
+        compact_error_message="Error occurred",
+        exception_type="ValueError",
+        device="samx",
     )
+    scan_stub_status.set_failed(error_info)
     assert scan_stub_status.done is True
     with pytest.raises(DeviceInstructionError) as exc_info:
         scan_stub_status.wait()
@@ -209,12 +208,12 @@ def test_scan_stub_status_wait_error(scan_stub_status):
             metadata={"device_instr_id": diid},
             device="samx",
             status="error",
-            error_info={
-                "error_message": "Error message",
-                "compact_error_message": "Error message",
-                "exception_type": "ValueError",
-                "device": "samx",
-            },
+            error_info=messages.ErrorInfo(
+                error_message="Error message",
+                compact_error_message="Error message",
+                exception_type="ValueError",
+                device="samx",
+            ),
             instruction=messages.DeviceInstructionMessage(
                 device="samx",
                 action="set",


### PR DESCRIPTION
This PR moves the error info typed dict to a proper pydantic models and simplifies the injection in to Alarms. This ensures proper validation but also removes duplicated parsing. 

Moreover, it adds a unique id to the error info which prevents the same alarm from being registered multiple times. This should also remove duplicates popping up in BEC Widgets. 

closes #685 