### PR TITLE
feat(metadata_schema): add scan_name and comment fields to basic schema

### DIFF
--- a/bec_lib/bec_lib/metadata_schema.py
+++ b/bec_lib/bec_lib/metadata_schema.py
@@ -19,11 +19,11 @@ class BasicScanMetadata(BaseModel):
 
     model_config = ConfigDict(extra="allow", validate_assignment=True)
     scan_name: str = Field(
-        "", title="Scan name", description="A human-friendly identifier for the scan"
+        "", title="Scan Name", description="A human-friendly identifier for the scan"
     )
     comment: str = Field("", title="Comment", description="A comment about the scan")
     sample_name: str = Field(
-        "", title="Sample name", description="A human-friendly identifier for the sample"
+        "", title="Sample Name", description="A human-friendly identifier for the sample"
     )
 
 


### PR DESCRIPTION
This PR adds two new fields to the default scan metadata schema: scan name and comment. Need to be merged together with 

https://github.com/bec-project/bec_widgets/pull/1002