### PR TITLE
ci: cancel previous CI run for PR or branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: write
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 **/.pytest_cache
 **/*.egg*
 **/*.env
-
+data/*
 # bec_widgets saved profiles
 widgets_settings/profiles/*
 
@@ -182,3 +182,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+


### PR DESCRIPTION
Modify the full CI workflow to cancel previous runs if a new update is pushed to the PR