### PR TITLE
refactor: scan worker and device instruction error for typing and style

### DIFF
--- a/bec_lib/bec_lib/messages.py
+++ b/bec_lib/bec_lib/messages.py
@@ -569,6 +569,12 @@ class DeviceInstructionResponse(BECMessage):
     instruction_id: str
     result: Any | None = None
 
+    @model_validator(mode="after")
+    def _ensure_error_info_if_error(self):
+        if self.status == "error" and self.error_info is None:
+            raise ValueError("Must supply error info for an error message!")
+        return self
+
 
 class DeviceMessage(BECMessage):
     """Message type for sending device readings from the device server

--- a/bec_server/bec_server/scan_server/errors.py
+++ b/bec_server/bec_server/scan_server/errors.py
@@ -29,10 +29,10 @@ class DeviceMessageError(Exception):
 
 
 class DeviceInstructionError(Exception):
-    def __init__(self, message):
-        super().__init__(message)
-        self.message = message
-        self.error_info: ErrorInfo | None = None
+    def __init__(self, error_info: ErrorInfo):
+        super().__init__(error_info.compact_error_message)
+        self.message = error_info.compact_error_message
+        self.error_info: ErrorInfo = error_info
 
-    def set_info(self, error_info: ErrorInfo):
+    def update_info(self, error_info: ErrorInfo):
         self.error_info = error_info

--- a/bec_server/bec_server/scan_server/scan_stubs.py
+++ b/bec_server/bec_server/scan_server/scan_stubs.py
@@ -133,7 +133,7 @@ class ScanStubStatus:
         self.done = True
         self._future.set_result(result)
 
-    def set_failed(self, error_info: messages.ErrorInfo | None = None):
+    def set_failed(self, error_info: messages.ErrorInfo):
         """
         Set the status object to failed.
 
@@ -141,9 +141,7 @@ class ScanStubStatus:
             error_info (messages.ErrorInfo, optional): Error information. Defaults to None.
         """
         self.done = True
-        exc = DeviceInstructionError(error_info.compact_error_message if error_info else None)
-        if error_info:
-            exc.set_info(error_info)
+        exc = DeviceInstructionError(error_info)
         self._future.set_exception(exc)
 
     def set_running(self):

--- a/bec_server/tests/tests_scan_server/test_scan_stub_status.py
+++ b/bec_server/tests/tests_scan_server/test_scan_stub_status.py
@@ -73,7 +73,11 @@ def test_scan_stub_status_update_future_completed(msg, scan_stub_status):
             metadata={"device_instr_id": "test"},
             device="samx",
             status="error",
-            error_info=None,
+            error_info=messages.ErrorInfo(
+                error_message="test_error",
+                compact_error_message="test_error",
+                exception_type="TestError",
+            ),
             instruction=messages.DeviceInstructionMessage(
                 device="samx",
                 action="set",


### PR DESCRIPTION
Should be no functional changes.

- splits process instructions into some smaller methods
- ensures device instruction response messages always have error info if they are in an error state
- fix some typing