### PR TITLE
fix(atlas): use proper endpoints to avoid deprecation warnings

### DIFF
--- a/bec_lib/bec_lib/endpoints.py
+++ b/bec_lib/bec_lib/endpoints.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import enum
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from bec_lib.utils.import_utils import lazy_import
 
@@ -1729,4 +1729,43 @@ class MessageEndpoints:
         endpoint = f"{EndpointType.INTERNAL.value}/deployment/{deployment_name}/request"
         return EndpointInfo(
             endpoint=endpoint, message_type=messages.RawMessage, message_op=MessageOp.SET_PUBLISH
+        )
+
+    @staticmethod
+    def atlas_deployment_ingest(deployment_name: str):
+        """
+        Endpoint for ingesting data from a particular deployment.
+
+        Returns:
+            EndpointInfo: Endpoint for deployment ingest.
+        """
+        endpoint = f"{EndpointType.INTERNAL.value}/deployment/{deployment_name}/ingest"
+        return EndpointInfo(endpoint=endpoint, message_type=Any, message_op=MessageOp.STREAM)
+
+    @staticmethod
+    def atlas_deployment_data(deployment_name: str, endpoint_suffix: str):
+        """
+        Endpoint for forwarding deployment data to Atlas.
+
+        Returns:
+            EndpointInfo: Endpoint for deployment data.
+        """
+        endpoint = (
+            f"{EndpointType.INTERNAL.value}/deployment/{deployment_name}/data/{endpoint_suffix}"
+        )
+        return EndpointInfo(endpoint=endpoint, message_type=Any, message_op=MessageOp.STREAM)
+
+    @staticmethod
+    def atlas_deployment_info(deployment_name: str):
+        """
+        Endpoint for deployment info updates.
+
+        Returns:
+            EndpointInfo: Endpoint for deployment info.
+        """
+        endpoint = f"{EndpointType.INTERNAL.value}/deployment/{deployment_name}/deployment_info"
+        return EndpointInfo(
+            endpoint=endpoint,
+            message_type=messages.VariableMessage,
+            message_op=MessageOp.SET_PUBLISH,
         )

--- a/bec_server/bec_server/scihub/atlas/atlas_connector.py
+++ b/bec_server/bec_server/scihub/atlas/atlas_connector.py
@@ -95,7 +95,7 @@ class AtlasConnector:
             return
 
         self.redis_atlas.xadd(
-            f"internal/deployment/{self.deployment_name}/ingest", data, max_size=1000
+            MessageEndpoints.atlas_deployment_ingest(self.deployment_name), data, max_size=1000
         )
 
     def update_acls(self):

--- a/bec_server/bec_server/scihub/atlas/atlas_forwarder.py
+++ b/bec_server/bec_server/scihub/atlas/atlas_forwarder.py
@@ -125,7 +125,9 @@ class AtlasForwarder:
         else:
             data = msg
         parent.atlas_connector.redis_atlas.xadd(
-            f"internal/deployment/{parent.atlas_connector.deployment_name}/data/{endpoint}",
+            MessageEndpoints.atlas_deployment_data(
+                parent.atlas_connector.deployment_name, endpoint
+            ),
             data if isinstance(data, dict) else {"pubsub_data": data},
             max_size=10,
             expire=60,

--- a/bec_server/bec_server/scihub/atlas/atlas_metadata_handler.py
+++ b/bec_server/bec_server/scihub/atlas/atlas_metadata_handler.py
@@ -37,7 +37,7 @@ class AtlasMetadataHandler:
             MessageEndpoints.account(), cb=self._handle_account_info, parent=self, from_start=True
         )
         self.atlas_connector.redis_atlas.register(
-            f"internal/deployment/{self.atlas_connector.deployment_name}/deployment_info",
+            MessageEndpoints.atlas_deployment_info(self.atlas_connector.deployment_name),
             cb=self._handle_atlas_account_update,
             parent=self,
             from_start=True,

--- a/bec_server/tests/tests_scihub/test_atlas_connector.py
+++ b/bec_server/tests/tests_scihub/test_atlas_connector.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from bec_lib import messages
+from bec_lib.endpoints import MessageEndpoints
 from bec_server.scihub.atlas.atlas_connector import AtlasConnector
 
 
@@ -43,7 +44,9 @@ def test_atlas_connector_ingest_data(atlas_connector):
     with mock.patch.object(atlas_connector.redis_atlas, "xadd") as mock_xadd:
         atlas_connector.ingest_data({"data": "dummy_data"})
         mock_xadd.assert_called_once_with(
-            "internal/deployment/test-deployment/ingest", {"data": "dummy_data"}, max_size=1000
+            MessageEndpoints.atlas_deployment_ingest(atlas_connector.deployment_name),
+            {"data": "dummy_data"},
+            max_size=1000,
         )
 
 


### PR DESCRIPTION
Moving hard-coded topic strings to proper endpoints