### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/source/developer/data_access/event_data.md
+++ b/docs/source/developer/data_access/event_data.md
@@ -60,7 +60,7 @@ In a step scan, the scan segment is updated for each step, while in a fly scan, 
 (developer.event_data.subscription)=
 ## Subscribing to events
 
-Subscriptions to events allow you to react to a new message published on a specific endpoint. We can register our own callback funtion to an endpoint. Incoming messages are enqueued at reception, and callbacks are executed one after the other to preserve events order. Callbacks must not block, otherwise events processing is put on hold. By default a thread consumes the queue, so the callbacks are executed in this consumer thread. 
+Subscriptions to events allow you to react to a new message published on a specific endpoint. We can register our own callback function to an endpoint. Incoming messages are enqueued at reception, and callbacks are executed one after the other to preserve events order. Callbacks must not block, otherwise events processing is put on hold. By default a thread consumes the queue, so the callbacks are executed in this consumer thread. 
 
 ``` python
 def my_cb(msg, **kwargs):
@@ -84,7 +84,7 @@ It is very important to keep the execution time of the callback function as shor
 
 ## Accessing event data outside of the BECIPythonClient
 
-If you like to use the event data oustide of the *BECIPythonClient*, you can use the [`RedisConnector`](/api_reference/_autosummary/bec_lib.redis_connector.RedisConnector) to access the REDIS server. You have to provide the correct `"host:port"` to the connector which allows you to connect to REDIS from the system you are running the code. If REDIS runs locally, this would be `"localhost:6379"`.
+If you like to use the event data outside of the *BECIPythonClient*, you can use the [`RedisConnector`](/api_reference/_autosummary/bec_lib.redis_connector.RedisConnector) to access the REDIS server. You have to provide the correct `"host:port"` to the connector which allows you to connect to REDIS from the system you are running the code. If REDIS runs locally, this would be `"localhost:6379"`.
 Note, at the beamline this would be the hostname of the bec_server. The port `"6379"` is the default port for REDIS. 
 ```python
 from bec_lib.endpoints import MessageEndpoints

--- a/docs/source/developer/developer.md
+++ b/docs/source/developer/developer.md
@@ -80,7 +80,7 @@ Discover how to get access to data in BEC. This ranges from an introduction into
 
 ## Scans
 
-Understand the basic structure of a scan in BEC and learn how to create a scan plugin to extend BEC's functionality and furthe tailor it to your needs.
+Understand the basic structure of a scan in BEC and learn how to create a scan plugin to extend BEC's functionality and further tailor it to your needs.
 
 ```
 

--- a/docs/source/developer/devices/devices.md
+++ b/docs/source/developer/devices/devices.md
@@ -2,7 +2,7 @@
 # Devices
 Whether new devices need to be added to BEC or existing devices need to be modified, the daily operation of beamlines at large-scale facilities depends on the ability change the behavior and configuration of devices. This section provides information on how to configure and use devices in BEC.
 
-After an introduction to the [Ophyd libary](#developer.ophyd), the section [device configuration](#developer.ophyd_device_config) explains how to configure devices in BEC and how to load new configs. 
+After an introduction to the [Ophyd library](#developer.ophyd), the section [device configuration](#developer.ophyd_device_config) explains how to configure devices in BEC and how to load new configs. 
 
 A dedicated section on the [BEC simulation framework](#developer.bec_sim) explains how to simulate devices in BEC, either for testing or for development purposes. Finally, a section on [external sources](#developer.external_sources) explains how to deal with external data sources in BEC. 
 

--- a/docs/source/developer/getting_started/tests.md
+++ b/docs/source/developer/getting_started/tests.md
@@ -38,8 +38,8 @@ General purpose fixtures are useful for all tests, or unit tests.
 
 ### Threads check
 
-The `threads_check` fixture ensures a test do not leak threads. Indeed, it is important for tests reproducibility and for
-BEC integrity to make sure that threads do not remain alive across tests execution, and that BEC provides the mecanism to
+The `threads_check` fixture ensures a test does not leak threads. Indeed, it is important for tests reproducibility and for
+BEC integrity to make sure that threads do not remain alive across tests execution, and that BEC provides the mechanism to
 shut down threads gracefully to guarantee proper freeing of resources.
 
 Just add `threads_check` fixture to a test to enable this check:

--- a/docs/source/developer/scans/scan_metadata.md
+++ b/docs/source/developer/scans/scan_metadata.md
@@ -29,7 +29,7 @@ constraints specified in the schema.
 
 Metadata schema are based on [Pydantic models](https://docs.pydantic.dev/latest/concepts/models/), which are simple ways of declaring
 required and optional fields using Python datatypes. If the entries contain a default value, then including them in the request is optional.
-The entry can alse include `None` as an acceptable value by including `| None` in the type annotation (such as in `treatment_temperature_k`
+The entry can also include `None` as an acceptable value by including `| None` in the type annotation (such as in `treatment_temperature_k`
 below), indicating the value is optional. In many cases, this might be the default value, indicating nothing was entered by the user, such
 as for `treatment_temperature_k` below.
 

--- a/docs/source/developer/scans/tutorials/tutorial_fly_scan_cont_line.md
+++ b/docs/source/developer/scans/tutorials/tutorial_fly_scan_cont_line.md
@@ -437,7 +437,7 @@ def test_TutorialFlyScanContLine(scan_assembler, ScanStubStatusMock):
 ````
 
 ## Step 7: (Optional) Setting up more devices 
-In general, it is good practice to keep the scan logic as simple as possible and to move as much device-specific logic as possible to the device classes. However, there are cases where it is necessary to set up devices after they have been staged for the scan. While we have already seen how to move a device to a specific position, the scan server also grants you access to any ophyd method available on the device. Let's take a delay generator (DDG) as an example: Before the scan, we want to configure the DDG and effectly run the following method on the ophyd object `ddg_detectors`:
+In general, it is good practice to keep the scan logic as simple as possible and to move as much device-specific logic as possible to the device classes. However, there are cases where it is necessary to set up devices after they have been staged for the scan. While we have already seen how to move a device to a specific position, the scan server also grants you access to any ophyd method available on the device. Let's take a delay generator (DDG) as an example: Before the scan, we want to configure the DDG and effectively run the following method on the ophyd object `ddg_detectors`:
 
 ```python
 ddg_detectors.burst_enable(count=1, delay=0.01, period=exp_time+readout_time,config="first")

--- a/docs/source/user/command_line_interface.md
+++ b/docs/source/user/command_line_interface.md
@@ -1,7 +1,7 @@
 (user.command_line_interface)=
 ## Command-Line Interface (CLI)
 
-In the previous sections, you have succesfully started BEC and also already interacted with the CLI to update the BEC device configuration. 
+In the previous sections, you have successfully started BEC and also already interacted with the CLI to update the BEC device configuration. 
 This section aims to explore the CLI capabilities further.
 
 ### Start-up
@@ -134,7 +134,7 @@ which again returns a nested dictionary, however, this time only for the request
 
 ```{note}
 The keys in the returned dictionary are composed of `<devicename>_<signalname>`. 
-However, for positioners the signal name <readback> is typically ommited, i,e. see `dev.samx.readback.read()`.
+However, for positioners the signal name `<readback>` is typically omitted, i,e. see `dev.samx.readback.read()`.
 ```
 
 #### Get interface
@@ -346,7 +346,7 @@ It allows us to run a sequence of functions as if it were a scan, resulting in a
     @scans.scan_def
     def custom_grid_scan():
         open_shutter()
-        umv(dev.samz, 0) # move to samz to start position (absolut)
+        umv(dev.samz, 0) # move to samz to start position (absolute)
         for i in range(10):
             scans.grid_scan(dev.samx, 0, 10, 10, dev.samy, 0, 10, 10, exp_time=0.1, relative=False)
             umvr(dev.samz, 0.1) # move samz + 0.1mm after each grid scan

--- a/docs/source/user/data_access_and_plotting.md
+++ b/docs/source/user/data_access_and_plotting.md
@@ -1,5 +1,5 @@
 (user.data_access_and_plotting)= 
-# Data Acess and Plotting
+# Data Access and Plotting
 
 Let's recapture how to do a scan, and explore the data contained within it. 
 
@@ -139,5 +139,5 @@ scan_to_csv(scan_data, "<path_to_output_file.csv>")
 ```
 
 ```{note}
-Large data from 2D detectors are usually processing by backend services and are, therefore, not available for client-based export.
+Large data from 2D detectors are usually processed by backend services and are, therefore, not available for client-based export.
 ```


### PR DESCRIPTION
Hello,

I noticed a typo in the word "Access" and then decided to run spellcheck for the docs.