### PR TITLE
Fix/redis busy loading

### DIFF
--- a/bec_lib/bec_lib/redis_connector.py
+++ b/bec_lib/bec_lib/redis_connector.py
@@ -344,7 +344,7 @@ class RedisConnector:
             Retry: The retry policy object.
         """
         return Retry(
-            ExponentialBackoff(cap=300),
+            ExponentialBackoff(cap=30),
             retries=0,
             supported_errors=(
                 redis.exceptions.TimeoutError,


### PR DESCRIPTION
This pull request makes a targeted update to the Redis connector's retry policy to improve error handling and reduce wait times on failures.

- Retry policy adjustments in `redis_connector.py`:
  * Reduced the exponential backoff cap from 300 seconds to 30 seconds, which will decrease the maximum wait time between retries.
  * Added `redis.exceptions.BusyLoadingError` to the list of supported errors that will trigger a retry, allowing the connector to handle Redis busy loading scenarios more gracefully.