### PR TITLE
feat: enhance ConfigHelper to handle configuration conflicts with user input

### DIFF
--- a/bec_ipython_client/bec_ipython_client/main.py
+++ b/bec_ipython_client/bec_ipython_client/main.py
@@ -13,6 +13,7 @@ import redis
 import redis.exceptions
 from IPython.terminal.ipapp import TerminalIPythonApp
 from IPython.terminal.prompts import Prompts, Token
+from pydantic import ValidationError
 from rich.console import Console
 from rich.panel import Panel
 from rich.text import Text
@@ -30,6 +31,7 @@ from bec_lib.client import BECClient
 from bec_lib.logger import bec_logger
 from bec_lib.redis_connector import RedisConnector
 from bec_lib.service_config import ServiceConfig
+from bec_lib.utils.pydantic_pretty_print import pretty_print_pydantic_validation_error
 
 logger = bec_logger.logger
 
@@ -247,6 +249,9 @@ def _ip_exception_handler(
         print("\x1b[31m BEC alarm:\x1b[0m")
         evalue.pretty_print()
         print("For more details, use 'bec.show_last_alarm()'")
+        return
+    if issubclass(etype, ValidationError):
+        pretty_print_pydantic_validation_error(evalue)
         return
     if issubclass(etype, (ScanInterruption, DeviceConfigError)):
         print(f"\x1b[31m {evalue.__class__.__name__}:\x1b[0m {evalue}")

--- a/bec_ipython_client/tests/end-2-end/test_scans_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_scans_e2e.py
@@ -737,12 +737,12 @@ def test_update_config(bec_ipython_client_fixture):
     bec = bec_ipython_client_fixture
     bec.metadata.update({"unit_test": "test_update_config"})
     demo_config_path = os.path.join(os.path.dirname(configs.__file__), "demo_config.yaml")
-    config = bec.config._load_config_from_file(demo_config_path)
+    config = bec.device_manager.config_helper._load_config_from_file(demo_config_path)
     config.pop("samx")
-    bec.config.send_config_request(action="set", config=config)
+    bec.device_manager.config_helper.send_config_request(action="set", config=config)
     assert "samx" not in bec.device_manager.devices
-    config = bec.config._load_config_from_file(demo_config_path)
-    bec.config.send_config_request(action="set", config=config)
+    config = bec.device_manager.config_helper._load_config_from_file(demo_config_path)
+    bec.device_manager.config_helper.send_config_request(action="set", config=config)
 
 
 @pytest.mark.timeout(100)

--- a/bec_lib/bec_lib/client.py
+++ b/bec_lib/bec_lib/client.py
@@ -22,6 +22,7 @@ from bec_lib.alarm_handler import AlarmHandler, Alarms
 from bec_lib.bec_service import BECService
 from bec_lib.bl_checks import BeamlineChecks
 from bec_lib.callback_handler import CallbackHandler, EventType
+from bec_lib.config_helper import ConfigHelperUser
 from bec_lib.dap_plugins import DAPPlugins
 from bec_lib.device_monitor_plugin import DeviceMonitorPlugin
 from bec_lib.devicemanager import DeviceManagerBase
@@ -219,7 +220,7 @@ class BECClient(BECService):
         self._start_scan_queue()
         self._start_alarm_handler()
         self.macros.load_all_user_macros()
-        self.config = self.device_manager.config_helper
+        self.config = ConfigHelperUser(self.device_manager.config_helper)
         self.history = ScanHistory(client=self)
         self.dap = DAPPlugins(self)
         self.bl_checks = BeamlineChecks(self)

--- a/bec_lib/bec_lib/config_helper.py
+++ b/bec_lib/bec_lib/config_helper.py
@@ -4,6 +4,7 @@ This module provides a helper class for updating and saving the BEC device confi
 
 from __future__ import annotations
 
+import ast
 import datetime
 import json
 import os
@@ -14,8 +15,15 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import yaml
+from pydantic import ValidationError
+from rich.console import Console
+from rich.panel import Panel
+from rich.prompt import Prompt
+from rich.table import Table
+from rich.text import Text
 
 import bec_lib
+from bec_lib.atlas_models import _DeviceModelCore
 from bec_lib.bec_errors import DeviceConfigError, ServiceConfigError
 from bec_lib.bec_yaml_loader import yaml_load
 from bec_lib.endpoints import MessageEndpoints
@@ -28,6 +36,7 @@ from bec_lib.utils.json import ExtendedEncoder
 if TYPE_CHECKING:  # pragma: no cover
     from bec_lib.messages import DeviceConfigMessage, RequestResponseMessage, ServiceResponseMessage
     from bec_lib.redis_connector import RedisConnector
+
 else:
     # TODO: put back normal import when Pydantic gets faster
     DeviceConfigMessage = lazy_import_from("bec_lib.messages", ("DeviceConfigMessage",))
@@ -54,39 +63,106 @@ class _ConfigConstants:
 CONF = _ConfigConstants()
 
 
+class ConfigHelperUser:
+    """
+    Thin wrapper around ConfigHelper to expose only selected methods to the user.
+    """
+
+    def __init__(self, config_helper: ConfigHelper) -> None:
+        self._config_helper = config_helper
+
+    def update_session_with_file(
+        self, file_path: str, save_recovery: bool = True, force: bool = False, validate: bool = True
+    ) -> None:
+        """Update the current session with a yaml file from disk.
+
+        Args:
+            file_path (str): Full path to the yaml file.
+            save_recovery (bool, optional): Save the current session before updating. Defaults to True.
+            force (bool, optional): Force update even if there are conflicts. Defaults to False.
+            validate (bool, optional): Whether to validate the new config. Defaults to True.
+        """
+        self._config_helper.update_session_with_file(
+            file_path, save_recovery=save_recovery, force=force, validate=validate
+        )
+
+    def save_current_session(self, file_path: str):
+        """Save the current session as a yaml file to disk.
+
+        Args:
+            file_path (str): Full path to the yaml file.
+        """
+        self._config_helper.save_current_session(file_path)
+
+    def reset_config(self, wait_for_response: bool = True, timeout_s: float | None = None) -> None:
+        """
+        Send a request to reset config to default
+        Args:
+            wait_for_response (bool): whether to wait for the response, default True
+            timeout_s (float, optional): how long to wait for a response. Ignored if not waiting. Defaults to best effort calculated value based on message length.
+        Returns: None
+        """
+        self._config_helper.reset_config(wait_for_response=wait_for_response, timeout_s=timeout_s)
+
+    def load_demo_config(self, force: bool = False) -> None:
+        """
+        Load BEC device demo_config.yaml for simulation.
+        Args:
+            force (bool, optional): Force update even if there are conflicts. Defaults to False.
+        Returns: None
+        """
+        self._config_helper.load_demo_config(force=force)
+
+
 class ConfigHelper:
     """Config Helper"""
 
-    def __init__(self, connector: RedisConnector, service_name: str = None) -> None:
+    def __init__(self, connector: RedisConnector, service_name: str | None = None) -> None:
         """Helper class for updating and saving the BEC device configuration.
 
         Args:
             connector (RedisConnector): Redis connector.
             service_name (str, optional): Name of the service. Defaults to None.
         """
-        self.connector = connector
+        self._connector = connector
         self._service_name = service_name
-        self.writer_mixin = None
+        self._writer_mixin = None
         self._base_path_recovery = None
 
-    def update_session_with_file(self, file_path: str, save_recovery: bool = True) -> None:
+    def update_session_with_file(
+        self, file_path: str, save_recovery: bool = True, force: bool = False, validate: bool = True
+    ) -> None:
         """Update the current session with a yaml file from disk.
 
         Args:
             file_path (str): Full path to the yaml file.
             save_recovery (bool, optional): Save the current session before updating. Defaults to True.
+            force (bool, optional): Force update even if there are conflicts. Defaults to False.
+            validate (bool, optional): Whether to validate the new config. Defaults to True.
         """
+        config = self._load_config_from_file(file_path)
+        config_conflicts = self._get_config_conflicts(config, validate=validate)
+        if config_conflicts and not force:
+            try:
+                self._merge_conflicts_with_user_input(config, config_conflicts)
+            except KeyboardInterrupt:
+                print("\nConfiguration update aborted by user. No changes were made.")
+                return
         if save_recovery:
             time_stamp = f"{datetime.datetime.now():%Y-%m-%d_%H-%M-%S}"
             if not self._base_path_recovery:
                 self._update_base_path_recovery()
+            # after update_base_path_recovery, we can
+            assert self._base_path_recovery is not None
+            assert self._writer_mixin is not None
+
             if not os.path.exists(self._base_path_recovery):
-                self.writer_mixin.create_directory(self._base_path_recovery)
+                self._writer_mixin.create_directory(self._base_path_recovery)
             fname = os.path.join(self._base_path_recovery, f"recovery_config_{time_stamp}.yaml")
             success = self._save_config_to_file(fname, raise_on_error=False)
             if success:
                 print(f"A recovery config was written to {fname}.")
-        config = self._load_config_from_file(file_path)
+
         self.send_config_request(action="set", config=config)
 
     def _update_base_path_recovery(self):
@@ -101,9 +177,9 @@ class ConfigHelper:
             raise ServiceConfigError(
                 f"ServiceConfig {service_cfg} must at least contain key with 'log_writer'"
             )
-        self.writer_mixin = DeviceConfigWriter(service_cfg)
-        self._base_path_recovery = self.writer_mixin.get_recovery_directory()
-        self.writer_mixin.create_directory(self._base_path_recovery)
+        self._writer_mixin = DeviceConfigWriter(service_cfg)
+        self._base_path_recovery = self._writer_mixin.get_recovery_directory()
+        self._writer_mixin.create_directory(self._base_path_recovery)
 
     def _load_config_from_file(self, file_path: str) -> dict:
         data = {}
@@ -128,8 +204,313 @@ class ConfigHelper:
         self._save_config_to_file(file_path)
         print(f"Config was written to {file_path}.")
 
+    def _get_config_conflicts(self, new_config: dict, validate: bool = True) -> dict:
+        """
+        Check if the newly provided config has conflicts with the current session config.
+        The current session config is fetched from Redis.
+
+        Args:
+            new_config (dict): New config to check.
+            validate (bool): Whether to validate the new config. Defaults to True.
+
+        Returns:
+            dict: Conflicts found in the config: Device name -> List of conflicting elements.
+        """
+        _config = self._connector.get(MessageEndpoints.device_config())
+        if not _config:
+            return {}
+        _config = _config.content["resource"]
+        current_config = {dev["name"]: _DeviceModelCore(**dev).model_dump() for dev in _config}
+
+        output_conflicts = {}
+        for dev, config in new_config.items():
+            if dev not in current_config:
+                continue
+            if validate:
+                try:
+                    config = _DeviceModelCore(**config).model_dump()
+                except ValidationError as exc:
+                    exc.model = _DeviceModelCore  # type: ignore
+                    exc.context = f"the provided device config for device '{dev}'"  # type: ignore
+                    raise exc
+
+            for element, value in config.items():
+                current_value = current_config[dev].get(element, None)
+                if element == "deviceConfig" and value is None:
+                    value = {}
+                if value == current_value:
+                    continue
+                if isinstance(value, dict):
+                    # only store conflicts for nested dicts if there is a difference
+                    # Note: also a missing key in current_value will be detected as a conflict
+                    nested_conflicts = {}
+                    all_config_keys = set(value.keys()).union(
+                        set(current_value.keys() if current_value else [])
+                    )
+                    for sub_element in all_config_keys:
+                        sub_value = value.get(sub_element, None)
+                        current_sub_value = (
+                            current_value.get(sub_element, None) if current_value else None
+                        )
+                        if sub_value != current_sub_value:
+                            nested_conflicts[sub_element] = {
+                                "new": sub_value,
+                                "current": current_sub_value,
+                            }
+                    if nested_conflicts:
+                        if dev not in output_conflicts:
+                            output_conflicts[dev] = {}
+                        output_conflicts[dev][element] = nested_conflicts
+
+                else:
+                    if dev not in output_conflicts:
+                        output_conflicts[dev] = {}
+                    output_conflicts[dev].update(
+                        {element: {"new": value, "current": current_value}}
+                    )
+
+        return output_conflicts
+
+    def _merge_conflicts_with_user_input(self, config: dict, conflicts: dict) -> None:
+        """
+        Merge the conflicts found in the config with user input.
+        Prompts the user interactively for each conflict to decide whether to accept
+        the new value, keep the current value, or manually merge.
+
+        Args:
+            config (dict): Config to update.
+            conflicts (dict): Conflicts found in the config.
+        """
+        console = Console()
+
+        # Display initial warning
+        text = "Configuration Conflicts Detected"
+        device_names = ", ".join(conflicts.keys())
+        body = Text(
+            f"Found conflicts in {len(conflicts)} device(s). The following devices have conflicts: \n\n{device_names}\n",
+            style="bold yellow",
+        )
+        panel = Panel(body, title=text, expand=False, border_style="red")
+        console.print(panel)
+        console.print()
+
+        # Ask for global resolution strategy
+        console.print("[bold]Please choose:[/bold]")
+        console.print("  [green](a)[/green] Accept all new values from file")
+        console.print("  [red](k)[/red] Keep all current session values")
+        console.print("  [cyan](r)[/cyan] Resolve conflicts individually")
+        global_choice = Prompt.ask(
+            "Your choice", choices=["a", "k", "r"], show_default=False, console=console
+        )
+        console.print()
+
+        if global_choice.lower() == "a":
+            # Accept all new values
+            console.print("[green]Accepting all new values from file...[/green]\n")
+            # Config already has new values, nothing to do
+            console.print(
+                "[bold green]✓ All conflicts resolved - new values accepted![/bold green]\n"
+            )
+            return
+        if global_choice.lower() == "k":
+            # Keep all current values
+            console.print("[red]Keeping all current session values...[/red]\n")
+            self._apply_all_current_values(config, conflicts)
+            console.print(
+                "[bold green]✓ All conflicts resolved - current values kept![/bold green]\n"
+            )
+            return
+
+        # Individual resolution (i)
+        console.print("[cyan]Resolving conflicts individually...[/cyan]\n")
+
+        # Iterate through each device with conflicts
+        for device_name, device_conflicts in conflicts.items():
+            console.print(f"\n[bold cyan]Device: {device_name}[/bold cyan]")
+            console.rule(style="cyan")
+
+            # Iterate through each conflicting element in the device
+            for element, conflict_data in device_conflicts.items():
+                # Handle nested conflicts (e.g., deviceConfig)
+                if not self._is_nested_conflict(conflict_data):
+                    self._resolve_single_conflict(
+                        console,
+                        config,
+                        device_name,
+                        element,
+                        None,
+                        conflict_data["new"],
+                        conflict_data["current"],
+                    )
+                    continue
+                # This is a nested conflict (like deviceConfig)
+                console.print(f"\n  [bold]Element:[/bold] [yellow]{element}[/yellow]")
+                for sub_element, sub_conflict in conflict_data.items():
+                    self._resolve_single_conflict(
+                        console,
+                        config,
+                        device_name,
+                        element,
+                        sub_element,
+                        sub_conflict["new"],
+                        sub_conflict["current"],
+                    )
+
+        console.print("\n[bold green]✓ All conflicts resolved![/bold green]\n")
+
+    def _resolve_single_conflict(
+        self,
+        console: Console,
+        config: dict,
+        device_name: str,
+        element: str,
+        sub_element: str | None,
+        new_value,
+        current_value,
+    ) -> None:
+        """
+        Resolve a single conflict by prompting the user.
+
+        Args:
+            console (Console): Rich console instance.
+            config (dict): Config to update.
+            device_name (str): Name of the device.
+            element (str): Element with conflict.
+            sub_element (str | None): Sub-element for nested conflicts (e.g., deviceConfig.key).
+            new_value: New value from the file.
+            current_value: Current value in the session.
+        """
+        # Create a table to display the conflict
+        table = Table(show_header=True, header_style="bold magenta", padding=(0, 1))
+        table.add_column("Element", style="yellow", no_wrap=True)
+        table.add_column("New (file)", style="green")
+        table.add_column("Current (session)", style="red")
+
+        display_element = f"{element}.{sub_element}" if sub_element else element
+
+        # Format values for display
+        new_value_str = self._format_value_for_display(new_value)
+        current_value_str = self._format_value_for_display(current_value)
+
+        table.add_row(display_element, new_value_str, current_value_str)
+        console.print(table)
+
+        # Prompt user for choice with detailed context
+        choice = Prompt.ask(
+            "  [bold]Action:[/bold] [green](a)[/green]ccept new  [red](k)[/red]eep current  [cyan](m)[/cyan]anual merge",
+            choices=["a", "k", "m"],
+            show_default=False,
+            console=console,
+        )
+
+        if choice.lower() == "a":
+            # Accept new value
+            self._apply_config_value(config, device_name, element, sub_element, new_value)
+            console.print("  [green]→ Accepted new value[/green]")
+        elif choice.lower() == "k":
+            # Keep current value - do nothing to config since we're loading from file
+            # We need to update config dict to keep current value
+            self._apply_config_value(config, device_name, element, sub_element, current_value)
+            console.print("  [yellow]→ Kept current value[/yellow]")
+        elif choice.lower() == "m":
+            # Manual merge - prompt for custom value
+            console.print(
+                "  [cyan]Enter custom value (will be evaluated as Python literal):[/cyan]"
+            )
+            custom_input = Prompt.ask("  Value")
+            try:
+                # Try to evaluate as Python literal (handles lists, dicts, numbers, strings, etc.)
+
+                custom_value = ast.literal_eval(custom_input)
+            except (ValueError, SyntaxError):
+                # If evaluation fails, treat as string
+                custom_value = custom_input
+            self._apply_config_value(config, device_name, element, sub_element, custom_value)
+            console.print(f"  [blue]→ Applied custom value: {custom_value}[/blue]")
+
+    def _format_value_for_display(self, value) -> str:
+        """
+        Format a value for display in the conflict resolution UI.
+
+        Args:
+            value: Value to format.
+
+        Returns:
+            str: Formatted value string.
+        """
+        if value is None:
+            return "None"
+        if isinstance(value, (list, set)):
+            # Format lists and sets on a single line
+            return json.dumps(value, cls=ExtendedEncoder)
+        if isinstance(value, dict):
+            # Format dicts compactly if small, otherwise use indentation
+            return json.dumps(value, indent=2, cls=ExtendedEncoder)
+        return str(value)
+
+    def _apply_config_value(
+        self, config: dict, device_name: str, element: str, sub_element: str | None, value
+    ) -> None:
+        """
+        Apply a resolved value to the config dict.
+
+        Args:
+            config (dict): Config to update.
+            device_name (str): Name of the device.
+            element (str): Element to update.
+            sub_element (str | None): Sub-element for nested conflicts.
+            value: Value to apply.
+        """
+        if device_name not in config:
+            config[device_name] = {}
+
+        if sub_element:
+            # Nested element (e.g., deviceConfig.key)
+            if element not in config[device_name]:
+                config[device_name][element] = {}
+            config[device_name][element][sub_element] = value
+        else:
+            # Top-level element
+            config[device_name][element] = value
+
+    def _apply_all_current_values(self, config: dict, conflicts: dict) -> None:
+        """
+        Apply all current values to the config for all conflicts.
+
+        Args:
+            config (dict): Config to update.
+            conflicts (dict): Conflicts found in the config.
+        """
+        for device_name, device_conflicts in conflicts.items():
+            for element, conflict_data in device_conflicts.items():
+                # Handle nested conflicts (e.g., deviceConfig)
+                if not self._is_nested_conflict(conflict_data):
+                    self._apply_config_value(
+                        config, device_name, element, None, conflict_data["current"]
+                    )
+                    continue
+                # This is a nested conflict (like deviceConfig)
+                for sub_element, sub_conflict in conflict_data.items():
+                    self._apply_config_value(
+                        config, device_name, element, sub_element, sub_conflict["current"]
+                    )
+
+    def _is_nested_conflict(self, conflict_data: dict) -> bool:
+        """
+        Check if the conflict data represents a nested conflict.
+
+        Args:
+            conflict_data (dict): Conflict data to check.
+
+        Returns:
+            bool: True if nested conflict, False otherwise.
+        """
+        return isinstance(conflict_data, dict) and all(
+            isinstance(v, dict) and "new" in v and "current" in v for v in conflict_data.values()
+        )
+
     def _save_config_to_file(self, file_path: str, raise_on_error: bool = True) -> bool:
-        config = self.connector.get(MessageEndpoints.device_config())
+        config = self._connector.get(MessageEndpoints.device_config())
         if not config:
             if raise_on_error:
                 raise DeviceConfigError("No config found in the session.")
@@ -167,18 +548,18 @@ class ConfigHelper:
         """
         if action in ["update", "add", "set"] and not config:
             raise DeviceConfigError(f"Config cannot be empty for an {action} request.")
-        RID = str(uuid.uuid4())
-        self.connector.send(
+        request_id = str(uuid.uuid4())
+        self._connector.send(
             MessageEndpoints.device_config_request(),
-            DeviceConfigMessage(action=action, config=config, metadata={"RID": RID}),
+            DeviceConfigMessage(action=action, config=config, metadata={"RID": request_id}),
         )
 
         if wait_for_response:
             timeout = timeout_s if timeout_s is not None else self.suggested_timeout_s(config)
             logger.info(f"Waiting for reply with timeout {timeout} s")
-            reply = self.wait_for_config_reply(RID, timeout=timeout)
-            self.handle_update_reply(reply, RID, timeout)
-        return RID
+            reply = self.wait_for_config_reply(request_id, timeout=timeout)
+            self.handle_update_reply(reply, request_id, timeout)
+        return request_id
 
     def reset_config(self, wait_for_response: bool = True, timeout_s: float | None = None) -> None:
         """
@@ -189,7 +570,7 @@ class ConfigHelper:
         Returns: None
         """
         RID = str(uuid.uuid4())
-        self.connector.send(
+        self._connector.send(
             MessageEndpoints.device_config_request(),
             DeviceConfigMessage(action="reset", config=None, metadata={"RID": RID}),
         )
@@ -230,7 +611,7 @@ class ConfigHelper:
             # wait for the device server and scan server to acknowledge the config change
             self.wait_for_service_response(RID, timeout)
 
-    def wait_for_service_response(self, RID: str, timeout: float = 60) -> ServiceResponseMessage:
+    def wait_for_service_response(self, RID: str, timeout: float = 60) -> None:
         """
         wait for service response
 
@@ -238,13 +619,11 @@ class ConfigHelper:
             RID (str): request id
             timeout (float, optional): timeout in seconds. Defaults to 60.
 
-        Returns:
-            ServiceResponseMessage: reply message
         """
         start_time = time.monotonic()
         while True:
             elapsed_time = time.monotonic() - start_time
-            service_messages = self.connector.lrange(MessageEndpoints.service_response(RID), 0, -1)
+            service_messages = self._connector.lrange(MessageEndpoints.service_response(RID), 0, -1)
             if not service_messages:
                 time.sleep(0.005)
             else:
@@ -284,7 +663,7 @@ class ConfigHelper:
         start = time.monotonic()
         while True:
             elapsed_time = time.monotonic() - start
-            msg = self.connector.get(MessageEndpoints.device_config_request_response(RID))
+            msg = self._connector.get(MessageEndpoints.device_config_request_response(RID))
             if msg is None:
                 time.sleep(0.01)
                 if elapsed_time > timeout:
@@ -292,8 +671,13 @@ class ConfigHelper:
                 continue
             return msg
 
-    def load_demo_config(self):
-        """Load BEC device demo_config.yaml for simulation."""
+    def load_demo_config(self, force: bool = False) -> None:
+        """
+        Load BEC device demo_config.yaml for simulation.
+        Args:
+            force (bool, optional): Force update even if there are conflicts. Defaults to False.
+        Returns: None
+        """
         dir_path = os.path.abspath(os.path.join(os.path.dirname(bec_lib.__file__), "./configs/"))
         fpath = os.path.join(dir_path, "demo_config.yaml")
-        self.update_session_with_file(fpath)
+        self.update_session_with_file(fpath, force=force)

--- a/bec_lib/bec_lib/devicemanager.py
+++ b/bec_lib/bec_lib/devicemanager.py
@@ -462,7 +462,9 @@ class DeviceManagerBase:
         self.parent = service  # for backwards compatibility; will be removed in the future
         self.connector = self._service.connector
         self.scan_info = ScanInfo(msg=None)
-        self.config_helper = ConfigHelper(self.connector, self._service._service_name)
+        self.config_helper = ConfigHelper(
+            connector=self.connector, service_name=self._service._service_name
+        )
         self._status_cb = status_cb if isinstance(status_cb, list) else [status_cb]
 
     def initialize(self, bootstrap_server) -> None:

--- a/bec_lib/bec_lib/utils/pydantic_pretty_print.py
+++ b/bec_lib/bec_lib/utils/pydantic_pretty_print.py
@@ -1,0 +1,114 @@
+from pydantic import BaseModel, ValidationError
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+
+def pretty_print_pydantic_validation_error(
+    exc: ValidationError, context: str | None = None, model: type[BaseModel] | None = None
+) -> None:
+    """
+    Pretty print a Pydantic ValidationError using rich formatting.
+
+    Args:
+        exc (ValidationError): The Pydantic ValidationError to pretty print.
+        context (str | None): Context or description of where the error occurred.
+        model (type[BaseModel] | None): The Pydantic model that raised the ValidationError.
+    """
+
+    if context is None and hasattr(exc, "context"):
+        context = exc.context  # type: ignore
+    if model is None and hasattr(exc, "model"):
+        model = exc.model  # type: ignore
+
+    console = Console()
+
+    # Create the main table
+    table = Table(
+        title="[bold red]Validation Errors[/bold red]",
+        show_header=True,
+        header_style="bold cyan",
+        border_style="red",
+        title_style="bold red",
+    )
+
+    table.add_column("Field", style="yellow", no_wrap=False)
+    table.add_column("Error Type", style="magenta")
+    table.add_column("Message", style="white")
+    table.add_column("Input", style="dim")
+
+    # Process each error
+    for error in exc.errors():
+        # Format the location (field path)
+        field_parts = []
+        for loc in error.get("loc", []):
+            field_parts.append(str(loc))
+        field = " → ".join(field_parts) if field_parts else "[root]"
+
+        # Get error type
+        error_type = error.get("type", "unknown")
+
+        # Get the message
+        message = error.get("msg", "No message provided")
+
+        # For missing fields, enhance the message with the expected type from the model
+        if error_type == "missing" and model is not None:
+            # Get the field info from the model
+            field_name = error.get("loc", [])[-1] if error.get("loc") else None
+            if field_name and hasattr(model, "model_fields"):
+                field_info = model.model_fields.get(field_name)
+                if field_info:
+                    field_type = field_info.annotation
+                    # Get a readable type name
+                    type_name = getattr(field_type, "__name__", str(field_type))
+                    message = f"{message} (expected type: {type_name})"
+
+        # Get the input value (if available)
+        # For missing fields, don't show the entire parent object
+        if error_type == "missing":
+            input_str = "[dim italic]missing[/dim italic]"
+        else:
+            input_value = error.get("input", "")
+            if input_value == "":
+                input_str = "[dim italic]N/A[/dim italic]"
+            else:
+                # Truncate long inputs
+                input_str = str(input_value)
+                if len(input_str) > 50:
+                    input_str = input_str[:47] + "..."
+
+        # Add row to table
+        table.add_row(field, error_type, message, input_str)
+
+    # Create a summary text
+    error_count = exc.error_count()
+    summary = Text()
+    summary.append(f"Found ", style="white")
+    summary.append(f"{error_count}", style="bold red")
+    summary.append(f" validation error{'s' if error_count != 1 else ''}", style="white")
+    if context:
+        summary.append(f" in {context}", style="white")
+
+    # Print everything
+    console.print()
+    console.print(Panel(summary, border_style="red", padding=(0, 2)))
+    console.print(table)
+    console.print()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    # Example usage
+    from pydantic import BaseModel, Field
+
+    class ExampleModel(BaseModel):
+        name: str = Field(..., min_length=3)
+        age: int = Field(..., ge=0)
+        email: str
+
+    try:
+        ExampleModel(name="Jo", age=-5)
+    except ValidationError as ve:
+        pretty_print_pydantic_validation_error(
+            ve, context="samx device configuration", model=ExampleModel
+        )

--- a/bec_lib/tests/test_config_helper.py
+++ b/bec_lib/tests/test_config_helper.py
@@ -13,45 +13,56 @@ from bec_lib.service_config import ServiceConfigModel
 
 dir_path = os.path.dirname(bec_lib.__file__)
 
+# pylint: disable=protected-access
 
-def test_load_demo_config():
+
+@pytest.fixture
+def config_helper_plain():
     connector = mock.MagicMock()
-    config_helper = ConfigHelper(connector)
+    config_helper_inst = ConfigHelper(connector)
+    yield config_helper_inst
+
+
+@pytest.fixture
+def config_helper(config_helper_plain):
+    config_helper_inst = config_helper_plain
+    with mock.patch.object(config_helper_inst, "wait_for_config_reply"):
+        with mock.patch.object(config_helper_inst, "wait_for_service_response"):
+            yield config_helper_inst
+
+
+def test_load_demo_config(config_helper):
     with mock.patch.object(config_helper, "update_session_with_file") as mock_update:
         config_helper.load_demo_config()
         dirpath = os.path.dirname(bec_lib.__file__)
         fpath = os.path.join(dirpath, "configs/demo_config.yaml")
-        mock_update.assert_called_once_with(fpath)
+        mock_update.assert_called_once_with(fpath, force=False)
 
 
-def test_config_helper_update_session_with_file():
-    connector = mock.MagicMock()
-    config_helper = ConfigHelper(connector)
+def test_config_helper_update_session_with_file(config_helper):
     with mock.patch.object(config_helper, "send_config_request") as mock_send_config_request:
         with mock.patch.object(
             config_helper, "_load_config_from_file"
         ) as mock_load_config_from_file:
             mock_load_config_from_file.return_value = {"test": "test"}
             config_helper._base_path_recovery = "."
+            config_helper._writer_mixin = mock.MagicMock()
             config_helper.update_session_with_file("test.yaml")
             mock_send_config_request.assert_called_once_with(action="set", config={"test": "test"})
 
 
 @pytest.mark.parametrize("config_file", ["test.yaml", "test.yml"])
-def test_config_helper_load_config_from_file(tmp_path, test_config_yaml_file_path, config_file):
+def test_config_helper_load_config_from_file(
+    config_helper, tmp_path, test_config_yaml_file_path, config_file
+):
     orig_cfg_file = test_config_yaml_file_path
     test_cfg_file = tmp_path / config_file
     shutil.copyfile(orig_cfg_file, test_cfg_file)
-    connector = mock.MagicMock()
-    config_helper = ConfigHelper(connector)
-    config = config_helper._load_config_from_file(test_cfg_file)
+    config_helper._load_config_from_file(test_cfg_file)
 
 
-def test_config_helper_save_current_session():
-    connector = mock.MagicMock()
-
-    config_helper = ConfigHelper(connector)
-    connector.get.return_value = messages.AvailableResourceMessage(
+def test_config_helper_save_current_session(config_helper):
+    config_helper._connector.get.return_value = messages.AvailableResourceMessage(
         resource=[
             {
                 "id": "648c817f67d3c7cd6a354e8e",
@@ -122,15 +133,6 @@ def test_config_helper_save_current_session():
         mock_open().write.assert_called_once_with(yaml.dump(out_data))
 
 
-@pytest.fixture
-def config_helper():
-    connector = mock.MagicMock()
-    config_helper_inst = ConfigHelper(connector)
-    with mock.patch.object(config_helper_inst, "wait_for_config_reply"):
-        with mock.patch.object(config_helper_inst, "wait_for_service_response"):
-            yield config_helper_inst
-
-
 def test_send_config_request_raises_with_empty_config(config_helper):
     with pytest.raises(DeviceConfigError):
         config_helper.send_config_request(action="update")
@@ -155,30 +157,24 @@ def test_send_config_request_raises_for_rejected_update(config_helper):
         config_helper.wait_for_config_reply.assert_called_once_with(mock.ANY)
 
 
-def test_wait_for_config_reply():
-    connector = mock.MagicMock()
-    config_helper = ConfigHelper(connector)
-    connector.get.return_value = messages.RequestResponseMessage(
+def test_wait_for_config_reply(config_helper_plain):
+    config_helper_plain._connector.get.return_value = messages.RequestResponseMessage(
         accepted=True, message={"msg": "test"}
     )
 
-    res = config_helper.wait_for_config_reply("test")
+    res = config_helper_plain.wait_for_config_reply("test")
     assert res == messages.RequestResponseMessage(accepted=True, message={"msg": "test"})
 
 
-def test_wait_for_config_raises_timeout():
-    connector = mock.MagicMock()
-    config_helper = ConfigHelper(connector)
-    connector.get.return_value = None
+def test_wait_for_config_raises_timeout(config_helper_plain):
+    config_helper_plain._connector.get.return_value = None
 
     with pytest.raises(DeviceConfigError):
-        config_helper.wait_for_config_reply("test", timeout=0.3)
+        config_helper_plain.wait_for_config_reply("test", timeout=0.3)
 
 
-def test_wait_for_service_response():
-    connector = mock.MagicMock()
-    config_helper = ConfigHelper(connector)
-    connector.lrange.side_effect = [
+def test_wait_for_service_response(config_helper):
+    config_helper._connector.lrange.side_effect = [
         [],
         [
             messages.ServiceResponseMessage(
@@ -193,23 +189,22 @@ def test_wait_for_service_response():
     config_helper.wait_for_service_response("test", timeout=0.3)
 
 
-def test_wait_for_service_response_raises_timeout():
-    connector = mock.MagicMock()
-    config_helper = ConfigHelper(connector)
-    connector.lrange.return_value = []
+def test_wait_for_service_response_raises_timeout(config_helper_plain):
+    config_helper = config_helper_plain
+    config_helper._connector.lrange.return_value = []
 
     with pytest.raises(DeviceConfigError):
         config_helper.wait_for_service_response("test", timeout=0.3)
 
 
-def test_wait_for_service_response_handles_one_by_one():
+def test_wait_for_service_response_handles_one_by_one(config_helper_plain):
     mock_msg_1, mock_msg_2, mock_msg_3 = mock.MagicMock(), mock.MagicMock(), mock.MagicMock()
     mock_msg_1.content = {"response": {"service": "DeviceServer"}}
     mock_msg_2.content = {"response": {"service": "ScanServer"}}
     mock_msg_3.content = {"response": {"service": "ServiceName123"}}
 
-    connector = mock.MagicMock()
-    config_helper = ConfigHelper(connector)
+    config_helper = config_helper_plain
+    connector = config_helper._connector
     config_helper._service_name = "ServiceName123"
     connector.lrange = mock.MagicMock(
         side_effect=[(mock_msg_1,), (mock_msg_1, mock_msg_2), (mock_msg_1, mock_msg_2, mock_msg_3)]
@@ -218,13 +213,12 @@ def test_wait_for_service_response_handles_one_by_one():
     config_helper.wait_for_service_response("test", timeout=0.3)
 
 
-def test_update_base_path_recovery():
+def test_update_base_path_recovery(config_helper_plain):
     with mock.patch("bec_lib.bec_service.SERVICE_CONFIG") as mock_service_config:
         with mock.patch("bec_lib.config_helper.DeviceConfigWriter") as mock_device_config_writer:
             config = ServiceConfigModel(**{"log_writer": {"base_path": "./"}}).model_dump()
             mock_service_config.config = config
-            connector = mock.MagicMock()
-            config_helper = ConfigHelper(connector)
+            config_helper = config_helper_plain
             dir_path = os.path.join(
                 config["log_writer"]["base_path"], "device_configs/recovery_configs"
             )
@@ -235,3 +229,301 @@ def test_update_base_path_recovery():
             mock_service_config.config = {}
             with pytest.raises(ServiceConfigError):
                 config_helper._update_base_path_recovery()
+
+
+@pytest.mark.parametrize(
+    "new_config, current_config, expected_conflicts",
+    [
+        (
+            {
+                "pinz": {
+                    "deviceClass": "SimPositioner",
+                    "deviceTags": {"user motors"},
+                    "enabled": True,
+                    "readOnly": False,
+                    "deviceConfig": {
+                        "delay": 1,
+                        "labels": "pinz",
+                        "limits": [-50, 50],
+                        "name": "pinz",
+                        "tolerance": 0.01,
+                        "update_frequency": 400,
+                    },
+                    "readoutPriority": "baseline",
+                    "onFailure": "retry",
+                },
+                "transd": {
+                    "deviceClass": "SimMonitor",
+                    "deviceTags": {"beamline"},
+                    "enabled": True,
+                    "readOnly": False,
+                    "deviceConfig": {"labels": "transd", "name": "transd", "tolerance": 0.5},
+                    "readoutPriority": "monitored",
+                    "onFailure": "retry",
+                },
+            },
+            {
+                "pinz": {
+                    "deviceClass": "SimPositioner",
+                    "deviceTags": {"user motors"},
+                    "enabled": True,
+                    "readOnly": True,
+                    "deviceConfig": {
+                        "delay": 1,
+                        "labels": "pinz",
+                        "limits": [-50, 50],
+                        "name": "pinz",
+                        "tolerance": 0.01,
+                        "update_frequency": 400,
+                    },
+                    "readoutPriority": "baseline",
+                    "onFailure": "retry",
+                },
+                "transd": {
+                    "deviceClass": "SimMonitor",
+                    "deviceTags": {"beamline"},
+                    "enabled": True,
+                    "readOnly": False,
+                    "deviceConfig": {"labels": "transd", "name": "transd", "tolerance": 0.5},
+                    "readoutPriority": "monitored",
+                    "onFailure": "retry",
+                },
+            },
+            {"pinz": {"readOnly": {"new": False, "current": True}}},
+        ),
+        (
+            {
+                "pinz": {
+                    "deviceClass": "SimPositioner",
+                    "deviceTags": {"user motors"},
+                    "enabled": True,
+                    "readOnly": False,
+                    "deviceConfig": {
+                        "delay": 1,
+                        "labels": "pinz",
+                        "limits": [-50, 50],
+                        "name": "pinz",
+                        "tolerance": 0.01,
+                        "update_frequency": 400,
+                    },
+                    "readoutPriority": "baseline",
+                    "onFailure": "retry",
+                },
+                "transd": {
+                    "deviceClass": "SimMonitor",
+                    "deviceTags": {"beamline"},
+                    "enabled": True,
+                    "readOnly": False,
+                    "deviceConfig": {"labels": "transd", "name": "transd", "tolerance": 0.5},
+                    "readoutPriority": "monitored",
+                    "onFailure": "retry",
+                },
+            },
+            {
+                "pinz": {
+                    "deviceClass": "SimPositioner",
+                    "deviceTags": {"user motors"},
+                    "enabled": True,
+                    "readOnly": False,
+                    "deviceConfig": {
+                        "delay": 1,
+                        "labels": "pinz",
+                        "limits": [-20, 20],
+                        "name": "pinz",
+                        "tolerance": 0.01,
+                        "update_frequency": 400,
+                    },
+                    "readoutPriority": "baseline",
+                    "onFailure": "retry",
+                },
+                "transd": {
+                    "deviceClass": "SimMonitor",
+                    "deviceTags": {"beamline"},
+                    "enabled": True,
+                    "readOnly": False,
+                    "deviceConfig": {"labels": "transd", "name": "transd", "tolerance": 0.5},
+                    "readoutPriority": "monitored",
+                    "onFailure": "retry",
+                },
+            },
+            {"pinz": {"deviceConfig": {"limits": {"new": [-50, 50], "current": [-20, 20]}}}},
+        ),
+        (
+            {
+                "pinz": {
+                    "deviceClass": "SimPositioner",
+                    "deviceTags": {"user motors"},
+                    "enabled": True,
+                    "readOnly": False,
+                    "deviceConfig": {
+                        "delay": 1,
+                        "labels": "pinz",
+                        "limits": [-50, 50],
+                        "name": "pinz",
+                        "tolerance": 0.01,
+                        "update_frequency": 400,
+                    },
+                    "readoutPriority": "baseline",
+                    "onFailure": "retry",
+                },
+                "transd": {
+                    "deviceClass": "SimMonitor",
+                    "deviceTags": {"beamline"},
+                    "enabled": True,
+                    "readOnly": False,
+                    "deviceConfig": {"labels": "transd", "name": "transd", "tolerance": 0.5},
+                    "readoutPriority": "monitored",
+                    "onFailure": "retry",
+                },
+            },
+            {
+                "pinz": {
+                    "deviceClass": "SimPositioner",
+                    "deviceTags": {"user motors"},
+                    "enabled": True,
+                    "readOnly": False,
+                    "deviceConfig": {
+                        "delay": 1,
+                        "labels": "pinz",
+                        "limits": [-50, 50],
+                        "name": "pinz",
+                        "tolerance": 0.01,
+                        "update_frequency": 400,
+                    },
+                    "readoutPriority": "baseline",
+                    "onFailure": "retry",
+                },
+                "transd": {
+                    "deviceClass": "SimMonitor",
+                    "deviceTags": {"beamline"},
+                    "enabled": True,
+                    "readOnly": False,
+                    "deviceConfig": {"labels": "transd", "name": "transd", "tolerance": 0.5},
+                    "readoutPriority": "monitored",
+                    "onFailure": "retry",
+                    "userParameter": {"in": 123},
+                },
+            },
+            {"transd": {"userParameter": {"in": {"new": None, "current": 123}}}},
+        ),
+    ],
+)
+def test_config_helper_get_config_conflicts(
+    config_helper, new_config, current_config, expected_conflicts
+):
+
+    config_in_redis = []
+    for dev_name, dev_cfg in current_config.items():
+        config = {}
+        config["name"] = dev_cfg.pop("name", dev_name)
+        config.update(dev_cfg)
+        config_in_redis.append(config)
+    config_helper._connector.get.return_value = messages.AvailableResourceMessage(
+        resource=config_in_redis
+    )
+    conflicts = config_helper._get_config_conflicts(new_config)
+    assert conflicts == expected_conflicts
+
+
+def test_format_value_for_display(config_helper):
+    """Test value formatting for display in conflict resolution."""
+    # Test None
+    assert config_helper._format_value_for_display(None) == "None"
+
+    # Test list (should be single line)
+    result = config_helper._format_value_for_display([1, 2, 3])
+    assert "\n" not in result
+    assert "1" in result and "2" in result and "3" in result
+
+    # Test dict (can be multi-line)
+    result = config_helper._format_value_for_display({"key": "value"})
+    assert "key" in result and "value" in result
+
+    # Test set
+    result = config_helper._format_value_for_display({"a", "b"})
+    assert "\n" not in result
+
+    # Test string
+    assert config_helper._format_value_for_display("test") == "test"
+
+
+def test_apply_config_value_simple(config_helper):
+    """Test applying a simple config value."""
+    config = {}
+    config_helper._apply_config_value(config, "device1", "enabled", None, True)
+    assert config == {"device1": {"enabled": True}}
+
+
+def test_apply_config_value_nested(config_helper):
+    """Test applying a nested config value."""
+    config = {}
+    config_helper._apply_config_value(config, "device1", "deviceConfig", "timeout", 30)
+    assert config == {"device1": {"deviceConfig": {"timeout": 30}}}
+
+    # Add another nested value to same device
+    config_helper._apply_config_value(config, "device1", "deviceConfig", "delay", 5)
+    assert config == {"device1": {"deviceConfig": {"timeout": 30, "delay": 5}}}
+
+
+def test_apply_all_current_values(config_helper):
+    """Test applying all current values for conflicts."""
+    config = {
+        "device1": {"enabled": True, "deviceConfig": {"timeout": 30}},
+        "device2": {"readOnly": False},
+    }
+
+    conflicts = {
+        "device1": {
+            "enabled": {"new": True, "current": False},
+            "deviceConfig": {
+                "timeout": {"new": 30, "current": 60},
+                "delay": {"new": 5, "current": 10},
+            },
+        },
+        "device2": {"readOnly": {"new": False, "current": True}},
+    }
+
+    config_helper._apply_all_current_values(config, conflicts)
+
+    # All values should now be the "current" values
+    assert config["device1"]["enabled"] is False
+    assert config["device1"]["deviceConfig"]["timeout"] == 60
+    assert config["device1"]["deviceConfig"]["delay"] == 10
+    assert config["device2"]["readOnly"] is True
+
+
+def test_merge_conflicts_accept_all(config_helper):
+    """Test accepting all new values in conflict resolution."""
+    config = {"device1": {"enabled": True}}
+    conflicts = {"device1": {"enabled": {"new": True, "current": False}}}
+
+    with mock.patch("bec_lib.config_helper.Prompt.ask", return_value="a"):
+        config_helper._merge_conflicts_with_user_input(config, conflicts)
+
+    # Config should still have new value (no changes needed)
+    assert config["device1"]["enabled"] is True
+
+
+def test_merge_conflicts_keep_all(config_helper):
+    """Test keeping all current values in conflict resolution."""
+    config = {"device1": {"enabled": True}}
+    conflicts = {"device1": {"enabled": {"new": True, "current": False}}}
+
+    with mock.patch("bec_lib.config_helper.Prompt.ask", return_value="k"):
+        config_helper._merge_conflicts_with_user_input(config, conflicts)
+
+    # Config should now have current value
+    assert config["device1"]["enabled"] is False
+
+
+def test_merge_conflicts_individual_resolution(config_helper):
+    """Test individual conflict resolution."""
+    config = {"device1": {"enabled": True}}
+    conflicts = {"device1": {"enabled": {"new": True, "current": False}}}
+
+    # Mock: first prompt returns "r" for individual, second returns "k" to keep current
+    with mock.patch("bec_lib.config_helper.Prompt.ask", side_effect=["r", "k"]):
+        config_helper._merge_conflicts_with_user_input(config, conflicts)
+
+    # Config should have current value after individual resolution
+    assert config["device1"]["enabled"] is False

--- a/bec_lib/tests/test_pydantic_pretty_print.py
+++ b/bec_lib/tests/test_pydantic_pretty_print.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel, ValidationError
+
+from bec_lib.utils.pydantic_pretty_print import pretty_print_pydantic_validation_error
+
+
+def test_pretty_print_pydantic_validation_error(capsys):
+    from pydantic import Field
+
+    class TestModel(BaseModel):
+        name: str = Field(..., min_length=3)
+        age: int = Field(..., ge=0)
+        email: str
+
+    try:
+        TestModel(name="Jo", age=-5)  # type: ignore
+    except ValidationError as ve:
+        pretty_print_pydantic_validation_error(ve, context="test model", model=TestModel)
+    captured = capsys.readouterr()
+    assert "Found 3 validation errors in test model" in captured.out
+    assert "string_too_short" in captured.out
+    assert "String should have at least 3" in captured.out
+    assert "missing" in captured.out
+    assert "expected type: str" in captured.out

--- a/pytest_bec_e2e/pytest_bec_e2e/plugin.py
+++ b/pytest_bec_e2e/pytest_bec_e2e/plugin.py
@@ -217,7 +217,7 @@ def bec_ipython_client_with_demo_config(
     config = ServiceConfig(bec_services_config_file_path)
     bec = BECIPythonClient(config, RedisConnector, forced=True)
     bec.start()
-    bec.config.load_demo_config()
+    bec.config.load_demo_config(force=True)
     try:
         yield bec
     finally:
@@ -230,7 +230,7 @@ def bec_client_lib_with_demo_config(bec_redis_fixture, bec_services_config_file_
     config = ServiceConfig(bec_services_config_file_path)
     bec = BECClient(config, RedisConnector, forced=True, wait_for_server=True)
     bec.start()
-    bec.config.load_demo_config()
+    bec.config.load_demo_config(force=True)
     try:
         yield bec
     finally:


### PR DESCRIPTION
This PR adds the option to resolve conflicts between session and file config before uploading the file config. 

It also moves a few members of the ConfigHelper class from public to private as they are only used internally. To avoid the exposure of the developer api to users, a wrapper was introduced: ConfigHelperUsers. It receives the config helper instance and only exposes a few methods that CLI users should call. 

<img width="1182" height="536" alt="image" src="https://github.com/user-attachments/assets/652dafa9-2fa6-4524-9bc6-565001d66ea4" />

To improve the error message report for pydantic validation errors, a utility function has been added: pretty_print_pydantic_validation_error. It receives the pydantic model, the exception and potentially an additional string for providing better context. 

<img width="637" height="162" alt="image" src="https://github.com/user-attachments/assets/177f5e20-a01a-40b7-97ab-89f7172384ee" />


closes #684 


