### PR TITLE
feat(altas): forward feedback message to atlas

### DIFF
--- a/bec_server/bec_server/scihub/atlas/atlas_metadata_handler.py
+++ b/bec_server/bec_server/scihub/atlas/atlas_metadata_handler.py
@@ -16,6 +16,7 @@ from bec_lib.logger import bec_logger
 logger = bec_logger.logger
 
 if TYPE_CHECKING:  # pragma: no cover
+    from bec_lib.redis_connector import MessageObject
     from bec_server.scihub.atlas.atlas_connector import AtlasConnector
 
 
@@ -28,11 +29,13 @@ class AtlasMetadataHandler:
         self.atlas_connector = atlas_connector
         self._scan_status_register = None
         self._account = None
+        self._deployment_info: messages.DeploymentInfoMessage | None = None
         self._start_account_subscription()
         self._start_deployment_info_subscription()
         self._start_scan_subscription()
         self._start_scan_history_subscription()
         self._start_messaging_subscription()
+        self._start_feedback_subscription()
 
     def _start_account_subscription(self):
         init_data = self.atlas_connector.connector.get_last(MessageEndpoints.account())
@@ -69,6 +72,11 @@ class AtlasMetadataHandler:
             MessageEndpoints.message_service_queue(), cb=self._handle_messaging, parent=self
         )
 
+    def _start_feedback_subscription(self):
+        self.atlas_connector.connector.register(
+            MessageEndpoints.user_feedback(), cb=self._handle_feedback, parent=self
+        )
+
     @staticmethod
     def _update_deployment_info(
         msg: dict[str, messages.DeploymentInfoMessage], *, parent: AtlasMetadataHandler, **_kwargs
@@ -87,6 +95,7 @@ class AtlasMetadataHandler:
             info (messages.DeploymentInfoMessage): Deployment information, including session and experiment info
         """
         # We store the deployment info in the local redis instance so that other services can access it if needed
+        self._deployment_info = info
         self.atlas_connector.connector.xadd(
             MessageEndpoints.deployment_info(), {"data": info}, max_size=1, approximate=False
         )
@@ -189,6 +198,28 @@ class AtlasMetadataHandler:
         Update the scan status in Atlas
         """
         self.atlas_connector.ingest_data(msg)
+
+    @staticmethod
+    def _handle_feedback(
+        msg_obj: MessageObject, *, parent: AtlasMetadataHandler, **_kwargs
+    ) -> None:
+        msg: messages.FeedbackMessage = msg_obj.value
+        content = msg.model_dump()
+        if parent._deployment_info:
+            if (
+                parent._deployment_info.active_session
+                and parent._deployment_info.active_session.experiment
+            ):
+                content["experiment_id"] = parent._deployment_info.active_session.experiment.pgroup
+                content["realm_id"] = parent._deployment_info.active_session.experiment.realm_id
+            content["deployment_id"] = parent._deployment_info.deployment_id
+        try:
+            enriched_msg: messages.FeedbackMessage = messages.FeedbackMessage(**content)
+            parent.atlas_connector.ingest_data({"user_feedback": enriched_msg})
+        # pylint: disable=broad-except
+        except Exception:
+            traceback_info = traceback.format_exc()
+            logger.exception(f"Failed to update feedback: {traceback_info}")
 
     def shutdown(self):
         """

--- a/bec_server/tests/tests_scihub/test_atlas_metadata_handler.py
+++ b/bec_server/tests/tests_scihub/test_atlas_metadata_handler.py
@@ -311,3 +311,131 @@ def test_handle_messaging_error(atlas_connector):
             msg, parent=atlas_connector.metadata_handler
         )
         mock_logger_error.assert_called()
+
+
+def test_handle_feedback_message(atlas_connector):
+    """Test handling of feedback messages"""
+    fb_message = messages.FeedbackMessage(feedback="Great experiment!", rating=5)
+    msg_obj = MessageObject(topic=MessageEndpoints.user_feedback().endpoint, value=fb_message)
+
+    with mock.patch.object(
+        atlas_connector.metadata_handler.atlas_connector, "ingest_data"
+    ) as mock_ingest:
+        atlas_connector.metadata_handler._handle_feedback(
+            msg_obj, parent=atlas_connector.metadata_handler
+        )
+        mock_ingest.assert_called_once_with({"user_feedback": fb_message})
+
+
+def test_handle_feedback_message_fills_deployment_info(atlas_connector):
+    """Test that feedback messages are enriched with deployment info"""
+    fb_message = messages.FeedbackMessage(feedback="Great experiment!", rating=5)
+    msg_obj = MessageObject(topic=MessageEndpoints.user_feedback().endpoint, value=fb_message)
+
+    deployment_info = create_dummy_deployment_info()
+    atlas_connector.metadata_handler._deployment_info = deployment_info
+
+    with mock.patch.object(
+        atlas_connector.metadata_handler.atlas_connector, "ingest_data"
+    ) as mock_ingest:
+        atlas_connector.metadata_handler._handle_feedback(
+            msg_obj, parent=atlas_connector.metadata_handler
+        )
+        enriched_message = messages.FeedbackMessage(
+            feedback="Great experiment!",
+            rating=5,
+            experiment_id=deployment_info.active_session.experiment.pgroup,
+            realm_id=deployment_info.active_session.experiment.realm_id,
+            deployment_id=deployment_info.deployment_id,
+            timestamp=fb_message.timestamp,
+        )
+        mock_ingest.assert_called_once_with({"user_feedback": enriched_message})
+
+
+def test_handle_feedback_message_fills_deployment_info_no_session(atlas_connector):
+    """Test that feedback messages are enriched with deployment info even if session is missing"""
+    fb_message = messages.FeedbackMessage(feedback="Great experiment!", rating=5)
+    msg_obj = MessageObject(topic=MessageEndpoints.user_feedback().endpoint, value=fb_message)
+
+    deployment_info = messages.DeploymentInfoMessage(
+        metadata={},
+        deployment_id="test-id",
+        name="Test Deployment",
+        active_session=None,
+        messaging_config=messages.MessagingConfig(
+            scilog=messages.MessagingServiceScopeConfig(enabled=False, default=None),
+            signal=messages.MessagingServiceScopeConfig(enabled=False, default=None),
+            teams=messages.MessagingServiceScopeConfig(enabled=False, default=None),
+        ),
+        messaging_services=[],
+    )
+    atlas_connector.metadata_handler._deployment_info = deployment_info
+
+    with mock.patch.object(
+        atlas_connector.metadata_handler.atlas_connector, "ingest_data"
+    ) as mock_ingest:
+        atlas_connector.metadata_handler._handle_feedback(
+            msg_obj, parent=atlas_connector.metadata_handler
+        )
+        enriched_message = messages.FeedbackMessage(
+            feedback="Great experiment!",
+            rating=5,
+            deployment_id=deployment_info.deployment_id,
+            timestamp=fb_message.timestamp,
+        )
+        mock_ingest.assert_called_once_with({"user_feedback": enriched_message})
+
+
+def test_handle_feedback_message_fills_deployment_info_no_experiment(atlas_connector):
+    """Test that feedback messages are enriched with deployment info even if experiment is missing"""
+    fb_message = messages.FeedbackMessage(feedback="Great experiment!", rating=5)
+    msg_obj = MessageObject(topic=MessageEndpoints.user_feedback().endpoint, value=fb_message)
+
+    deployment_info = messages.DeploymentInfoMessage(
+        metadata={},
+        deployment_id="test-id",
+        name="Test Deployment",
+        active_session=messages.SessionInfoMessage(
+            metadata={}, name="_default_", experiment=None, messaging_services=[]
+        ),
+        messaging_config=messages.MessagingConfig(
+            scilog=messages.MessagingServiceScopeConfig(enabled=False, default=None),
+            signal=messages.MessagingServiceScopeConfig(enabled=False, default=None),
+            teams=messages.MessagingServiceScopeConfig(enabled=False, default=None),
+        ),
+        messaging_services=[],
+    )
+    atlas_connector.metadata_handler._deployment_info = deployment_info
+
+    with mock.patch.object(
+        atlas_connector.metadata_handler.atlas_connector, "ingest_data"
+    ) as mock_ingest:
+        atlas_connector.metadata_handler._handle_feedback(
+            msg_obj, parent=atlas_connector.metadata_handler
+        )
+        enriched_message = messages.FeedbackMessage(
+            feedback="Great experiment!",
+            rating=5,
+            deployment_id=deployment_info.deployment_id,
+            timestamp=fb_message.timestamp,
+        )
+        mock_ingest.assert_called_once_with({"user_feedback": enriched_message})
+
+
+def test_handle_feedback_message_error(atlas_connector):
+    """Test handling of feedback messages when ingest_data raises an error"""
+    fb_message = messages.FeedbackMessage(feedback="Great experiment!", rating=5)
+    msg_obj = MessageObject(topic=MessageEndpoints.user_feedback().endpoint, value=fb_message)
+
+    with (
+        mock.patch.object(
+            atlas_connector.metadata_handler.atlas_connector,
+            "ingest_data",
+            side_effect=ValueError("Test error"),
+        ),
+        mock.patch("bec_lib.logger.bec_logger.logger.exception") as mock_logger_error,
+    ):
+        atlas_connector.metadata_handler._handle_feedback(
+            msg_obj, parent=atlas_connector.metadata_handler
+        )
+        mock_logger_error.assert_called()


### PR DESCRIPTION
This pull request introduces support for handling user feedback messages in the Atlas metadata handler. The main changes include adding a feedback subscription mechanism, implementing logic to enrich feedback messages with deployment info, and providing tests to ensure correct behavior.
