### PR TITLE
fix: improve version output

### DIFF
--- a/bec_ipython_client/bec_ipython_client/main.py
+++ b/bec_ipython_client/bec_ipython_client/main.py
@@ -340,7 +340,6 @@ def main():
     parser = argparse.ArgumentParser(
         prog="BEC IPython client", description="BEC command line interface"
     )
-    parser.add_argument("--version", action="store_true", default=False)
     parser.add_argument("--nogui", action="store_true", default=False)
     parser.add_argument(
         "--gui-id",
@@ -359,10 +358,6 @@ def main():
 
     # remove already parsed args from command line args
     sys.argv = sys.argv[:1] + left_args
-
-    if args.version:
-        print(f"BEC IPython client: {version('bec_ipython_client')}")
-        sys.exit(0)
 
     if available_plugins and config.is_default():
         # check if config is defined in a plugin;

--- a/bec_lib/bec_lib/_print_versions.py
+++ b/bec_lib/bec_lib/_print_versions.py
@@ -1,0 +1,24 @@
+import json
+from importlib.metadata import PackageNotFoundError, version
+
+
+def _try_version(package: str):
+    try:
+        return version(package)
+    except PackageNotFoundError:
+        return "not installed"
+
+
+def print_versions(output_json: bool = False):
+    packages = {
+        "bec_lib": "BEC Core Library",
+        "bec_server": "BEC Server",
+        "bec_ipython_client": "BEC IPython Client",
+        "bec_widgets": "BEC Widgets",
+    }
+    versions = {mod: _try_version(mod) for mod in packages.keys()}
+    if not output_json:
+        for mod, ver in versions.items():
+            print(f"{packages.get(mod)}: {ver}")
+    else:
+        print(json.dumps(versions))

--- a/bec_lib/bec_lib/bec_service.py
+++ b/bec_lib/bec_lib/bec_service.py
@@ -8,6 +8,7 @@ import argparse
 import getpass
 import os
 import socket
+import sys
 import threading
 import time
 import uuid
@@ -20,6 +21,7 @@ import tomli
 from rich.console import Console
 from rich.table import Table
 
+from bec_lib._print_versions import print_versions
 from bec_lib.acl_login import BECAccess
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.logger import bec_logger
@@ -50,6 +52,14 @@ def parse_cmdline_args(parser=None, config_name: Literal["client", "server"] | s
     """
     if parser is None:
         parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    parser.add_argument("--version", action="store_true", default=False)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        help="Format the output from --version as JSON for programmatic consumption.",
+    )
     parser.add_argument("--config", default="", help="path to the config file")
     parser.add_argument(
         "--bec-server", default=None, help="BEC server URL (Redis server), e.g. 'localhost:6379'"
@@ -75,6 +85,10 @@ def parse_cmdline_args(parser=None, config_name: Literal["client", "server"] | s
     parser.add_argument("--user", default=None, help="user name to use for the service.", type=str)
 
     args, extra_args = parser.parse_known_args()
+
+    if args.version:
+        print_versions(output_json=args.json)
+        sys.exit(0)
 
     # pylint: disable=protected-access
     bec_logger._stderr_log_level = (

--- a/bec_lib/tests/test_bec_service.py
+++ b/bec_lib/tests/test_bec_service.py
@@ -336,6 +336,8 @@ def test_parse_cmdline_args_with_config():
             mock_service_config.assert_called_once_with(
                 "test_config.yaml",
                 cmdline_args={
+                    "version": False,
+                    "json": False,
                     "config": "test_config.yaml",
                     "log_level": None,
                     "file_log_level": None,


### PR DESCRIPTION
Currently running `bec --version` will print logging about loading a config file from disk, as this happens during the argument parsing process.

This change fixes this issue, and adds a JSON output option for the version flag for other applications to use.