### PR TITLE
fix(macro update handler): ensure user macros are in sync with builtins

### DIFF
--- a/bec_lib/tests/test_user_macros.py
+++ b/bec_lib/tests/test_user_macros.py
@@ -1,4 +1,3 @@
-import builtins
 from unittest import mock
 
 import pytest
@@ -23,15 +22,28 @@ def dummy_func2():
     pass
 
 
+class MockBuiltins:
+    def __init__(self, *args, **kwargs):
+        self.__dict__ = {}
+
+    def __contains__(self, item):
+        return item in self.__dict__
+
+
 @pytest.fixture
-def macros():
-    yield UserMacros(mock.MagicMock())
+def user_macros():
+    with mock.patch("bec_lib.macro_update_handler.builtins", new_callable=MockBuiltins) as builtins:
+        macros = UserMacros(mock.MagicMock())
+        macros.forget_all_user_macros()
+        yield macros, builtins
+        macros.forget_all_user_macros()
 
 
-def test_user_macros_forget(macros):
+def test_user_macros_forget(user_macros):
+    macros, builtins = user_macros
     mock_run = macros._client.callbacks.run
-    macros._update_handler.macros = {"test": {"cls": dummy_func, "file": "path_to_my_file.py"}}
-    builtins.test = dummy_func
+
+    macros._update_handler._add_macro("test", {"cls": dummy_func, "file": "path_to_my_file.py"})
     macros.forget_all_user_macros()
     assert mock_run.call_count == 1
     assert mock_run.call_args == mock.call(
@@ -41,10 +53,10 @@ def test_user_macros_forget(macros):
     assert len(macros._update_handler.macros) == 0
 
 
-def test_user_macro_forget(macros):
+def test_user_macro_forget(user_macros):
+    macros, builtins = user_macros
     mock_run = macros._client.callbacks.run
-    macros._update_handler.macros = {"test": {"cls": dummy_func, "file": "path_to_my_file.py"}}
-    builtins.test = dummy_func
+    macros._update_handler._add_macro("test", {"cls": dummy_func, "file": "path_to_my_file.py"})
     macros.forget_user_macro("test")
     assert mock_run.call_count == 1
     assert mock_run.call_args == mock.call(
@@ -53,9 +65,10 @@ def test_user_macro_forget(macros):
     assert "test" not in builtins.__dict__
 
 
-def test_load_user_macro(macros):
+def test_load_user_macro(user_macros):
+    macros, _ = user_macros
     mock_run = macros._client.callbacks.run
-    builtins.__dict__["dev"] = macros
+    mock_run.reset_mock()
     dummy_func.__module__ = "macros_dummy_file"
     with mock.patch.object(
         macros._update_handler,
@@ -73,8 +86,9 @@ def test_load_user_macro(macros):
         assert "wrong_test" not in macros._update_handler.macros
 
 
-def test_user_macros_with_executable_code(macros, tmpdir):
+def test_user_macros_with_executable_code(user_macros, tmpdir):
     """Test that user macros with executable code are not loaded."""
+    macros, _ = user_macros
     macro_file = tmpdir.join("macro_with_code.py")
     macro_file.write("print('This should not run')\n\ndef my_macro(): pass")
 
@@ -92,8 +106,9 @@ def test_user_macros_with_executable_code(macros, tmpdir):
     assert mock_run.call_count == 0
 
 
-def test_user_macros_with_safe_code(macros, tmpdir):
+def test_user_macros_with_safe_code(user_macros, tmpdir):
     """Test that user macros with only imports, functions, and classes are loaded correctly."""
+    macros, _ = user_macros
     macro_file = tmpdir.join("safe_macro.py")
     macro_file.write(
         """
@@ -141,8 +156,9 @@ class MyClass:
     assert macros._update_handler.macros["MyClass"]["cls"]().value == 42
 
 
-def test_on_macro_update_add_case(macros, tmpdir):
+def test_on_macro_update_add_case(user_macros, tmpdir):
     """Test on_macro_update with 'add' action."""
+    macros, _ = user_macros
     # Create a test macro file
     macro_file = tmpdir.join("test_add_macro.py")
     macro_file.write("def test_add_function(): return 'added'")
@@ -158,8 +174,9 @@ def test_on_macro_update_add_case(macros, tmpdir):
         mock_load.assert_called_once_with(str(macro_file), ignore_existing=True)
 
 
-def test_on_macro_update_remove_case(macros):
+def test_on_macro_update_remove_case(user_macros):
     """Test on_macro_update with 'remove' action."""
+    macros, _ = user_macros
     # Mock the forget_user_macro method
     with mock.patch.object(macros._update_handler, "forget_user_macro") as mock_forget:
         msg = messages.MacroUpdateMessage(update_type="remove", macro_name="test_macro")
@@ -169,8 +186,9 @@ def test_on_macro_update_remove_case(macros):
         mock_forget.assert_called_once_with("test_macro")
 
 
-def test_on_macro_update_reload_case(macros, tmpdir):
+def test_on_macro_update_reload_case(user_macros, tmpdir):
     """Test on_macro_update with 'reload' action."""
+    macros, _ = user_macros
     # Create a test macro file
     macro_file = tmpdir.join("test_reload_macro.py")
     macro_file.write("def test_reload_function(): return 'reloaded'")
@@ -187,8 +205,9 @@ def test_on_macro_update_reload_case(macros, tmpdir):
         mock_reload.assert_called_once_with("test_macro", str(macro_file))
 
 
-def test_on_macro_update_reload_all_case(macros):
+def test_on_macro_update_reload_all_case(user_macros):
     """Test on_macro_update with 'reload_all' action."""
+    macros, _ = user_macros
     # Mock the load_all_user_macros method
     with mock.patch.object(macros._update_handler, "load_all_user_macros") as mock_load_all:
         msg = messages.MacroUpdateMessage(update_type="reload_all")
@@ -198,8 +217,9 @@ def test_on_macro_update_reload_all_case(macros):
         mock_load_all.assert_called_once()
 
 
-def test_on_macro_update_unknown_type(macros):
+def test_on_macro_update_unknown_type(user_macros):
     """Test on_macro_update with unknown update_type."""
+    macros, _ = user_macros
     # Mock the logger
     with mock.patch("bec_lib.macro_update_handler.logger.error") as mock_logger:
         # Create a message with an invalid update_type by bypassing validation
@@ -212,8 +232,9 @@ def test_on_macro_update_unknown_type(macros):
         mock_logger.assert_called_once_with("Unknown macro update type: unknown_action")
 
 
-def test_on_macro_update_with_complete_message_fields(macros, tmpdir):
+def test_on_macro_update_with_complete_message_fields(user_macros, tmpdir):
     """Test on_macro_update with all message fields populated."""
+    macros, _ = user_macros
     macro_file = tmpdir.join("complete_test_macro.py")
     macro_file.write("def complete_function(): return 'complete'")
 
@@ -230,8 +251,9 @@ def test_on_macro_update_with_complete_message_fields(macros, tmpdir):
         mock_load.assert_called_once_with(str(macro_file), ignore_existing=True)
 
 
-def test_on_macro_update_integration_with_real_message(macros, tmpdir):
+def test_on_macro_update_integration_with_real_message(user_macros, tmpdir):
     """Test on_macro_update integration with actual MacroUpdateMessage instance."""
+    macros, _ = user_macros
     # Test with a real MacroUpdateMessage instance
     macro_file = tmpdir.join("integration_macro.py")
     macro_file.write(
@@ -243,13 +265,10 @@ def integration_test():
     )
 
     # Add a mock macro to the handler first
-    macros._update_handler.macros = {
-        "existing_macro": {
-            "cls": dummy_func,
-            "fname": "/some/path.py",
-            "source": "def dummy_func(): pass",
-        }
-    }
+    macros._update_handler._add_macro(
+        "existing_macro",
+        {"cls": dummy_func, "fname": "/some/path.py", "source": "def dummy_func(): pass"},
+    )
 
     with (
         mock.patch.object(macros._update_handler, "load_user_macro") as mock_load,
@@ -315,8 +334,10 @@ def test_macro_update_message_validation():
         )  # Missing file_path for add action
 
 
-def test_broadcast_method(macros):
+def test_broadcast_method(user_macros):
     """Test the broadcast method sends correct MacroUpdateMessage."""
+
+    macros, _ = user_macros
     # Mock the client connector
     mock_connector = macros._update_handler.client.connector
 
@@ -339,8 +360,10 @@ def test_broadcast_method(macros):
     assert message.file_path == "/path/to/test.py"
 
 
-def test_broadcast_different_actions(macros):
+def test_broadcast_different_actions(user_macros):
     """Test broadcast method with different action types."""
+
+    macros, _ = user_macros
     mock_connector = macros._update_handler.client.connector
 
     # Test remove action
@@ -368,15 +391,23 @@ def test_broadcast_different_actions(macros):
     assert message.file_path is None
 
 
-def test_get_existing_macros_method(macros):
+def test_get_existing_macros_method(user_macros):
     """Test the get_existing_macros method."""
+
+    macros, _ = user_macros
     # Setup test data
-    macros._update_handler.macros = {
-        "macro1": {"cls": dummy_func, "fname": "/path/to/file1.py", "source": "code1"},
-        "macro2": {"cls": dummy_func2, "fname": "/path/to/file2.py", "source": "code2"},
-        "macro3": {"cls": dummy_func, "fname": "/path/to/file1.py", "source": "code3"},
-        "macro4": {"cls": dummy_func2, "fname": "/path/to/file3.py", "source": "code4"},
-    }
+    macros._update_handler._add_macro(
+        "macro1", {"cls": dummy_func, "fname": "/path/to/file1.py", "source": "code1"}
+    )
+    macros._update_handler._add_macro(
+        "macro2", {"cls": dummy_func2, "fname": "/path/to/file2.py", "source": "code2"}
+    )
+    macros._update_handler._add_macro(
+        "macro3", {"cls": dummy_func, "fname": "/path/to/file1.py", "source": "code3"}
+    )
+    macros._update_handler._add_macro(
+        "macro4", {"cls": dummy_func2, "fname": "/path/to/file3.py", "source": "code4"}
+    )
 
     # Test getting macros from file1.py
     result = macros._update_handler.get_existing_macros("/path/to/file1.py")
@@ -396,15 +427,19 @@ def test_get_existing_macros_method(macros):
     assert result == {}
 
 
-def test_get_existing_macros_with_missing_fname(macros):
+def test_get_existing_macros_with_missing_fname(user_macros):
     """Test get_existing_macros with macros that don't have fname attribute."""
+    macros, _ = user_macros
     # Setup test data with some macros missing fname
-    macros._update_handler.macros = {
-        "macro1": {"cls": dummy_func, "fname": "/path/to/file1.py", "source": "code1"},
-        "macro2": {"cls": dummy_func2, "source": "code2"},  # Missing fname
-        "macro3": {"cls": dummy_func, "fname": "/path/to/file1.py", "source": "code3"},
-    }
-
+    macros._update_handler._add_macro(
+        "macro1", {"cls": dummy_func, "fname": "/path/to/file1.py", "source": "code1"}
+    )
+    macros._update_handler._add_macro(
+        "macro2", {"cls": dummy_func2, "source": "code2"}  # Missing fname
+    )
+    macros._update_handler._add_macro(
+        "macro3", {"cls": dummy_func, "fname": "/path/to/file1.py", "source": "code3"}
+    )
     # Should only return macros with matching fname
     result = macros._update_handler.get_existing_macros("/path/to/file1.py")
     expected = {
@@ -414,8 +449,9 @@ def test_get_existing_macros_with_missing_fname(macros):
     assert result == expected
 
 
-def test_macro_update_callback_valid_message(macros):
+def test_macro_update_callback_valid_message(user_macros):
     """Test _macro_update_callback with valid MacroUpdateMessage."""
+    macros, _ = user_macros
     # Create a mock message object
     mock_msg = mock.MagicMock()
     mock_msg.value = messages.MacroUpdateMessage(
@@ -431,8 +467,9 @@ def test_macro_update_callback_valid_message(macros):
         mock_on_update.assert_called_once_with(mock_msg.value)
 
 
-def test_macro_update_callback_invalid_message_type(macros):
+def test_macro_update_callback_invalid_message_type(user_macros):
     """Test _macro_update_callback with invalid message type."""
+    macros, _ = user_macros
     # Create a mock message with wrong type
     mock_msg = mock.MagicMock()
     mock_msg.value = "not_a_macro_update_message"
@@ -449,8 +486,9 @@ def test_macro_update_callback_invalid_message_type(macros):
             mock_on_update.assert_not_called()
 
 
-def test_macro_update_callback_with_different_message_types(macros):
+def test_macro_update_callback_with_different_message_types(user_macros):
     """Test _macro_update_callback with various message types."""
+    macros, _ = user_macros
     with mock.patch("bec_lib.macro_update_handler.logger.error") as mock_logger:
         # Test with None
         mock_msg = mock.MagicMock()
@@ -488,16 +526,14 @@ def test_macro_update_callback_static_method():
     mock_parent.on_macro_update.assert_called_once_with(mock_msg.value)
 
 
-def test_reload_user_macro_basic(macros):
+def test_reload_user_macro_basic(user_macros):
     """Test the basic reload_user_macro functionality."""
+    macros, _ = user_macros
     # Setup - add a macro to the handler
-    macros._update_handler.macros = {
-        "test_macro": {
-            "cls": dummy_func,
-            "fname": "/test/path.py",
-            "source": "def dummy_func(): pass",
-        }
-    }
+    macros._update_handler._add_macro(
+        "test_macro",
+        {"cls": dummy_func, "fname": "/test/path.py", "source": "def dummy_func(): pass"},
+    )
 
     # Mock the methods that reload_user_macro calls
     with (
@@ -513,8 +549,9 @@ def test_reload_user_macro_basic(macros):
         mock_load.assert_called_once_with("/test/path.py", ignore_existing=True)
 
 
-def test_reload_user_macro_with_real_files(macros, tmpdir):
+def test_reload_user_macro_with_real_files(user_macros, tmpdir):
     """Test reload_user_macro with actual file operations."""
+    macros, _ = user_macros
     # Create initial macro file
     macro_file = tmpdir.join("test_reload_macro.py")
     macro_file.write(
@@ -564,8 +601,9 @@ def new_function():
     assert macros._update_handler.macros["new_function"]["cls"]() == "new"
 
 
-def test_reload_user_macro_nonexistent_macro(macros):
+def test_reload_user_macro_nonexistent_macro(user_macros):
     """Test reloading a macro that doesn't exist."""
+    macros, _ = user_macros
     # Mock forget_user_macro to not raise an error (it should handle this gracefully)
     with (
         mock.patch.object(macros._update_handler, "forget_user_macro") as mock_forget,
@@ -580,16 +618,14 @@ def test_reload_user_macro_nonexistent_macro(macros):
         mock_load.assert_called_once_with("/test/path.py", ignore_existing=True)
 
 
-def test_reload_user_macro_error_handling(macros):
+def test_reload_user_macro_error_handling(user_macros):
     """Test reload_user_macro error handling."""
+    macros, _ = user_macros
     # Setup initial macro
-    macros._update_handler.macros = {
-        "test_macro": {
-            "cls": dummy_func,
-            "fname": "/test/path.py",
-            "source": "def dummy_func(): pass",
-        }
-    }
+    macros._update_handler._add_macro(
+        "test_macro",
+        {"cls": dummy_func, "fname": "/test/path.py", "source": "def dummy_func(): pass"},
+    )
 
     # Mock forget_user_macro to raise an exception
     with mock.patch.object(
@@ -601,8 +637,9 @@ def test_reload_user_macro_error_handling(macros):
         mock_forget.assert_called_once_with("test_macro")
 
 
-def test_reload_user_macro_integration_with_callbacks(macros, tmpdir):
+def test_reload_user_macro_integration_with_callbacks(user_macros, tmpdir):
     """Test that reload_user_macro properly triggers callbacks."""
+    macros, _ = user_macros
     macro_file = tmpdir.join("callback_test_macro.py")
     macro_file.write(
         """
@@ -644,8 +681,9 @@ def callback_test():
     assert "callback_test" in add_call[1]["ns_objects"]
 
 
-def test_on_macro_update_reload_case_updated(macros, tmpdir):
+def test_on_macro_update_reload_case_updated(user_macros, tmpdir):
     """Test the updated on_macro_update reload case with new content."""
+    macros, _ = user_macros
     macro_file = tmpdir.join("test_reload_macro.py")
     macro_file.write("def test_reload_function(): return 'reloaded'")
 
@@ -657,8 +695,9 @@ def test_on_macro_update_reload_case_updated(macros, tmpdir):
     assert macros._update_handler.macros["test_reload_function"]["cls"]() == "reloaded_v2"
 
 
-def test_reload_user_macro_with_different_file(macros, tmpdir):
+def test_reload_user_macro_with_different_file(user_macros, tmpdir):
     """Test reloading a macro from a different file."""
+    macros, _ = user_macros
     # Create two different files
     original_file = tmpdir.join("original.py")
     original_file.write("def shared_macro(): return 'original_file'")
@@ -679,8 +718,10 @@ def test_reload_user_macro_with_different_file(macros, tmpdir):
     assert macros._update_handler.macros["shared_macro"]["fname"] == str(new_file)
 
 
-def test_load_macro_overwrite_builtin(macros, tmpdir):
+def test_load_macro_overwrite_builtin(user_macros, tmpdir):
     """Test that loading a macro with the same name as a built-in function is skipped."""
+    macros, builtins = user_macros
+    builtins.__dict__["print"] = print  # Ensure built-in print is present
     macro_file = tmpdir.join("test_macro.py")
     macro_file.write("def print(): return 'This should not overwrite built-in'")
 
@@ -689,11 +730,12 @@ def test_load_macro_overwrite_builtin(macros, tmpdir):
 
     # Verify that the built-in print function was not overwritten
     assert macros._update_handler.macros.get("print") is None
-    assert builtins.print is print  # Ensure built-in print is unchanged
+    assert builtins.__dict__["print"] is print  # Ensure built-in print is unchanged
 
 
-def test_load_all_user_macros_basic(macros, tmpdir, monkeypatch):
+def test_load_all_user_macros_basic(user_macros, tmpdir, monkeypatch):
     """Test the load_all_user_macros method with mocked directories."""
+    macros, builtins = user_macros
     # Create temporary directories and files
     user_macro_dir = tmpdir.mkdir("bec").mkdir("macros")
     config_macro_dir = tmpdir.mkdir("config_macros")


### PR DESCRIPTION
Multiple clients on the same process may run out of sync with their user macros as the list of already loaded macros is kept within the macro instance. This PR fixes it by ensuring that the macros in builtins remain self-descriptive. 