### PR TITLE
fix(messages): new rpc kwargs to GUIRegistryStateMessage

### DIFF
--- a/bec_lib/bec_lib/messages.py
+++ b/bec_lib/bec_lib/messages.py
@@ -1386,6 +1386,7 @@ class GUIRegistryStateMessage(BECMessage):
                 "config",
                 "__rpc__",
                 "container_proxy",
+                "skip_rpc_namespace",
             ],
             str | bool | dict | None,
         ],


### PR DESCRIPTION
New allowed states ( "skip_rpc_namespace",  "rpc_exposed") in pydantic model reflecting changes made in https://github.com/bec-project/bec_widgets/pull/1061