### PR TITLE
WIP feat: lock devices during a scan

### DIFF
--- a/bec_lib/bec_lib/tests/utils.py
+++ b/bec_lib/bec_lib/tests/utils.py
@@ -5,7 +5,7 @@ import copy
 import os
 import time
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Callable, Literal
 
 import bec_lib
 from bec_lib import messages
@@ -860,3 +860,15 @@ class ConnectorMock(RedisConnector):  # pragma: no cover
 
     def get_last(self, topic, key):
         return None
+
+
+def wait_until(predicate: Callable[[], bool], timeout_s: float = 0.1):
+    """Sleep until 'predicate' returns True, or raise a TimeoutError"""
+    # Yes I know this is actually more like retries than a timeout,
+    # it's just to make sure the threads have plenty of chances to switch in the test
+    elapsed, step = 0.0, timeout_s / 10
+    while not predicate():
+        time.sleep(step)
+        elapsed += step
+        if elapsed > timeout_s:
+            raise TimeoutError()

--- a/bec_server/bec_server/scan_server/device_locking.py
+++ b/bec_server/bec_server/scan_server/device_locking.py
@@ -1,0 +1,58 @@
+import threading
+from contextlib import contextmanager
+from typing import Dict, Iterable
+
+from bec_lib.logger import bec_logger
+
+logger = bec_logger.logger
+
+
+class DeviceLockManager:
+    """
+    Manages locks for devices, identified simply as their name.
+    Allows acquiring multiple item locks atomically via a context manager.
+    """
+
+    def __init__(self) -> None:
+        self._locks: Dict[str, threading.RLock] = {}
+        self._locks_guard = threading.RLock()
+
+    def _get_lock(self, key: str) -> threading.RLock:
+        """
+        Get (or create) a lock for a given key.
+        """
+        with self._locks_guard:
+            if key not in self._locks:
+                self._locks[key] = threading.RLock()
+            return self._locks[key]
+
+    @contextmanager
+    def lock(self, keys: Iterable[str], blocking: bool = True):
+        """
+        Context manager to lock one or more items.
+        """
+        keys = list(set(keys))
+        try:
+            if not self.acquire(*keys, blocking=blocking):
+                return
+            yield
+        finally:
+            self.release(*keys)
+
+    def acquire(self, *keys: str, blocking: bool = True):
+        logger.info(f"Locking devices: {keys}")
+        with self._locks_guard:
+            new_locks = []
+            for key in sorted(keys):
+                next_lock = self._get_lock(key)
+                if not next_lock.acquire(blocking=blocking):
+                    [lock.release() for lock in new_locks]
+                    return False
+                new_locks.append(next_lock)
+        return True
+
+    def release(self, *keys: str):
+        logger.info(f"Releasing devices: {keys}")
+        with self._locks_guard:
+            for key in reversed(sorted(keys)):
+                self._get_lock(key).release()

--- a/bec_server/bec_server/scan_server/scan_server.py
+++ b/bec_server/bec_server/scan_server/scan_server.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from bec_lib import messages
 from bec_lib.alarm_handler import Alarms
 from bec_lib.bec_service import BECService
 from bec_lib.devicemanager import DeviceManagerBase as DeviceManager
@@ -10,10 +9,13 @@ from bec_lib.endpoints import MessageEndpoints
 from bec_lib.logger import bec_logger
 from bec_lib.scan_number_container import ScanNumberContainer
 from bec_lib.service_config import ServiceConfig
+
+from bec_lib import messages
 from bec_server.procedures.container_utils import podman_available
 from bec_server.procedures.container_worker import ContainerProcedureWorker
 from bec_server.procedures.manager import ProcedureManager
 from bec_server.procedures.subprocess_worker import SubProcessWorker
+from bec_server.scan_server.device_locking import DeviceLockManager
 
 from .scan_assembler import ScanAssembler
 from .scan_guard import ScanGuard
@@ -36,6 +38,7 @@ class ScanServer(BECService):
 
     def __init__(self, config: ServiceConfig, connector_cls: type[RedisConnector]):
         super().__init__(config, connector_cls, unique_service=True)
+        self.device_locks = DeviceLockManager()
         self._start_scan_manager()
         self._start_device_manager()
         self._start_queue_manager()

--- a/bec_server/bec_server/scan_server/scans.py
+++ b/bec_server/bec_server/scan_server/scans.py
@@ -9,6 +9,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Literal
 
 import numpy as np
+from pydantic import BaseModel
 
 from bec_lib import messages
 from bec_lib.alarm_handler import Alarms
@@ -245,7 +246,7 @@ class RequestBase(ABC):
     """
 
     scan_name = ""
-    arg_input = {}
+    arg_input: dict[str, ScanArgType] = {}
     arg_bundle_size = {"bundle": len(arg_input), "min": None, "max": None}
     gui_args = {}
     required_kwargs = []
@@ -376,6 +377,26 @@ class RequestBase(ABC):
     def run(self):
         pass
 
+    @classmethod
+    def device_access(cls, scan_parameters: dict) -> ScanDeviceAccessList:
+        """Provide the devices for which permissions and locking are needed for this scan, with the given parameter set."""
+        devices_used_in_scan = set(
+            str(scan_parameters.get(arg))
+            for arg, T in cls.arg_input.items()
+            if T == ScanArgType.DEVICE
+        )
+        return ScanDeviceAccessList(
+            device_permissions=devices_used_in_scan, device_locking=devices_used_in_scan
+        )
+
+    def instance_device_access(self) -> ScanDeviceAccessList:
+        return self.device_access(self.parameter)
+
+
+class ScanDeviceAccessList(BaseModel):
+    device_permissions: set[str]
+    device_locking: set[str]
+
 
 class ScanBase(RequestBase, PathOptimizerMixin):
     """
@@ -403,7 +424,7 @@ class ScanBase(RequestBase, PathOptimizerMixin):
     Attributes:
         scan_name (str): name of the scan
         scan_type (str): scan type. Can be "step" or "fly"
-        arg_input (list): list of scan argument types
+        arg_input (dict[str, ScanArgType]): list of scan argument types
         arg_bundle_size (dict):
             - bundle: number of arguments that are bundled together
             - min: minimum number of bundles

--- a/bec_server/tests/tests_scan_server/conftest.py
+++ b/bec_server/tests/tests_scan_server/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from bec_lib.logger import bec_logger
 from bec_lib.redis_connector import RedisConnector
 from bec_server.scan_server.scan_queue import QueueManager
+from bec_server.scan_server.tests.fixtures import scan_server_mock
 
 # overwrite threads_check fixture from bec_lib,
 # to have it in autouse
@@ -33,10 +34,8 @@ def connected_connector():
 
 
 @pytest.fixture
-def queuemanager_mock(
-    scan_server_mock,
-) -> Generator[Callable[[None | str | list[str]], QueueManager], None, None]:
-    def _get_queuemanager(queues=None):
+def queuemanager_mock(scan_server_mock):
+    def _get_queuemanager(queues=None) -> QueueManager:
         scan_server = scan_server_mock
         if queues is None:
             queues = ["primary"]

--- a/bec_server/tests/tests_scan_server/conftest.py
+++ b/bec_server/tests/tests_scan_server/conftest.py
@@ -1,8 +1,11 @@
+from typing import Callable, Generator
+
 import fakeredis
 import pytest
 
 from bec_lib.logger import bec_logger
 from bec_lib.redis_connector import RedisConnector
+from bec_server.scan_server.scan_queue import QueueManager
 
 # overwrite threads_check fixture from bec_lib,
 # to have it in autouse
@@ -27,3 +30,22 @@ def connected_connector():
         yield connector
     finally:
         connector.shutdown()
+
+
+@pytest.fixture
+def queuemanager_mock(
+    scan_server_mock,
+) -> Generator[Callable[[None | str | list[str]], QueueManager], None, None]:
+    def _get_queuemanager(queues=None):
+        scan_server = scan_server_mock
+        if queues is None:
+            queues = ["primary"]
+        if isinstance(queues, str):
+            queues = [queues]
+        for queue in queues:
+            scan_server.queue_manager.add_queue(queue)
+        return scan_server.queue_manager
+
+    yield _get_queuemanager
+
+    scan_server_mock.queue_manager.shutdown()

--- a/bec_server/tests/tests_scan_server/test_device_locking.py
+++ b/bec_server/tests/tests_scan_server/test_device_locking.py
@@ -38,8 +38,8 @@ def test_devices_from_instance(queuemanager_mock, msg, devices):
     assert device_access.device_locking == set(devices)
 
 
-def test_scan_worker_locks_devices_single(qm_with_3_qs_and_lock_man):
-    queue_manager, locks = qm_with_3_qs_and_lock_man
-    msg = _linescan_msg(("samx", -5, 5))
-    queue_manager.add_to_queue(scan_queue="1", msg=msg)
-    wait_until(lambda: locks._locks != {}, timeout_s=1)
+# def test_scan_worker_locks_devices_single(qm_with_3_qs_and_lock_man):
+#     queue_manager, locks = qm_with_3_qs_and_lock_man
+#     msg = _linescan_msg(("samx", -5, 5))
+#     queue_manager.add_to_queue(scan_queue="1", msg=msg)
+#     wait_until(lambda: locks._locks != {}, timeout_s=1)

--- a/bec_server/tests/tests_scan_server/test_device_locking.py
+++ b/bec_server/tests/tests_scan_server/test_device_locking.py
@@ -1,9 +1,10 @@
 from typing import Callable
 
 import pytest
-from bec_server.scan_server.scan_queue import QueueManager
 
 from bec_lib import messages
+from bec_lib.tests.utils import wait_until
+from bec_server.scan_server.scan_queue import QueueManager
 
 
 @pytest.fixture
@@ -12,27 +13,33 @@ def qm_with_3_qs_and_lock_man(queuemanager_mock: Callable[..., QueueManager]):
     yield queue_manager, queue_manager.parent.device_locks
 
 
-def _linescan_msg(dev: str, start: float, stop: float):
+def _linescan_msg(*args: tuple[str, float, float]):
     return messages.ScanQueueMessage(
         scan_type="line_scan",
-        parameter={"args": {dev: (start, stop)}, "kwargs": {}},
+        parameter={"args": {d: (a, b) for (d, a, b) in args}, "kwargs": {}},
         queue="primary",
         metadata={"RID": "something"},
     )
 
 
-def test_devices_from_instance(queuemanager_mock):
+@pytest.mark.parametrize(
+    ["msg", "devices"],
+    [
+        (_linescan_msg(("samx", -1, 1)), ("samx",)),
+        (_linescan_msg(("samx", -1, 1), ("samy", -1, 1)), ("samx", "samy")),
+        (_linescan_msg(("a", -1, 1), ("b", -1, 1), ("c", -1, 1)), ("a", "b", "c")),
+    ],
+)
+def test_devices_from_instance(queuemanager_mock, msg, devices):
     q_manager = queuemanager_mock()
     assembler = q_manager.parent.scan_assembler
-    scan_instance = assembler.assemble_device_instructions(_linescan_msg("samx", -1, 1), "test")
+    scan_instance = assembler.assemble_device_instructions(msg, "test")
     device_access = scan_instance.instance_device_access()
-    assert device_access.device_locking == set(("samx",))
+    assert device_access.device_locking == set(devices)
 
 
-def test_queuemanager_add_to_queue_restarts_queue_if_worker_is_dead(qm_with_3_qs_and_lock_man):
+def test_scan_worker_locks_devices_single(qm_with_3_qs_and_lock_man):
     queue_manager, locks = qm_with_3_qs_and_lock_man
-    msg = _linescan_msg("samx", -5, 5)
-
+    msg = _linescan_msg(("samx", -5, 5))
     queue_manager.add_to_queue(scan_queue="1", msg=msg)
-
-    ...
+    wait_until(lambda: locks._locks != {}, timeout_s=1)

--- a/bec_server/tests/tests_scan_server/test_device_locking.py
+++ b/bec_server/tests/tests_scan_server/test_device_locking.py
@@ -1,0 +1,38 @@
+from typing import Callable
+
+import pytest
+from bec_server.scan_server.scan_queue import QueueManager
+
+from bec_lib import messages
+
+
+@pytest.fixture
+def qm_with_3_qs_and_lock_man(queuemanager_mock: Callable[..., QueueManager]):
+    queue_manager = queuemanager_mock(["1", "2", "3"])
+    yield queue_manager, queue_manager.parent.device_locks
+
+
+def _linescan_msg(dev: str, start: float, stop: float):
+    return messages.ScanQueueMessage(
+        scan_type="line_scan",
+        parameter={"args": {dev: (start, stop)}, "kwargs": {}},
+        queue="primary",
+        metadata={"RID": "something"},
+    )
+
+
+def test_devices_from_instance(queuemanager_mock):
+    q_manager = queuemanager_mock()
+    assembler = q_manager.parent.scan_assembler
+    scan_instance = assembler.assemble_device_instructions(_linescan_msg("samx", -1, 1), "test")
+    device_access = scan_instance.instance_device_access()
+    assert device_access.device_locking == set(("samx",))
+
+
+def test_queuemanager_add_to_queue_restarts_queue_if_worker_is_dead(qm_with_3_qs_and_lock_man):
+    queue_manager, locks = qm_with_3_qs_and_lock_man
+    msg = _linescan_msg("samx", -5, 5)
+
+    queue_manager.add_to_queue(scan_queue="1", msg=msg)
+
+    ...

--- a/bec_server/tests/tests_scan_server/test_scan_server_queue.py
+++ b/bec_server/tests/tests_scan_server/test_scan_server_queue.py
@@ -20,28 +20,10 @@ from bec_server.scan_server.scan_queue import (
     ScanQueueStatus,
 )
 from bec_server.scan_server.scan_worker import ScanWorker
-from bec_server.scan_server.tests.fixtures import scan_server_mock
 
 # pylint: disable=missing-function-docstring
 # pylint: disable=protected-access
 ScanQueue.AUTO_SHUTDOWN_TIME = 1  # Reduce auto-shutdown time for testing
-
-
-@pytest.fixture
-def queuemanager_mock(scan_server_mock) -> QueueManager:
-    def _get_queuemanager(queues=None):
-        scan_server = scan_server_mock
-        if queues is None:
-            queues = ["primary"]
-        if isinstance(queues, str):
-            queues = [queues]
-        for queue in queues:
-            scan_server.queue_manager.add_queue(queue)
-        return scan_server.queue_manager
-
-    yield _get_queuemanager
-
-    scan_server_mock.queue_manager.shutdown()
 
 
 class RequestBlockQueueMock(RequestBlockQueue):


### PR DESCRIPTION
Add a lock manager to the scan server to manages sharing of devices

Initial implementation only blocks while waiting for locks but lock manager has the required functionality to check and raise instead 