### PR TITLE
fix: remove gitlab ci file from check

### DIFF
--- a/bec_lib/tests/test_plugin_system.py
+++ b/bec_lib/tests/test_plugin_system.py
@@ -138,7 +138,6 @@ class TestPluginSystem:
             "LICENSE",
             "tests",
             "bin",
-            ".gitlab-ci.yml",
         ]:
             assert file in files
         files = os.listdir(TestPluginSystem._tmp_plugin_dir / TestPluginSystem._tmp_plugin_name)


### PR DESCRIPTION
copier has been updated but the test in bec_lib still expects a gitlab-ci file. 