### PR TITLE
Feature/gui config types

### DIFF
--- a/bec_lib/bec_lib/scan_args.py
+++ b/bec_lib/bec_lib/scan_args.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+import pint
+from pint.facets.plain import PlainQuantity
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+Units = pint.UnitRegistry()
+
+
+class ScanArgument(BaseModel):
+
+    display_name: Annotated[str | None, Field(description="Display name for the argument")] = None
+    description: Annotated[str | None, Field(description="Description of the argument")] = None
+    tooltip: Annotated[str | None, Field(description="Tooltip for the argument")] = None
+    expert: Annotated[bool, Field(description="Whether the argument is for expert users only")] = (
+        False
+    )
+    units: Annotated[
+        str | pint.Unit | PlainQuantity[Any] | None, Field(description="Units of the argument")
+    ] = None
+    reference_units: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Reference for the units. Use it when the units depend on another argument, e.g. "
+                "the units of a step size might depend on the units of the specified motor. The "
+                "reference_units should be set to the name of the argument that serves as reference."
+            )
+        ),
+    ] = None
+    gt: Annotated[float | None, Field(description="Value must be greater than this")] = None
+    ge: Annotated[
+        float | None, Field(description="Value must be greater than or equal to this")
+    ] = None
+    lt: Annotated[float | None, Field(description="Value must be less than this")] = None
+    le: Annotated[float | None, Field(description="Value must be less than or equal to this")] = (
+        None
+    )
+    reference_limits: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Reference for the limits. Use it when the limits depend on another argument, e.g. "
+                "the limits of start / stop positions might depend on the range of the specified motor. "
+                "The reference_limits should be set to the name of the argument that serves as reference."
+            )
+        ),
+    ] = None
+    alternative_group: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Identifier for arguments that are alternative parameterizations of the same "
+                "concept and should not be supplied together, e.g. step_size and steps."
+            )
+        ),
+    ] = None
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    @field_validator("units", mode="before")
+    @classmethod
+    def _serialize_units(cls, value: object) -> object:
+        """
+        Serialize Pint units to compact unit strings before model validation.
+
+        Args:
+            value (object): Units value supplied for the model field.
+
+        Returns:
+            The compact string form for Pint units, otherwise the original value.
+        """
+        if isinstance(value, pint.Unit):
+            return f"{value:~P}"
+        if isinstance(value, PlainQuantity):
+            return f"{value.units:~P}"
+        return value
+
+    @model_validator(mode="after")
+    def _validate_unit_fields_are_exclusive(self) -> ScanArgument:
+        """
+        Validate that only one unit source is specified.
+
+        Returns:
+            ScanArgument: The validated scan argument model.
+        """
+        if self.units is not None and self.reference_units is not None:
+            raise ValueError("units and reference_units are mutually exclusive")
+        return self

--- a/bec_lib/bec_lib/scans.py
+++ b/bec_lib/bec_lib/scans.py
@@ -7,11 +7,12 @@ from __future__ import annotations
 
 import builtins
 import time
+import types
 import uuid
 from collections.abc import Callable
 from contextlib import ContextDecorator
 from copy import deepcopy
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated, Literal, get_args, get_origin
 
 from toolz import partition
 from typeguard import typechecked
@@ -22,7 +23,7 @@ from bec_lib.endpoints import MessageEndpoints
 from bec_lib.logger import bec_logger
 from bec_lib.scan_repeat import _scan_repeat_depth
 from bec_lib.scan_report import ScanReport
-from bec_lib.signature_serializer import dict_to_signature
+from bec_lib.signature_serializer import deserialize_dtype, dict_to_signature
 from bec_lib.utils import scan_to_csv
 from bec_lib.utils.import_utils import lazy_import
 
@@ -196,11 +197,75 @@ class Scans:
             setattr(
                 getattr(self, scan_name),
                 "__signature__",
-                dict_to_signature(scan_info.get("signature")),
+                dict_to_signature(
+                    self._strip_scan_signature_annotations(scan_info.get("signature"))
+                ),
             )
 
     @staticmethod
-    def get_arg_type(in_type: str):
+    def _strip_scan_signature_annotations(params: list[dict]) -> list[dict]:
+        """
+        Strip rich scan argument metadata from serialized params for IPython signatures.
+
+        Args:
+            params (list[dict]): Serialized function signature parameter dictionaries.
+
+        Returns:
+            list[dict]: Serialized parameter dictionaries with rich Annotated metadata replaced by
+            base types.
+        """
+        return [
+            {**param, "annotation": Scans._strip_scan_arg_annotation(param["annotation"])}
+            for param in params
+        ]
+
+    @staticmethod
+    def _strip_scan_arg_annotation(annotation: str | dict | list) -> str | dict | list:
+        """
+        Return the base serialized type for rich Annotated scan argument metadata.
+
+        Args:
+            annotation (str | dict | list): Serialized annotation value from a signature parameter.
+
+        Returns:
+            str | dict | list: The serialized base annotation with scan argument metadata removed.
+        """
+        if isinstance(annotation, list):
+            return [Scans._strip_scan_arg_annotation(entry) for entry in annotation]
+        if isinstance(annotation, dict) and (annotated := annotation.get("Annotated")):
+            return Scans._strip_scan_arg_annotation(annotated["type"])
+        return annotation
+
+    @staticmethod
+    def _get_runtime_arg_type(dtype: object) -> type | tuple[type, ...]:
+        """
+        Convert a deserialized annotation into a type suitable for isinstance checks.
+
+        Args:
+            dtype (object): Deserialized annotation value.
+
+        Returns:
+            type | tuple[type, ...]: Runtime type or tuple of types accepted by isinstance.
+        """
+        if get_origin(dtype) is Annotated:
+            return Scans._get_runtime_arg_type(get_args(dtype)[0])
+        if get_origin(dtype) is Literal:
+            return tuple(type(arg) for arg in get_args(dtype))
+        if dtype.__class__.__name__ == "_UnionGenericAlias" or dtype.__class__ == types.UnionType:
+            runtime_types = []
+            for arg in get_args(dtype):
+                runtime_type = Scans._get_runtime_arg_type(arg)
+                if isinstance(runtime_type, tuple):
+                    runtime_types.extend(runtime_type)
+                    continue
+                runtime_types.append(runtime_type)
+            return tuple(runtime_types)
+        if dtype is None:
+            return types.NoneType
+        return dtype
+
+    @staticmethod
+    def get_arg_type(in_type: str | dict | list):
         """translate type string into python type"""
         # pylint: disable=too-many-return-statements
         if in_type == "float":
@@ -209,14 +274,16 @@ class Scans:
             return int
         if in_type == "list":
             return list
-        if in_type == "boolean":
+        if in_type in ("boolean", "bool"):
             return bool
         if in_type == "str":
             return str
         if in_type == "dict":
             return dict
-        if in_type == "device":
+        if in_type in ("device", "DeviceBase"):
             return DeviceBase
+        if dtype := deserialize_dtype(in_type):
+            return Scans._get_runtime_arg_type(dtype)
         raise TypeError(f"Unknown type {in_type}")
 
     @staticmethod

--- a/bec_lib/bec_lib/signature_serializer.py
+++ b/bec_lib/bec_lib/signature_serializer.py
@@ -9,35 +9,115 @@ import inspect
 import itertools
 import types
 from collections.abc import Callable
-from typing import Generator, Literal, Union, get_type_hints
+from typing import Annotated, Generator, Literal, Union, get_args, get_origin, get_type_hints
 
 import numpy as np
+from pydantic import ValidationError
 
 from bec_lib.device import DeviceBase
+from bec_lib.scan_args import ScanArgument
 from bec_lib.scan_items import ScanItem
 
 _special_types = {DeviceBase, ScanItem}
 
 
-def _serialize_dtype(dtype: type) -> Generator[str | dict, None, None]:
+def _serialize_dtype(dtype: object) -> Generator[str | dict, None, None]:
+    """
+    Yield serialized dtype entries for simple, union, and literal annotations.
+
+    Args:
+        dtype (object): Type annotation to serialize.
+
+    Yields:
+        str | dict: Serialized dtype entries.
+    """
     if dtype is None or dtype is types.NoneType:
         yield "NoneType"
     if (name := getattr(dtype, "__name__", None)) and isinstance(dtype, type):
         if name in builtins.__dict__ or name in np.__dict__ or dtype in _special_types:
             yield name
     if dtype.__class__.__name__ == "_UnionGenericAlias" or dtype.__class__ == types.UnionType:
-        yield from itertools.chain.from_iterable(_serialize_dtype(x) for x in dtype.__args__)  # type: ignore
+        yield from itertools.chain.from_iterable(_serialize_union_arg(x) for x in dtype.__args__)  # type: ignore
     if dtype.__class__.__name__ == "_LiteralGenericAlias":
         yield {"Literal": dtype.__args__}  # type: ignore
 
 
+def _serialize_union_arg(dtype: object) -> list[str | dict]:
+    """
+    Serialize one member of a union annotation.
+
+    Args:
+        dtype (object): Union member annotation to serialize.
+
+    Returns:
+        list[str | dict]: Serialized dtype entries for the union member.
+    """
+    if annotated_dtype := _serialize_annotated_dtype(dtype):
+        return [annotated_dtype]
+    return list(_merge_literals(_serialize_dtype(dtype)))
+
+
+def _get_scan_argument(metadata: tuple) -> ScanArgument | None:
+    """
+    Return ScanArgument metadata from an Annotated metadata tuple, if present.
+
+    Args:
+        metadata (tuple): Metadata entries from an Annotated annotation.
+
+    Returns:
+        ScanArgument | None: ScanArgument metadata if present, otherwise None.
+    """
+    for entry in metadata:
+        if isinstance(entry, ScanArgument):
+            return entry
+    return None
+
+
+def _serialize_annotated_dtype(dtype: object) -> dict | str | list[str | dict] | None:
+    """
+    Serialize Annotated dtype metadata supported by the scan argument schema.
+
+    Args:
+        dtype (object): Type annotation to serialize.
+
+    Returns:
+        dict | str | list[str | dict] | None: Serialized annotation, base annotation, or None if
+        dtype is not Annotated.
+    """
+    if get_origin(dtype) is not Annotated:
+        return None
+
+    dtype_arg, *metadata = get_args(dtype)
+    serialized_dtype = serialize_dtype(dtype_arg)
+    scan_argument = _get_scan_argument(tuple(metadata))
+    if scan_argument is None:
+        return serialized_dtype
+    return {
+        "Annotated": {
+            "type": serialized_dtype,
+            "metadata": {"ScanArgument": scan_argument.model_dump()},
+        }
+    }
+
+
 def _merge_literals(vals: Generator[str | dict, None, None]) -> Generator[str | dict, None, None]:
+    """
+    Merge serialized Literal entries while preserving non-literal annotation payloads.
+
+    Args:
+        vals (Generator[str | dict, None, None]): Serialized dtype values to merge.
+
+    Yields:
+        str | dict: Serialized dtype values with Literal entries merged.
+    """
     _literal_args = []
     for val in vals:
         if val == "NoneType":
             _literal_args.append(None)
             continue
         if not isinstance(val, dict):
+            yield val
+        elif "Literal" not in val:
             yield val
         else:
             _literal_args.extend(val["Literal"])
@@ -47,12 +127,32 @@ def _merge_literals(vals: Generator[str | dict, None, None]) -> Generator[str | 
         yield {"Literal": tuple(_literal_args)}
 
 
-def serialize_dtype(dtype: type) -> list[str | dict] | str | dict:
+def serialize_dtype(dtype: object) -> list[str | dict] | str | dict:
+    """
+    Serialize a Python type annotation.
+
+    Args:
+        dtype (object): Type annotation to serialize.
+
+    Returns:
+        list[str | dict] | str | dict: Serialized dtype payload.
+    """
+    if annotated_dtype := _serialize_annotated_dtype(dtype):
+        return annotated_dtype
     type_list = list(_merge_literals(_serialize_dtype(dtype)))
     return (type_list[0] if len(type_list) == 1 else type_list) or "_empty"
 
 
-def _deser_simple_type(dtype):
+def _deser_simple_type(dtype: str) -> type | None:
+    """
+    Deserialize a simple named type, if it is supported.
+
+    Args:
+        dtype (str): Serialized type name.
+
+    Returns:
+        type | None: Deserialized type if supported, otherwise None.
+    """
     if hasattr(builtins, dtype):
         return getattr(builtins, dtype)
     if hasattr(np, dtype):
@@ -63,7 +163,37 @@ def _deser_simple_type(dtype):
         return ScanItem
 
 
-def deserialize_dtype(dtype: list | dict | str):
+def _deserialize_annotated_dtype(annotated_dtype: object) -> object:
+    """
+    Deserialize an Annotated payload if it contains valid ScanArgument metadata.
+
+    Args:
+        annotated_dtype (object): Serialized Annotated payload.
+
+    Returns:
+        object: Annotated type for valid ScanArgument metadata, otherwise the base type.
+    """
+    if not isinstance(annotated_dtype, dict):
+        # pylint: disable=protected-access
+        return inspect._empty
+
+    base_dtype = deserialize_dtype(annotated_dtype.get("type", "_empty"))
+    metadata = annotated_dtype.get("metadata", {})
+    if not isinstance(metadata, dict):
+        return base_dtype
+
+    scan_argument_data = metadata.get("ScanArgument")
+    if scan_argument_data is None:
+        return base_dtype
+
+    try:
+        scan_argument = ScanArgument.model_validate(scan_argument_data)
+    except ValidationError:
+        return base_dtype
+    return Annotated[base_dtype, scan_argument]
+
+
+def deserialize_dtype(dtype: list | dict | str) -> object:
     """
     Convert a serialized dtype to a type.
 
@@ -76,6 +206,9 @@ def deserialize_dtype(dtype: list | dict | str):
     if isinstance(dtype, list):
         return Union[*(deserialize_dtype(t) for t in dtype)]
     if isinstance(dtype, dict):
+        if "Annotated" in dtype:
+            annotated_dtype = dtype.get("Annotated")
+            return _deserialize_annotated_dtype(annotated_dtype)
         return Literal[*dtype["Literal"]]
     if dtype == "_empty":
         # pylint: disable=protected-access
@@ -100,7 +233,7 @@ def signature_to_dict(func: Callable, include_class_obj=False) -> list[dict]:
     out = []
     params = inspect.signature(func).parameters
     try:
-        type_hints = get_type_hints(func)
+        type_hints = get_type_hints(func, include_extras=True)
     except NameError as e:
         raise TypeError(
             f"Couldn't find annotated type {e.name}. The type you annotate with must be available in the local scope! Check it is not hidden by TYPE_CHECKING."

--- a/bec_lib/pyproject.toml
+++ b/bec_lib/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "prettytable~=3.9",
     "h5py~=3.10",
     "hdf5plugin >=4.3, < 6.0",
+    "pint~=0.25",
     "python-dotenv~=1.0",
     "python-slugify~=8.0",
 ]

--- a/bec_lib/tests/test_scan_context.py
+++ b/bec_lib/tests/test_scan_context.py
@@ -1,8 +1,10 @@
+from typing import Annotated
 from unittest import mock
 
 import pytest
 
 from bec_lib.device import DeviceBase
+from bec_lib.scan_args import ScanArgument
 from bec_lib.scans import (
     DatasetIdOnHold,
     FileWriter,
@@ -11,7 +13,9 @@ from bec_lib.scans import (
     ScanDef,
     ScanExport,
     ScanGroup,
+    Scans,
 )
+from bec_lib.signature_serializer import serialize_dtype
 
 # pylint: disable=no-member
 # pylint: disable=missing-function-docstring
@@ -146,15 +150,56 @@ def test_parameter_bundler(bec_client_mock):
         ("int", int),
         ("list", list),
         ("boolean", bool),
+        ("bool", bool),
         ("str", str),
         ("dict", dict),
         ("device", DeviceBase),
+        ("DeviceBase", DeviceBase),
+        (serialize_dtype(Annotated[float, ScanArgument(description="Step size")]), float),
+        (
+            serialize_dtype(Annotated[float, ScanArgument(description="Step size")] | None),
+            (float, type(None)),
+        ),
     ],
 )
 def test_get_arg_type(bec_client_mock, in_type, out):
     client = bec_client_mock
     res = client.scans.get_arg_type(in_type)
     assert res == out
+
+
+def test_strip_scan_signature_annotations_for_ipython_signature():
+    signature = [
+        {
+            "name": "step",
+            "kind": "POSITIONAL_OR_KEYWORD",
+            "default": "_empty",
+            "annotation": serialize_dtype(Annotated[float, ScanArgument(description="Step size")]),
+        },
+        {
+            "name": "optional_step",
+            "kind": "POSITIONAL_OR_KEYWORD",
+            "default": None,
+            "annotation": serialize_dtype(
+                Annotated[float, ScanArgument(description="Optional step size")] | None
+            ),
+        },
+    ]
+
+    assert Scans._strip_scan_signature_annotations(signature) == [
+        {
+            "name": "step",
+            "kind": "POSITIONAL_OR_KEYWORD",
+            "default": "_empty",
+            "annotation": "float",
+        },
+        {
+            "name": "optional_step",
+            "kind": "POSITIONAL_OR_KEYWORD",
+            "default": None,
+            "annotation": ["float", "NoneType"],
+        },
+    ]
 
 
 def test_get_arg_type_raises(bec_client_mock):

--- a/bec_lib/tests/test_signature_serializer.py
+++ b/bec_lib/tests/test_signature_serializer.py
@@ -1,10 +1,12 @@
 import inspect
-from typing import Literal, Optional, Union
+from typing import Annotated, Literal, Optional, Union
 
 import numpy as np
 import pytest
+from pydantic import ValidationError
 
 from bec_lib.device import DeviceBase
+from bec_lib.scan_args import ScanArgument, Units
 from bec_lib.scan_items import ScanItem
 from bec_lib.signature_serializer import (
     deserialize_dtype,
@@ -107,6 +109,154 @@ def test_signature_serializer_with_literals():
     assert sig == inspect.signature(test_func)
 
 
+def test_signature_serializer_with_scan_argument_annotation():
+    scan_argument = ScanArgument(
+        description="Step size", tooltip="Motor step size", expert=True, units=Units.mm
+    )
+
+    def test_func(step: Annotated[float, scan_argument]):
+        pass
+
+    params = signature_to_dict(test_func)
+    assert params == [
+        {
+            "name": "step",
+            "kind": "POSITIONAL_OR_KEYWORD",
+            "default": "_empty",
+            "annotation": {
+                "Annotated": {
+                    "type": "float",
+                    "metadata": {
+                        "ScanArgument": {
+                            "description": "Step size",
+                            "display_name": None,
+                            "tooltip": "Motor step size",
+                            "expert": True,
+                            "alternative_group": None,
+                            "units": "mm",
+                            "reference_units": None,
+                            "gt": None,
+                            "ge": None,
+                            "lt": None,
+                            "le": None,
+                            "reference_limits": None,
+                        }
+                    },
+                }
+            },
+        }
+    ]
+
+    sig = dict_to_signature(params)
+    assert sig == inspect.signature(test_func)
+
+
+def test_scan_argument_accepts_units():
+    scan_argument = ScanArgument(units=Units.mm)
+
+    assert scan_argument.units == "mm"
+
+
+def test_scan_argument_accepts_compound_units():
+    scan_argument = ScanArgument(units=Units.mm / Units.s)
+
+    assert scan_argument.units == "mm/s"
+
+
+def test_scan_argument_accepts_quantity_units():
+    scan_argument = ScanArgument(units=1 * Units.mm / Units.s)
+
+    assert scan_argument.units == "mm/s"
+
+
+def test_scan_argument_accepts_reference_units():
+    scan_argument = ScanArgument(reference_units="motor")
+
+    assert scan_argument.reference_units == "motor"
+
+
+def test_scan_argument_accepts_alternative_group():
+    scan_argument = ScanArgument(alternative_group="scan_resolution")
+
+    assert scan_argument.alternative_group == "scan_resolution"
+
+
+def test_scan_argument_accepts_display_name_and_limits():
+    scan_argument = ScanArgument(
+        display_name="Step Size", gt=0, ge=0.1, lt=10, le=9.9, reference_limits="motor"
+    )
+
+    assert scan_argument.display_name == "Step Size"
+    assert scan_argument.gt == 0
+    assert scan_argument.ge == 0.1
+    assert scan_argument.lt == 10
+    assert scan_argument.le == 9.9
+    assert scan_argument.reference_limits == "motor"
+
+
+def test_scan_argument_unit_and_reference_units_are_exclusive():
+    with pytest.raises(ValidationError, match="units and reference_units are mutually exclusive"):
+        ScanArgument(units=Units.mm, reference_units="motor")
+
+
+def test_scan_argument_reference_units_rejects_units():
+    with pytest.raises(ValidationError):
+        ScanArgument(reference_units=Units.T / Units.min)
+
+
+def test_signature_serializer_ignores_unknown_annotated_metadata():
+    def test_func(a: Annotated[float, "unknown metadata"]):
+        pass
+
+    params = signature_to_dict(test_func)
+    assert params == [
+        {"name": "a", "kind": "POSITIONAL_OR_KEYWORD", "default": "_empty", "annotation": "float"}
+    ]
+
+
+def test_signature_serializer_with_optional_scan_argument_annotation():
+    scan_argument = ScanArgument(description="Optional step size")
+
+    def test_func(step: Annotated[float, scan_argument] | None = None):
+        pass
+
+    params = signature_to_dict(test_func)
+    assert params == [
+        {
+            "name": "step",
+            "kind": "POSITIONAL_OR_KEYWORD",
+            "default": None,
+            "annotation": [
+                {
+                    "Annotated": {
+                        "type": "float",
+                        "metadata": {
+                            "ScanArgument": {
+                                "description": "Optional step size",
+                                "display_name": None,
+                                "tooltip": None,
+                                "expert": False,
+                                "alternative_group": None,
+                                "units": None,
+                                "reference_units": None,
+                                "gt": None,
+                                "ge": None,
+                                "lt": None,
+                                "le": None,
+                                "reference_limits": None,
+                            }
+                        },
+                    }
+                },
+                "NoneType",
+            ],
+        }
+    ]
+
+    sig = dict_to_signature(params)
+    assert sig == inspect.signature(test_func)
+
+
 @pytest.mark.parametrize(
     "dtype_in,dtype_out",
     [
@@ -121,6 +271,57 @@ def test_signature_serializer_with_literals():
         (DeviceBase, "DeviceBase"),
         (ScanItem, "ScanItem"),
         (np.ndarray, "ndarray"),
+        (
+            Annotated[
+                float, ScanArgument(description="Step size", alternative_group="scan_resolution")
+            ],
+            {
+                "Annotated": {
+                    "type": "float",
+                    "metadata": {
+                        "ScanArgument": {
+                            "description": "Step size",
+                            "display_name": None,
+                            "tooltip": None,
+                            "expert": False,
+                            "alternative_group": "scan_resolution",
+                            "units": None,
+                            "reference_units": None,
+                            "gt": None,
+                            "ge": None,
+                            "lt": None,
+                            "le": None,
+                            "reference_limits": None,
+                        }
+                    },
+                }
+            },
+        ),
+        (
+            Annotated[float, ScanArgument(units=Units.mm / Units.s)],
+            {
+                "Annotated": {
+                    "type": "float",
+                    "metadata": {
+                        "ScanArgument": {
+                            "description": None,
+                            "display_name": None,
+                            "tooltip": None,
+                            "expert": False,
+                            "alternative_group": None,
+                            "units": "mm/s",
+                            "reference_units": None,
+                            "gt": None,
+                            "ge": None,
+                            "lt": None,
+                            "le": None,
+                            "reference_limits": None,
+                        }
+                    },
+                }
+            },
+        ),
+        (Annotated[float, "unknown metadata"], "float"),
     ],
 )
 def test_serialize_dtype(dtype_in, dtype_out):
@@ -142,6 +343,44 @@ def test_serialize_dtype(dtype_in, dtype_out):
         ("DeviceBase", DeviceBase),
         ("ScanItem", ScanItem),
         ("ndarray", np.ndarray),
+        (
+            {
+                "Annotated": {
+                    "type": "float",
+                    "metadata": {
+                        "ScanArgument": {
+                            "description": "Step size",
+                            "display_name": None,
+                            "tooltip": None,
+                            "expert": False,
+                            "alternative_group": "scan_resolution",
+                            "units": None,
+                            "reference_units": None,
+                            "gt": None,
+                            "ge": None,
+                            "lt": None,
+                            "le": None,
+                            "reference_limits": None,
+                        }
+                    },
+                }
+            },
+            Annotated[
+                float, ScanArgument(description="Step size", alternative_group="scan_resolution")
+            ],
+        ),
+        ({"Annotated": {"type": "float", "metadata": {"Other": {}}}}, float),
+        ({"Annotated": {"type": "float", "metadata": {}}}, float),
+        ({"Annotated": {"type": "float"}}, float),
+        (
+            {
+                "Annotated": {
+                    "type": "float",
+                    "metadata": {"ScanArgument": {"units": "mm", "reference_units": "motor"}},
+                }
+            },
+            float,
+        ),
     ],
 )
 def test_deserialize_dtype(dtype_in, dtype_out):

--- a/bec_server/bec_server/scan_server/scan_gui_models.py
+++ b/bec_server/bec_server/scan_server/scan_gui_models.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
+import inspect
 import re
 from contextvars import ContextVar
-from typing import Any, Literal, Optional, Type
+from typing import Annotated, Any, Literal, Optional, Type, get_args, get_origin
 
 from pydantic import BaseModel, Field, field_validator
 from pydantic_core import PydanticCustomError
 
+from bec_lib.device import DeviceBase
 from bec_lib.signature_serializer import signature_to_dict
-from bec_server.scan_server.scans import ScanBase
+from bec_server.scan_server.scans import ScanArgType, ScanBase
 
 context_signature = ContextVar("context_signature")
 context_docstring = ContextVar("context_docstring")
@@ -31,6 +33,34 @@ class GUIInput(BaseModel):
     tooltip: Optional[str] = Field(None, validate_default=True)
     default: Optional[Any] = Field(None, validate_default=True)
     expert: Optional[bool] = Field(False)  # TODO decide later how to implement
+
+    @classmethod
+    def convert_to_legacy_scan_arg_type(cls, value):
+        """Convert richer typing annotations to the legacy ScanArgType enum."""
+        if isinstance(value, ScanArgType):
+            return value
+
+        if get_origin(value) is Annotated:
+            value = get_args(value)[0]
+
+        if not inspect.isclass(value):
+            return value
+
+        if issubclass(value, DeviceBase):
+            return ScanArgType.DEVICE
+        if issubclass(value, bool):
+            return ScanArgType.BOOL
+        if issubclass(value, int):
+            return ScanArgType.INT
+        if issubclass(value, float):
+            return ScanArgType.FLOAT
+        if issubclass(value, str):
+            return ScanArgType.STR
+        if issubclass(value, list):
+            return ScanArgType.LIST
+        if issubclass(value, dict):
+            return ScanArgType.DICT
+        return value
 
     @field_validator("name")
     @classmethod
@@ -167,13 +197,21 @@ class GUIArgGroup(BaseModel):
     min: Optional[int] = Field(None)
     max: Optional[int] = Field(None)
 
+    @field_validator("arg_inputs")
+    @classmethod
+    def validate_arg_inputs(cls, v):
+        return {key: GUIInput.convert_to_legacy_scan_arg_type(value) for key, value in v.items()}
+
     @field_validator("inputs")
     @classmethod
     def validate_inputs(cls, v, values):
         if v is not None:
             return v
         arg_inputs = values.data["arg_inputs"]
-        arg_inputs_str = {key: value.value for key, value in arg_inputs.items()}
+        arg_inputs_str = {
+            key: value.value if isinstance(value, ScanArgType) else value
+            for key, value in arg_inputs.items()
+        }
         v = []
         for name, type_ in arg_inputs_str.items():
             v.append(GUIInput(name=name, type=type_, arg=True))

--- a/bec_server/bec_server/scan_server/scan_manager.py
+++ b/bec_server/bec_server/scan_server/scan_manager.py
@@ -9,12 +9,22 @@ from bec_lib.device import DeviceBase
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.logger import bec_logger
 from bec_lib.messages import AvailableResourceMessage
-from bec_lib.signature_serializer import signature_to_dict
+from bec_lib.signature_serializer import serialize_dtype, signature_to_dict
 from bec_server.scan_server.scan_gui_models import GUIConfig
 
 from . import scans as scans_module
 
 logger = bec_logger.logger
+
+_SCAN_ARG_TYPE_TO_DTYPE = {
+    scans_module.ScanArgType.DEVICE: DeviceBase,
+    scans_module.ScanArgType.FLOAT: float,
+    scans_module.ScanArgType.INT: int,
+    scans_module.ScanArgType.BOOL: bool,
+    scans_module.ScanArgType.STR: str,
+    scans_module.ScanArgType.LIST: list,
+    scans_module.ScanArgType.DICT: dict,
+}
 
 
 class ScanManager:
@@ -77,15 +87,22 @@ class ScanManager:
                     base_cls = report_cls.__name__
             self.scan_dict[scan_cls.__name__] = scan_cls
             gui_config = self.validate_gui_config(scan_cls)
+            gui_visibility = {}
+            if hasattr(scan_cls, "gui_visibility"):
+                gui_visibility = scan_cls.gui_visibility  # type: ignore
+            elif hasattr(scan_cls, "gui_config"):  # type: ignore
+                gui_visibility = scan_cls.gui_config  # type: ignore
+
             self.available_scans[scan_cls.scan_name] = {
                 "class": scan_cls.__name__,
                 "base_class": base_cls,
                 "arg_input": self.convert_arg_input(scan_cls.arg_input),
-                "gui_config": gui_config,
                 "required_kwargs": scan_cls.required_kwargs,
                 "arg_bundle_size": scan_cls.arg_bundle_size,
                 "doc": scan_cls.__doc__ or scan_cls.__init__.__doc__,
                 "signature": signature_to_dict(scan_cls.__init__),
+                "gui_visibility": gui_visibility,
+                "gui_config": gui_config,  # deprecated! - should be removed
             }
 
     def validate_gui_config(self, scan_cls) -> dict:
@@ -125,18 +142,13 @@ class ScanManager:
         Returns:
             dict: converted arg_input
         """
+        converted_arg_input = {}
         for key, value in arg_input.items():
-            if isinstance(value, scans_module.ScanArgType):
-                continue
-            if issubclass(value, DeviceBase):
-                # once we have generalized the device types, this should be removed
-                arg_input[key] = "device"
-            elif issubclass(value, bool):
-                # should be unified with the ScanArgType.BOOL
-                arg_input[key] = "boolean"
-            else:
-                arg_input[key] = value.__name__
-        return arg_input
+            dtype = _SCAN_ARG_TYPE_TO_DTYPE.get(value, value)
+            if inspect.isclass(dtype) and issubclass(dtype, DeviceBase):
+                dtype = DeviceBase
+            converted_arg_input[key] = serialize_dtype(dtype)
+        return converted_arg_input
 
     def publish_available_scans(self):
         """send all available scans to the broker"""

--- a/bec_server/tests/tests_scan_server/test_scan_gui_models.py
+++ b/bec_server/tests/tests_scan_server/test_scan_gui_models.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Annotated, Literal
 
 import pytest
 from pydantic import ValidationError
@@ -100,6 +100,23 @@ class WrongDocs(ScanBase):  # pragma: no cover
         """
 
     print("I am a scan with wrong docs.")
+
+
+class RichArgInputScan(ScanBase):  # pragma: no cover
+    scan_name = "rich_arg_input_scan"
+    required_kwargs = []
+    arg_input = {
+        "device": ScanArgType.DEVICE,
+        "start": Annotated[float, "device"],
+        "stop": Annotated[float, "device"],
+        "steps": int,
+    }
+    arg_bundle_size = {"bundle": len(arg_input), "min": 1, "max": None}
+    gui_config = {"Scan Parameters": []}
+
+    def __init__(self, *args, **kwargs):
+        """Scan with richer arg_input typing for GUI compatibility tests."""
+        super().__init__(**kwargs)
 
 
 def test_gui_config_good_scan_dump():
@@ -262,3 +279,53 @@ def test_gui_config_wrong_docs():
         ],
     }
     assert gui_config.model_dump() == expected
+
+
+def test_gui_config_rich_arg_input_is_converted_to_legacy_scan_arg_types():
+    gui_config = GUIConfig.from_dict(RichArgInputScan)
+
+    assert gui_config.arg_group.model_dump()["arg_inputs"] == {
+        "device": ScanArgType.DEVICE,
+        "start": ScanArgType.FLOAT,
+        "stop": ScanArgType.FLOAT,
+        "steps": ScanArgType.INT,
+    }
+
+    assert gui_config.arg_group.model_dump()["inputs"] == [
+        {
+            "arg": True,
+            "name": "device",
+            "display_name": "Device",
+            "type": "device",
+            "tooltip": None,
+            "default": None,
+            "expert": False,
+        },
+        {
+            "arg": True,
+            "name": "start",
+            "display_name": "Start",
+            "type": "float",
+            "tooltip": None,
+            "default": None,
+            "expert": False,
+        },
+        {
+            "arg": True,
+            "name": "stop",
+            "display_name": "Stop",
+            "type": "float",
+            "tooltip": None,
+            "default": None,
+            "expert": False,
+        },
+        {
+            "arg": True,
+            "name": "steps",
+            "display_name": "Steps",
+            "type": "int",
+            "tooltip": None,
+            "default": None,
+            "expert": False,
+        },
+    ]

--- a/bec_server/tests/tests_scan_server/test_scan_server_scan_manager.py
+++ b/bec_server/tests/tests_scan_server/test_scan_server_scan_manager.py
@@ -18,20 +18,29 @@ def scan_manager():
     [
         ({"a": float}, {"a": "float"}),
         ({"a": ScanArgType.FLOAT}, {"a": "float"}),
-        ({"a": ScanArgType.DEVICE}, {"a": "device"}),
+        ({"a": ScanArgType.DEVICE}, {"a": "DeviceBase"}),
         ({"a": ScanArgType.INT}, {"a": "int"}),
-        ({"a": ScanArgType.BOOL}, {"a": "boolean"}),
+        ({"a": ScanArgType.BOOL}, {"a": "bool"}),
         ({"a": ScanArgType.LIST}, {"a": "list"}),
         ({"a": ScanArgType.DICT}, {"a": "dict"}),
         ({"a": str}, {"a": "str"}),
         ({"a": int}, {"a": "int"}),
-        ({"a": bool}, {"a": "boolean"}),
+        ({"a": bool}, {"a": "bool"}),
         ({"a": list}, {"a": "list"}),
         ({"a": dict}, {"a": "dict"}),
-        ({"a": DeviceBase}, {"a": "device"}),
-        ({"a": Device}, {"a": "device"}),
-        ({"a": Positioner}, {"a": "device"}),
+        ({"a": DeviceBase}, {"a": "DeviceBase"}),
+        ({"a": Device}, {"a": "DeviceBase"}),
+        ({"a": Positioner}, {"a": "DeviceBase"}),
+        ({"a": DeviceBase | str}, {"a": ["DeviceBase", "str"]}),
     ],
 )
 def test_scan_manager_convert_arg_input(scan_manager, arg_input, arg_output):
     assert scan_manager.convert_arg_input(arg_input) == arg_output
+
+
+def test_scan_manager_convert_arg_input_does_not_mutate(scan_manager):
+    arg_input = {"a": ScanArgType.FLOAT}
+
+    scan_manager.convert_arg_input(arg_input)
+
+    assert arg_input == {"a": ScanArgType.FLOAT}


### PR DESCRIPTION
This PR moves the scan signature from `ScanArgType` enums to proper python types and adds support for type annotations. Type annotations will allow us to augment the signature with metadata, provided through a ScanArgument pydantic model, e.g. 


```python 

def __init__(
    self,
    motor1: Annotated[DeviceBase, ScanArgument(description="Motor 1")],
    start_motor1: Annotated[
        float, ScanArgument(description="Start position for motor 1", reference_units="motor1")
    ],
    stop_motor1: Annotated[
        float, ScanArgument(description="Stop position for motor 1", reference_units="motor1")
    ],
    velocity: Annotated[
        float,
        ScanArgument(description="Velocity for the motor", units=Units.mm / Units.s, expert=True),
    ],
    energy: Annotated[
        float,
        ScanArgument(
            description="Energy for the scan",
            units=Units.keV,
            tooltip="Energy in keV, converted to motor units using the current calibration",
        ),
    ],
    step_size: Annotated[
        float,
        ScanArgument(
            description="Step size for the scan",
            reference_units="motor1",
            alternative_group="step_parameterization",
        ),
    ],
    steps: Annotated[
        int,
        ScanArgument(
            description="Number of steps for the scan. Alternative to step_size.",
            alternative_group="step_parameterization",
        ),
    ],
    ramp_up: Annotated[
        float, ScanArgument(description="Magnetic field ramp up speed", units=Units.T / Units.min)
    ] = 0.5,
):
```

Once we've migrated BW to the new interface, we can completely remove the `scan_gui_model` module. 

Please note that the gui_config dictionary will remain there (albeit called `gui_visibility`), to provide a grouping for gui elements.

## BEC Widgets

We will need to update BW to benefit from the new scan signature. There is already a somewhat dirty draft here: https://github.com/bec-project/bec_widgets/pull/1122 
Might be useful to test it together. 