### PR TITLE
fix(mv): stop device on keyboard interrupt

### DIFF
--- a/bec_lib/bec_lib/device.py
+++ b/bec_lib/bec_lib/device.py
@@ -1237,9 +1237,9 @@ class Positioner(AdjustableMixin, Device):
     * moving
     """
 
-    @rpc
     def stop(self):
-        pass
+        msg = messages.VariableMessage(value=[self.root.name])
+        self.root.parent.parent.connector.send(MessageEndpoints.stop_devices(), msg)
 
     @rpc
     def settle_time(self):
@@ -1253,7 +1253,7 @@ class Positioner(AdjustableMixin, Device):
         return self.describe_configuration().get("egu")
 
     def move(self, val: float, relative=False):
-        return self.parent.parent.scans.mv(self, val, relative=relative)
+        return self.root.parent.parent.scans.mv(self, val, relative=relative)
 
     @property
     @rpc

--- a/bec_lib/bec_lib/endpoints.py
+++ b/bec_lib/bec_lib/endpoints.py
@@ -636,16 +636,18 @@ class MessageEndpoints:
         )
 
     @staticmethod
-    def stop_all_devices():
+    def stop_devices():
         """
-        Endpoint for stopping all devices. This endpoint is used to publish a message
-        to stop all devices and is used by the scan server's scan queue if a scan queue
-        modification was requested and accepted and requires to stop all devices.
+        Endpoint for stopping devices. This endpoint is used to publish a message
+        to stop devices and is used by the scan server's scan queue if a scan queue
+        modification was requested and accepted and requires to stop devices.
+        The variable message's value contains a list of device names to stop. If
+        the list is empty, all devices will be stopped.
 
         Returns:
-            EndpointInfo: Endpoint for stopping all devices.
+            EndpointInfo: Endpoint for stopping devices.
         """
-        endpoint = f"{EndpointType.INFO.value}/queue/stop_all_devices"
+        endpoint = f"{EndpointType.INFO.value}/queue/stop_devices"
         return EndpointInfo(
             endpoint=endpoint, message_type=messages.VariableMessage, message_op=MessageOp.SEND
         )

--- a/bec_lib/tests/test_scan_report.py
+++ b/bec_lib/tests/test_scan_report.py
@@ -101,12 +101,14 @@ def test_scan_report_wait_for_scan_raises(scan_report):
 
 
 def test_scan_report_aborts_on_ctrl_c(scan_report):
-    scan_report.request.request = messages.ScanQueueMessage(scan_type="mv", parameter={})
+    scan_report.request.request = messages.ScanQueueMessage(
+        scan_type="mv", parameter={"args": {"samx": [5]}}
+    )
     with mock.patch.object(scan_report, "_wait_move") as mock_wait_move:
         mock_wait_move.side_effect = [KeyboardInterrupt]
         with pytest.raises(ScanAbortion):
             scan_report.wait()
-        assert scan_report._client.queue.request_scan_abortion.call_count == 1
+        scan_report._client.device_manager.devices.get("samx").stop.assert_called_once()
 
 
 @pytest.mark.parametrize(

--- a/bec_server/bec_server/scan_server/scan_queue.py
+++ b/bec_server/bec_server/scan_server/scan_queue.py
@@ -241,8 +241,9 @@ class QueueManager:
         """
         Send a message to the device server to stop all devices.
         """
-        msg = messages.VariableMessage(value=1, metadata={})
-        self.connector.send(MessageEndpoints.stop_all_devices(), msg)
+        # We send an empty list to indicate that all devices should be stopped
+        msg = messages.VariableMessage(value=[], metadata={})
+        self.connector.send(MessageEndpoints.stop_devices(), msg)
 
     def scan_interception(self, scan_mod_msg: messages.ScanQueueModificationMessage) -> None:
         """handle a scan interception by compiling the requested method name and forwarding the request.

--- a/bec_server/tests/tests_device_server/test_device_server.py
+++ b/bec_server/tests/tests_device_server/test_device_server.py
@@ -13,6 +13,7 @@ from bec_lib import messages
 from bec_lib.alarm_handler import Alarms
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.messages import BECStatus
+from bec_lib.redis_connector import MessageObject
 from bec_lib.service_config import ServiceConfig
 from bec_lib.tests.utils import ConnectorMock
 from bec_server.device_server.device_server import DeviceServer, InvalidDeviceError
@@ -188,12 +189,23 @@ def test_stop_devices(device_server_mock):
 
 
 @pytest.mark.parametrize("device_manager_class", [DeviceManagerDS])
-def test_on_stop_all_devices(device_server_mock):
-    msg = messages.VariableMessage(value=1, metadata={})
+def test_on_stop_devices(device_server_mock):
+    msg = messages.VariableMessage(value=[], metadata={})
+    msg_obj = MessageObject(topic="internal/queue/stop_devices", value=msg)
     device_server = device_server_mock
     with mock.patch.object(device_server, "stop_devices") as stop:
-        device_server.on_stop_all_devices(msg, parent=device_server)
-        stop.assert_called_once()
+        device_server.on_stop_devices(msg_obj, parent=device_server)
+        stop.assert_called_once_with()
+
+
+@pytest.mark.parametrize("device_manager_class", [DeviceManagerDS])
+def test_on_stop_devices_with_list(device_server_mock):
+    msg = messages.VariableMessage(value=["samx"], metadata={})
+    msg_obj = MessageObject(topic="internal/queue/stop_devices", value=msg)
+    device_server = device_server_mock
+    with mock.patch.object(device_server, "stop_devices") as stop:
+        device_server.on_stop_devices(msg_obj, parent=device_server)
+        stop.assert_called_once_with(["samx"])
 
 
 @pytest.mark.parametrize(

--- a/bec_server/tests/tests_scan_server/test_scan_server_queue.py
+++ b/bec_server/tests/tests_scan_server/test_scan_server_queue.py
@@ -257,8 +257,8 @@ def test_set_abort(queuemanager_mock):
     wait_to_reach_state(queue_manager, "primary", ScanQueueStatus.PAUSED)
     assert len(queue_manager.connector.message_sent) == 3
     assert {
-        "queue": MessageEndpoints.stop_all_devices(),
-        "msg": messages.VariableMessage(value=1, metadata={}),
+        "queue": MessageEndpoints.stop_devices(),
+        "msg": messages.VariableMessage(value=[], metadata={}),
     } in queue_manager.connector.message_sent
     assert (
         queue_manager.connector.message_sent[0].get("queue") == MessageEndpoints.scan_queue_status()
@@ -273,8 +273,8 @@ def test_set_abort_with_empty_queue(queuemanager_mock):
     wait_to_reach_state(queue_manager, "primary", ScanQueueStatus.RUNNING)
     assert len(queue_manager.connector.message_sent) == 1
     assert {
-        "queue": MessageEndpoints.stop_all_devices(),
-        "msg": messages.VariableMessage(value=1, metadata={}),
+        "queue": MessageEndpoints.stop_devices(),
+        "msg": messages.VariableMessage(value=[], metadata={}),
     } in queue_manager.connector.message_sent
 
 


### PR DESCRIPTION
This PR adds the option to call `cancel`  on status objects returned by scans. Similarly, any ctrl-c during a status.wait() will send an interrupt. To this end, the `stop_all_devices` method has been modified to also support stopping single devices. 