### PR TITLE
Refactor: remove all staticmethod callbacks

### DIFF
--- a/bec_ipython_client/bec_ipython_client/callbacks/move_device.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/move_device.py
@@ -48,13 +48,12 @@ class ReadbackDataHandler:
         """register callbacks for device readback messages."""
         for dev in self.devices:
             self.connector.register(
-                MessageEndpoints.device_readback(dev), cb=self.on_readback, parent=self, device=dev
+                MessageEndpoints.device_readback(dev), cb=self.on_readback, device=dev
             )
         self.connector.register(
             MessageEndpoints.device_req_status(self.request_id),
             cb=self.on_req_status,
             from_start=True,
-            parent=self,
         )
 
     def _unregister_callbacks(self):
@@ -65,10 +64,7 @@ class ReadbackDataHandler:
             MessageEndpoints.device_req_status(self.request_id), cb=self.on_req_status
         )
 
-    @staticmethod
-    def on_req_status(
-        msg_obj: dict[str, messages.DeviceReqStatusMessage], parent: ReadbackDataHandler
-    ):
+    def on_req_status(self, msg_obj: dict[str, messages.DeviceReqStatusMessage]):
         """Callback for device request status messages to track which devices are done.
 
         Args:
@@ -77,19 +73,18 @@ class ReadbackDataHandler:
         """
         # pylint: disable=protected-access
         msg = msg_obj["data"]
-        if msg.request_id != parent.request_id:
+        if msg.request_id != self.request_id:
             return
         device = msg.device
-        parent._devices_done_state[device] = (True, msg.success)
+        self._devices_done_state[device] = (True, msg.success)
 
         if (
-            all(done for done, _ in parent._devices_done_state.values())
-            and not parent.requests_done.is_set()
+            all(done for done, _ in self._devices_done_state.values())
+            and not self.requests_done.is_set()
         ):
-            parent._on_request_done()
+            self._on_request_done()
 
-    @staticmethod
-    def on_readback(msg_obj: MessageObject, parent: ReadbackDataHandler, device: str):
+    def on_readback(self, msg_obj: MessageObject, device: str):
         """Callback for updating device readback data.
 
         Args:
@@ -99,8 +94,8 @@ class ReadbackDataHandler:
         """
         # pylint: disable=protected-access
         msg: messages.DeviceMessage = cast(messages.DeviceMessage, msg_obj.value)
-        parent._devices_received[device] = True
-        parent.data[device] = msg
+        self._devices_received[device] = True
+        self.data[device] = msg
 
     def _on_request_done(self):
         """Callback for when all requests are done."""

--- a/bec_lib/bec_lib/alarm_handler.py
+++ b/bec_lib/bec_lib/alarm_handler.py
@@ -101,15 +101,11 @@ class AlarmHandler:
     def start(self):
         """start the alarm handler and its subscriptions"""
         self.connector.register(
-            topics=MessageEndpoints.alarm(),
-            name="AlarmHandler",
-            cb=self._alarm_register_callback,
-            parent=self,
+            topics=MessageEndpoints.alarm(), name="AlarmHandler", cb=self._alarm_register_callback
         )
 
-    @staticmethod
-    def _alarm_register_callback(msg, *, parent, **_kwargs):
-        parent.add_alarm(msg.value)
+    def _alarm_register_callback(self, msg, **_kwargs):
+        self.add_alarm(msg.value)
 
     @threadlocked
     def add_alarm(self, msg: messages.AlarmMessage):

--- a/bec_lib/bec_lib/bl_state_manager.py
+++ b/bec_lib/bec_lib/bl_state_manager.py
@@ -112,17 +112,13 @@ class BeamlineStateManager:
         self._connector = client.connector
         self._states: dict[str, BeamlineStateConfig] = {}
         self._connector.register(
-            MessageEndpoints.available_beamline_states(),
-            cb=self._on_state_update,
-            parent=self,
-            from_start=True,
+            MessageEndpoints.available_beamline_states(), cb=self._on_state_update, from_start=True
         )
 
-    @staticmethod
-    def _on_state_update(msg_dict: dict, *, parent: BeamlineStateManager, **_kwargs) -> None:
+    def _on_state_update(self, msg_dict: dict, **_kwargs) -> None:
         # type: ignore ; we know it's an AvailableBeamlineStatesMessage
         msg: messages.AvailableBeamlineStatesMessage = msg_dict["data"]
-        parent._update_states(msg.states)  # pylint: disable=protected-access
+        self._update_states(msg.states)  # pylint: disable=protected-access
 
     def _update_state(self, state: BeamlineStateConfig) -> None:
         if state.name in self._states:

--- a/bec_lib/bec_lib/bl_states.py
+++ b/bec_lib/bec_lib/bl_states.py
@@ -26,10 +26,11 @@ def with_state_error_handling(func: Callable) -> Callable:
     3. If the decorated function fails, emits an "unknown" state and raises an alarm
 
     The decorated function should expect a 'parent' parameter of type DeviceBeamlineState.
+    This could be the 'self' parameter of an instance method on a DeviceBeamlineState subclass.
     """
 
     @functools.wraps(func)
-    def wrapper(msg_obj: MessageObject, parent: "DeviceBeamlineState") -> None:
+    def wrapper(parent: "DeviceBeamlineState", msg_obj: MessageObject) -> None:
         assert parent.connector is not None
 
         try:
@@ -39,7 +40,7 @@ def with_state_error_handling(func: Callable) -> Callable:
             return
 
         try:
-            result = func(msg_obj, parent)
+            result = func(parent, msg_obj)
             if result is not None:
                 parent._emit_state(result)
         except Exception as exc:
@@ -293,13 +294,11 @@ class DeviceBeamlineState(BeamlineState[D], Generic[D]):
                 MessageObject(
                     topic=MessageEndpoints.device_readback(self.device_obj.root.name).endpoint,
                     value=msg,
-                ),
-                parent=self,
+                )
             )
         self.connector.register(
             MessageEndpoints.device_readback(self.device_obj.root.name),
             cb=self._update_device_state,
-            parent=self,
         )
 
     def stop(self) -> None:
@@ -314,16 +313,13 @@ class DeviceBeamlineState(BeamlineState[D], Generic[D]):
 
         super().stop()
 
-    @staticmethod
     @with_state_error_handling
-    def _update_device_state(
-        msg_obj: MessageObject, parent: DeviceBeamlineState
-    ) -> messages.BeamlineStateMessage | None:
+    def _update_device_state(self, msg_obj: MessageObject) -> messages.BeamlineStateMessage | None:
         """
         Update the device state based on the received message.
         """
         msg: messages.DeviceMessage = msg_obj.value  # type: ignore ; we know it's a DeviceMessage
-        return parent.evaluate(msg)
+        return self.evaluate(msg)
 
 
 class ShutterState(DeviceBeamlineState[DeviceStateConfig]):

--- a/bec_lib/bec_lib/device.py
+++ b/bec_lib/bec_lib/device.py
@@ -138,7 +138,6 @@ class Status:
         self._connector.register(
             MessageEndpoints.device_req_status(self._request_id),
             cb=self._on_status_update,
-            parent=self,
             from_start=True,
         )
 
@@ -147,11 +146,10 @@ class Status:
             return self._request_id == __value._request_id
         return False
 
-    @staticmethod
-    def _on_status_update(msg: dict[str, messages.DeviceReqStatusMessage], parent: Status):
+    def _on_status_update(self, msg: dict[str, messages.DeviceReqStatusMessage]):
         # pylint: disable=protected-access
-        parent._request_status = msg["data"]
-        parent._set_done()
+        self._request_status = msg["data"]
+        self._set_done()
 
     def _set_done(self):
         self._status_done.set()

--- a/bec_lib/bec_lib/devicemanager.py
+++ b/bec_lib/bec_lib/devicemanager.py
@@ -633,16 +633,11 @@ class DeviceManagerBase:
 
         """
         self.connector.register(
-            MessageEndpoints.device_config_update(),
-            cb=self._device_config_update_callback,
-            parent=self,
+            MessageEndpoints.device_config_update(), cb=self._device_config_update_callback
         )
-        self.connector.register(
-            MessageEndpoints.scan_status(), cb=self._update_scan_info, parent=self
-        )
+        self.connector.register(MessageEndpoints.scan_status(), cb=self._update_scan_info)
 
-    @staticmethod
-    def _log_callback(msg, *, parent, **kwargs) -> None:
+    def _log_callback(self, msg, **kwargs) -> None:
         """
         Consumer callback for handling log messages.
         Args:
@@ -655,8 +650,7 @@ class DeviceManagerBase:
         """
         logger.info(f"Received log message: {str(msg)}")
 
-    @staticmethod
-    def _device_config_update_callback(msg, *, parent, **kwargs) -> None:
+    def _device_config_update_callback(self, msg) -> None:
         """
         Consumer callback for handling new device configuration
         Args:
@@ -667,18 +661,17 @@ class DeviceManagerBase:
 
         """
         logger.info(f"Received new config: {str(msg)}")
-        allow_override = parent._allow_override
+        allow_override = self._allow_override
         try:
-            parent._allow_override = True
-            parent.parse_config_message(msg.value)
+            self._allow_override = True
+            self.parse_config_message(msg.value)
         finally:
-            parent._allow_override = allow_override
+            self._allow_override = allow_override
 
-    @staticmethod
-    def _update_scan_info(msg, *, parent, **kwargs) -> None:
+    def _update_scan_info(self, msg, **kwargs) -> None:
         msg = msg.value
         logger.info(f"Received new ScanStatusMessage with ID {msg.scan_id}")
-        parent.scan_info.msg = msg
+        self.scan_info.msg = msg
 
     def _get_config(self, cancel_event: threading.Event | None = None) -> None:
         self._session["devices"] = self._get_redis_device_config()

--- a/bec_lib/bec_lib/macro_update_handler.py
+++ b/bec_lib/bec_lib/macro_update_handler.py
@@ -100,7 +100,7 @@ class MacroUpdateHandler:
         self.client = macros._client
         self._macro_path = self.client._service_config.model.user_macros.base_path
         self.client.connector.register(
-            MessageEndpoints.macro_update(), cb=self._macro_update_callback, parent=self
+            MessageEndpoints.macro_update(), cb=self._macro_update_callback
         )
 
     @property
@@ -271,8 +271,7 @@ class MacroUpdateHandler:
         self.forget_user_macro(name)
         self.load_user_macro(file, ignore_existing=True)
 
-    @staticmethod
-    def _macro_update_callback(msg, parent):
+    def _macro_update_callback(self, msg, parent):
         """Callback to handle macro update messages.
 
         Args:
@@ -284,7 +283,7 @@ class MacroUpdateHandler:
             logger.error(f"Received invalid message type: {type(msg)}")
             return
 
-        parent.on_macro_update(msg)
+        self.on_macro_update(msg)
 
     def get_macros_from_file(self, file: str) -> dict[str, dict[str, Any]]:
         """

--- a/bec_lib/bec_lib/redis_connector.py
+++ b/bec_lib/bec_lib/redis_connector.py
@@ -1074,7 +1074,8 @@ class RedisConnector:
         try:
             g = cb(msg, **kwargs)
         # pylint: disable=broad-except
-        except Exception:
+        except Exception as e:
+            logger.error(e)
             sys.excepthook(*sys.exc_info())  # type: ignore # inside except
         else:
             if inspect.isgenerator(g):

--- a/bec_lib/bec_lib/scan_manager.py
+++ b/bec_lib/bec_lib/scan_manager.py
@@ -307,13 +307,13 @@ class ScanManager:
         """set the next dataset number in redis"""
         self._scan_number_container.dataset_number = max(val, 1) - 1
 
-    def _scan_queue_status_callback(self, msg, **_kwargs) -> None:
+    def _scan_queue_status_callback(self, msg) -> None:
         queue_status: messages.ScanQueueStatusMessage = msg.value
         if not queue_status:
             return
         self.update_with_queue_status(queue_status)
 
-    def _scan_queue_request_response_callback(self, msg, **_kwargs) -> None:
+    def _scan_queue_request_response_callback(self, msg) -> None:
         response = msg.value
         self.request_storage.update_with_response(response)
 
@@ -321,11 +321,11 @@ class ScanManager:
         message = msg["data"]
         self.queue_storage.update_with_client_message(message)
 
-    def _scan_status_callback(self, msg, **_kwargs) -> None:
+    def _scan_status_callback(self, msg) -> None:
         scan = msg.value
         self.scan_storage.update_with_scan_status(scan)
 
-    def _scan_segment_callback(self, msg, **_kwargs) -> None:
+    def _scan_segment_callback(self, msg) -> None:
         scan_msgs = msg.value
         if not isinstance(scan_msgs, list):
             scan_msgs = [scan_msgs]

--- a/bec_lib/tests/test_beamline_states.py
+++ b/bec_lib/tests/test_beamline_states.py
@@ -98,7 +98,7 @@ class TestDeviceBeamlineState:
             state.start()
 
         register.assert_called_once_with(
-            MessageEndpoints.device_readback("samx"), cb=state._update_device_state, parent=state
+            MessageEndpoints.device_readback("samx"), cb=state._update_device_state
         )
 
     def test_stop_unregisters_device_callback(self, connected_connector, dm_with_devices):
@@ -134,7 +134,7 @@ class TestDeviceBeamlineState:
         )
         msg_obj = MessageObject(value=msg, topic="test")
 
-        state._update_device_state(msg_obj, parent=state)
+        state._update_device_state(MessageObject(value=msg, topic="test"))
 
         assert state._last_state is not None
         assert state._last_state.status == "valid"
@@ -206,10 +206,7 @@ class TestBeamlineStateManager:
             BeamlineStateManager(client)
 
         register.assert_called_once_with(
-            MessageEndpoints.available_beamline_states(),
-            cb=mock.ANY,
-            parent=mock.ANY,
-            from_start=True,
+            MessageEndpoints.available_beamline_states(), cb=mock.ANY, from_start=True
         )
 
     def test_on_state_update_creates_client_attribute(self, state_manager):

--- a/bec_lib/tests/test_device_manager.py
+++ b/bec_lib/tests/test_device_manager.py
@@ -402,7 +402,7 @@ def test_device_config_update_callback(dm_with_devices):
     msg = MessageObject(value=dev_config_msg, topic="")
 
     with mock.patch.object(device_manager, "parse_config_message") as parse_config_message:
-        device_manager._device_config_update_callback(msg, parent=device_manager)
+        device_manager._device_config_update_callback(msg)
         parse_config_message.assert_called_once_with(dev_config_msg)
 
 

--- a/bec_lib/tests/test_devices.py
+++ b/bec_lib/tests/test_devices.py
@@ -286,7 +286,7 @@ def test_rpc_status_raises_error(dev: Any):
     msg = messages.DeviceReqStatusMessage(device="samx", success=False, request_id="request_id")
     connector = mock.MagicMock()
     status = Status(connector, "request_id")
-    status._on_status_update({"data": msg}, parent=status)
+    status._on_status_update({"data": msg})
     with pytest.raises(RPCError):
         status.wait(raise_on_failure=True)
 
@@ -454,8 +454,7 @@ def test_status_wait():
             "data": messages.DeviceReqStatusMessage(
                 device="test_device", success=True, request_id="test_rid"
             )
-        },
-        parent=status,
+        }
     )
     status.wait()
 

--- a/bec_lib/tests/test_user_macros.py
+++ b/bec_lib/tests/test_user_macros.py
@@ -127,7 +127,7 @@ class MyClass:
     '''A safe class'''
     def __init__(self):
         self.value = 42
-    
+
     def method(self):
         return self.value
 
@@ -505,21 +505,6 @@ def test_macro_update_callback_with_different_message_types(user_macros):
         mock_msg.value = {"not": "a_message"}
         macros._update_handler._macro_update_callback(mock_msg, macros._update_handler)
         mock_logger.assert_called_with("Received invalid message type: <class 'dict'>")
-
-
-def test_macro_update_callback_static_method():
-    """Test that _macro_update_callback is properly decorated as staticmethod."""
-    # Verify it's a static method by calling it directly on the class
-    mock_msg = mock.MagicMock()
-    mock_msg.value = messages.MacroUpdateMessage(update_type="reload_all")
-
-    mock_parent = mock.MagicMock()
-
-    # This should work without creating an instance
-    MacroUpdateHandler._macro_update_callback(mock_msg, mock_parent)
-
-    # Verify the parent's on_macro_update method was called
-    mock_parent.on_macro_update.assert_called_once_with(mock_msg.value)
 
 
 def test_reload_user_macro_basic(user_macros):

--- a/bec_server/bec_server/device_server/device_server.py
+++ b/bec_server/bec_server/device_server/device_server.py
@@ -342,7 +342,6 @@ class DeviceServer(BECService):
             MessageEndpoints.device_instructions(),
             event=register_stop,
             cb=self.instructions_callback,
-            parent=self,
         )
 
         self.status = BECStatus.RUNNING
@@ -598,10 +597,9 @@ class DeviceServer(BECService):
             tb = tb.tb_next
         return None
 
-    @staticmethod
-    def instructions_callback(msg, *, parent, **_kwargs) -> None:
+    def instructions_callback(self, msg, **_kwargs) -> None:
         """callback for handling device instructions"""
-        parent.executor.submit(parent.handle_device_instructions, msg.value)
+        self.executor.submit(self.handle_device_instructions, msg.value)
 
     def _add_status_object_info(
         self,

--- a/bec_server/bec_server/device_server/devices/config_update_handler.py
+++ b/bec_server/bec_server/device_server/devices/config_update_handler.py
@@ -34,33 +34,30 @@ class ConfigUpdateHandler:
         self._active_request: RequestInfo | None = None
         self._lock = threading.Lock()
         self.connector.register(
-            MessageEndpoints.device_server_config_request(),
-            cb=self._device_config_callback,
-            parent=self,
+            MessageEndpoints.device_server_config_request(), cb=self._device_config_callback
         )
 
-    @staticmethod
-    def _device_config_callback(msg, *, parent: ConfigUpdateHandler, **_kwargs) -> None:
+    def _device_config_callback(self, msg) -> None:
         logger.info(f"Received request: {msg}")
         config_msg: messages.DeviceConfigMessage = msg.value
 
         # Handle cancel requests immediately
         if config_msg.action == "cancel":
-            parent._cancel_config_request(config_msg)
+            self._cancel_config_request(config_msg)
             return
 
         # Create a cancel event for this request
         cancel_event = threading.Event()
 
         # Submit to executor and store both future and cancel_event
-        future = parent.executor.submit(parent.parse_config_request, msg.value, cancel_event)
+        future = self.executor.submit(self.parse_config_request, msg.value, cancel_event)
 
-        with parent._lock:
-            parent._active_request = RequestInfo(
+        with self._lock:
+            self._active_request = RequestInfo(
                 future=future, cancel_event=cancel_event, request_id=msg.value.metadata.get("RID")
             )
             # Add callback to clean up when done
-            future.add_done_callback(lambda f: parent._remove_active_request())
+            future.add_done_callback(lambda f: self._remove_active_request())
 
     def _remove_active_request(self) -> None:
         """Clear the active request."""

--- a/bec_server/bec_server/file_writer/file_writer_manager.py
+++ b/bec_server/bec_server/file_writer/file_writer_manager.py
@@ -101,21 +101,15 @@ class FileWriterManager(BECService):
         self.available_beamline_states: list[messages.BeamlineStateConfig] = []
         self.beamline_state_subscriptions: set[str] = set()
         self.beamline_states: dict[str, messages.BeamlineStateMessage] = {}
-        self.connector.register(
-            MessageEndpoints.scan_segment(), cb=self._scan_segment_callback, parent=self
-        )
-        self.connector.register(
-            MessageEndpoints.scan_status(), cb=self._scan_status_callback, parent=self
-        )
+        self.connector.register(MessageEndpoints.scan_segment(), cb=self._scan_segment_callback)
+        self.connector.register(MessageEndpoints.scan_status(), cb=self._scan_status_callback)
         self.connector.register(
             patterns=MessageEndpoints.device_read_configuration("*"),  # type: ignore
             cb=self._device_configuration_callback,
-            parent=self,
         )
         self.connector.register(
             MessageEndpoints.available_beamline_states(),
             cb=self._update_available_beamline_states,
-            parent=self,
             from_start=True,
         )
         self.async_writer = None
@@ -129,29 +123,26 @@ class FileWriterManager(BECService):
         self.device_manager = DeviceManagerBase(self)
         self.device_manager.initialize([self.bootstrap_server])
 
-    def _scan_segment_callback(self, msg: MessageObject, *, parent: FileWriterManager):
+    def _scan_segment_callback(self, msg: MessageObject):
         msgs = msg.value
         for scan_msg in msgs:
-            parent.insert_to_scan_storage(scan_msg)
+            self.insert_to_scan_storage(scan_msg)
 
-    @staticmethod
-    def _scan_status_callback(msg, *, parent: FileWriterManager):
+    def _scan_status_callback(self, msg):
         msg = msg.value
-        parent.update_scan_storage_with_status(msg)
+        self.update_scan_storage_with_status(msg)
 
-    @staticmethod
-    def _device_configuration_callback(msg, *, parent: FileWriterManager):
+    def _device_configuration_callback(self, msg):
         topic, msg = msg.topic, msg.value
         device = topic.split("/")[-1]
-        parent.update_device_configuration(device, msg)
+        self.update_device_configuration(device, msg)
 
-    @staticmethod
     def _update_available_beamline_states(
-        msg: dict[str, messages.AvailableBeamlineStatesMessage], *, parent: FileWriterManager
+        self, msg: dict[str, messages.AvailableBeamlineStatesMessage]
     ):
         info = msg["data"]
-        parent.available_beamline_states = info.states
-        parent.update_beamline_state_subscriptions()
+        self.available_beamline_states = info.states
+        self.update_beamline_state_subscriptions()
 
     def update_beamline_state_subscriptions(self):
         """
@@ -166,7 +157,6 @@ class FileWriterManager(BECService):
                 self.connector.register(
                     MessageEndpoints.beamline_state(state.name),
                     cb=self._beamline_state_callback,
-                    parent=self,
                     from_start=True,
                 )
                 self.beamline_state_subscriptions.add(state.name)
@@ -178,12 +168,9 @@ class FileWriterManager(BECService):
             self.beamline_state_subscriptions.remove(topic)
             self.beamline_states.pop(topic, None)
 
-    @staticmethod
-    def _beamline_state_callback(
-        msg: dict[str, messages.BeamlineStateMessage], *, parent: FileWriterManager
-    ):
+    def _beamline_state_callback(self, msg: dict[str, messages.BeamlineStateMessage]):
         state_msg = msg["data"]
-        parent.update_beamline_state(state_msg)
+        self.update_beamline_state(state_msg)
 
     def update_beamline_state(self, state_msg: messages.BeamlineStateMessage):
         """

--- a/bec_server/bec_server/scan_bundler/scan_bundler.py
+++ b/bec_server/bec_server/scan_bundler/scan_bundler.py
@@ -81,7 +81,7 @@ class ScanBundler(BECService):
         task = self.executor.submit(self._add_device_to_storage, msgs, dev)
         self.executor_tasks.append(task)
 
-    def _scan_status_callback(self, msg, **_kwargs):
+    def _scan_status_callback(self, msg):
         msg: messages.ScanStatusMessage = msg.value
         self.handle_scan_status_message(msg)
 

--- a/bec_server/bec_server/scan_server/beamline_state_manager.py
+++ b/bec_server/bec_server/scan_server/beamline_state_manager.py
@@ -20,16 +20,14 @@ class BeamlineStateManager:
         self.connector.register(
             MessageEndpoints.available_beamline_states(),
             cb=self._handle_state_update,
-            parent=self,
             from_start=True,
         )
 
-    @staticmethod
-    def _handle_state_update(msg_dict: dict, *, parent: BeamlineStateManager, **_kwargs) -> None:
+    def _handle_state_update(self, msg_dict: dict, **_kwargs) -> None:
 
         msg: messages.AvailableBeamlineStatesMessage = msg_dict["data"]  # type: ignore ; we know it's a AvailableBeamlineStatesMessage
         try:
-            parent.update_states(msg)
+            self.update_states(msg)
         except Exception as exc:
             content = traceback.format_exc()
             info = ErrorInfo(
@@ -37,7 +35,7 @@ class BeamlineStateManager:
                 error_message=content,
                 compact_error_message="Error updating beamline states.",
             )
-            parent.connector.raise_alarm(severity=Alarms.WARNING, info=info)
+            self.connector.raise_alarm(severity=Alarms.WARNING, info=info)
 
     def update_states(self, msg: messages.AvailableBeamlineStatesMessage) -> None:
         """

--- a/bec_server/bec_server/scan_server/instruction_handler.py
+++ b/bec_server/bec_server/scan_server/instruction_handler.py
@@ -29,16 +29,13 @@ class InstructionHandler:
         self._callback_storage = collections.defaultdict(lambda: [])
         self._lock = threading.Lock()
         self._connector.register(
-            MessageEndpoints.device_instructions_response(),
-            cb=self._device_instructions_callback,
-            parent=self,
+            MessageEndpoints.device_instructions_response(), cb=self._device_instructions_callback
         )
 
-    @staticmethod
-    def _device_instructions_callback(msg, parent):
+    def _device_instructions_callback(self, msg):
         # pylint: disable=protected-access
-        with parent._lock:
-            parent.add_instruction(msg.value)
+        with self._lock:
+            self.add_instruction(msg.value)
 
     def add_instruction(self, instruction: messages.DeviceInstructionResponse) -> None:
         """

--- a/bec_server/bec_server/scan_server/scan_guard.py
+++ b/bec_server/bec_server/scan_server/scan_guard.py
@@ -44,20 +44,15 @@ class ScanGuard:
         self.connector = self.parent.connector
 
         self.connector.register(
-            patterns=MessageEndpoints.scan_queue_request("*"),
-            cb=self._scan_queue_request_callback,
-            parent=self,
+            patterns=MessageEndpoints.scan_queue_request("*"), cb=self._scan_queue_request_callback
         )
 
         self.connector.register(
             MessageEndpoints.scan_queue_modification_request(),
             cb=self._scan_queue_modification_request_callback,
-            parent=self,
         )
         self.connector.register(
-            MessageEndpoints.scan_queue_order_change_request(),
-            cb=self._scan_queue_order_callback,
-            parent=self,
+            MessageEndpoints.scan_queue_order_change_request(), cb=self._scan_queue_order_callback
         )
 
     def _is_valid_scan_request(
@@ -167,8 +162,7 @@ class ScanGuard:
             if not self.device_manager.devices[motor].enabled:
                 raise ScanRejection(f"Device {motor} is not enabled.")
 
-    @staticmethod
-    def _scan_queue_request_callback(msg, parent, **_kwargs):
+    def _scan_queue_request_callback(self, msg):
         content = msg.value.content
         username_regex = f"^{MessageEndpoints.scan_queue_request('([^/]+)').endpoint}$"
         result = re.match(username_regex, msg.topic)
@@ -178,10 +172,9 @@ class ScanGuard:
 
         logger.info(f"Receiving scan request: {content} from user {username}")
         # pylint: disable=protected-access
-        parent._handle_scan_request(msg.value, username=username)
+        self._handle_scan_request(msg.value, username=username)
 
-    @staticmethod
-    def _scan_queue_modification_request_callback(msg, parent, **_kwargs):
+    def _scan_queue_modification_request_callback(self, msg):
         mod_msg = msg.value
         if mod_msg is None:
             logger.warning("Failed to parse scan queue modification message.")
@@ -189,7 +182,7 @@ class ScanGuard:
         content = mod_msg.content
         logger.info(f"Receiving scan modification request: {content}")
         # pylint: disable=protected-access
-        parent._handle_scan_modification_request(msg.value)
+        self._handle_scan_modification_request(msg.value)
 
     def _send_scan_request_response(self, scan_status: ScanStatus, metadata: dict):
         """
@@ -279,10 +272,8 @@ class ScanGuard:
         sqi = MessageEndpoints.scan_queue_insert()
         self.device_manager.connector.send(sqi, msg)
 
-    @staticmethod
-    def _scan_queue_order_callback(msg, parent, **_kwargs):
-        # pylint: disable=protected-access
-        parent._handle_scan_order_change(msg.value)
+    def _scan_queue_order_callback(self, msg):
+        self._handle_scan_order_change(msg.value)
 
     def _handle_scan_order_change(self, msg: messages.ScanQueueOrderMessage):
         """

--- a/bec_server/bec_server/scan_server/scan_queue.py
+++ b/bec_server/bec_server/scan_server/scan_queue.py
@@ -167,41 +167,31 @@ class QueueManager:
             self.send_queue_status()
 
     def _start_scan_queue_register(self) -> None:
+        self.connector.register(MessageEndpoints.scan_queue_insert(), cb=self._scan_queue_callback)
         self.connector.register(
-            MessageEndpoints.scan_queue_insert(), cb=self._scan_queue_callback, parent=self
+            MessageEndpoints.scan_queue_modification(), cb=self._scan_queue_modification_callback
         )
         self.connector.register(
-            MessageEndpoints.scan_queue_modification(),
-            cb=self._scan_queue_modification_callback,
-            parent=self,
-        )
-        self.connector.register(
-            MessageEndpoints.scan_queue_order_change(),
-            cb=self._scan_queue_order_callback,
-            parent=self,
+            MessageEndpoints.scan_queue_order_change(), cb=self._scan_queue_order_callback
         )
 
-    @staticmethod
-    def _scan_queue_callback(msg, parent, **_kwargs) -> None:
+    def _scan_queue_callback(self, msg) -> None:
         scan_msg = msg.value
         logger.info(f"Receiving scan: {scan_msg.content}")
-        # instructions = parent.scan_assembler.assemble_device_instructions(scan_msg)
+        # instructions = self.scan_assembler.assemble_device_instructions(scan_msg)
         queue = scan_msg.content.get("queue", "primary")
-        parent.add_to_queue(queue, scan_msg)
-        parent.send_queue_status()
+        self.add_to_queue(queue, scan_msg)
+        self.send_queue_status()
 
-    @staticmethod
-    def _scan_queue_modification_callback(msg, parent, **_kwargs):
+    def _scan_queue_modification_callback(self, msg):
         scan_mod_msg = msg.value
         logger.info(f"Receiving scan modification: {scan_mod_msg.content}")
         if scan_mod_msg:
-            parent.scan_interception(scan_mod_msg)
-            parent.send_queue_status()
+            self.scan_interception(scan_mod_msg)
+            self.send_queue_status()
 
-    @staticmethod
-    def _scan_queue_order_callback(msg, parent, **_kwargs):
-        # pylint: disable=protected-access
-        parent._handle_scan_order_change(msg.value)
+    def _scan_queue_order_callback(self, msg):
+        self._handle_scan_order_change(msg.value)
 
     def _handle_scan_order_change(self, msg: messages.ScanQueueOrderMessage) -> None:
         """Handle the scan queue order change request.

--- a/bec_server/bec_server/scan_server/scan_server.py
+++ b/bec_server/bec_server/scan_server/scan_server.py
@@ -66,7 +66,7 @@ class ScanServer(BECService):
         self.beamline_states = BeamlineStateManager(self.connector, self.device_manager)
 
     def _start_alarm_handler(self):
-        self.connector.register(MessageEndpoints.alarm(), cb=self._alarm_callback, parent=self)
+        self.connector.register(MessageEndpoints.alarm(), cb=self._alarm_callback)
 
     def _reset_scan_number(self):
         self.scan_number_container = ScanNumberContainer(self.connector)
@@ -83,14 +83,13 @@ class ScanServer(BECService):
         )
         self.proc_manager = ProcedureManager(self.bootstrap_server, procedure_worker)
 
-    @staticmethod
-    def _alarm_callback(msg, parent: ScanServer, **_kwargs):
+    def _alarm_callback(self, msg):
         msg = msg.value
         queue = msg.metadata.get("queue", "primary")
         if Alarms(msg.content["severity"]) == Alarms.MAJOR:
             logger.info(f"Received alarm: {msg}")
             scan_id = msg.metadata.get("scan_id")
-            parent.queue_manager.set_abort(
+            self.queue_manager.set_abort(
                 scan_id=scan_id, queue=queue, exit_info=("aborted", "alarm")
             )
 

--- a/bec_server/bec_server/scihub/atlas/atlas_connector.py
+++ b/bec_server/bec_server/scihub/atlas/atlas_connector.py
@@ -238,15 +238,12 @@ class AtlasConnector:
 
     def _start_config_request_handler(self) -> None:
         self._config_request_handler = self.connector.register(
-            MessageEndpoints.device_config_request(),
-            cb=self._device_config_request_callback,
-            parent=self,
+            MessageEndpoints.device_config_request(), cb=self._device_config_request_callback
         )
 
-    @staticmethod
-    def _device_config_request_callback(msg, *, parent, **_kwargs) -> None:
+    def _device_config_request_callback(self, msg, **_kwargs) -> None:
         """Callback for device config requests - delegates to config_handler."""
-        parent.config_handler.handle_config_request_callback(msg.value)
+        self.config_handler.handle_config_request_callback(msg.value)
 
     def shutdown(self):
         """

--- a/bec_server/bec_server/scihub/atlas/atlas_forwarder.py
+++ b/bec_server/bec_server/scihub/atlas/atlas_forwarder.py
@@ -35,14 +35,12 @@ class AtlasForwarder:
                 self.atlas_connector.deployment_name, "*"
             ),
             cb=self._update_deployment_subscriptions,
-            parent=self,
         )
         self.atlas_connector.redis_atlas.register(
             patterns=MessageEndpoints.atlas_deployment_request(
                 self.atlas_connector.deployment_name
             ),
             cb=self._on_redis_request,
-            parent=self,
         )
 
     def _start_deployment_cleanup_loop(self):
@@ -66,11 +64,10 @@ class AtlasForwarder:
                     self.update_deployment_state(msg)
             self._shutdown_event.wait(60)
 
-    @staticmethod
-    def _on_redis_request(msg_obj, parent):
+    def _on_redis_request(self, msg_obj):
         msg: messages.RawMessage = msg_obj.value
-        redis_atlas: RedisConnector = parent.atlas_connector.redis_atlas
-        redis_bec: RedisConnector = parent.atlas_connector.connector
+        redis_atlas: RedisConnector = self.atlas_connector.redis_atlas
+        redis_bec: RedisConnector = self.atlas_connector.connector
         if msg.data.get("action") == "get":
             key = msg.data.get("key")
 
@@ -80,10 +77,9 @@ class AtlasForwarder:
                 out = json.dumps({"out": None})
             redis_atlas.send(topic, out)
 
-    @staticmethod
-    def _update_deployment_subscriptions(msg_obj, parent):
+    def _update_deployment_subscriptions(self, msg_obj):
         msg = msg_obj.value
-        parent.update_deployment_state(msg)
+        self.update_deployment_state(msg)
 
     def update_deployment_state(self, msg: messages.RawMessage):
         requested_subscriptions = {
@@ -96,7 +92,7 @@ class AtlasForwarder:
             self.active_subscriptions.add(subscription)
             endpoint = self._get_endpoint_from_subscription(subscription)
             self.atlas_connector.connector.register(
-                endpoint, cb=self.forward_message, parent=self, endpoint=endpoint
+                endpoint, cb=self.forward_message, endpoint=endpoint
             )
 
         # Remove subscriptions that are no longer needed
@@ -117,17 +113,14 @@ class AtlasForwarder:
             endpoint = func()
         return endpoint
 
-    @staticmethod
-    def forward_message(msg, parent, endpoint):
+    def forward_message(self, msg, endpoint):
         endpoint = endpoint.endpoint
         if isinstance(msg, MessageObject):
             data = msg.value
         else:
             data = msg
-        parent.atlas_connector.redis_atlas.xadd(
-            MessageEndpoints.atlas_deployment_data(
-                parent.atlas_connector.deployment_name, endpoint
-            ),
+        self.atlas_connector.redis_atlas.xadd(
+            MessageEndpoints.atlas_deployment_data(self.atlas_connector.deployment_name, endpoint),
             data if isinstance(data, dict) else {"pubsub_data": data},
             max_size=10,
             expire=60,

--- a/bec_server/bec_server/scihub/atlas/atlas_metadata_handler.py
+++ b/bec_server/bec_server/scihub/atlas/atlas_metadata_handler.py
@@ -42,9 +42,9 @@ class AtlasMetadataHandler:
     def _start_account_subscription(self):
         init_data = self.atlas_connector.connector.get_last(MessageEndpoints.account())
         if init_data is not None:
-            self._handle_account_info(init_data, parent=self, emit_update=False)
+            self._handle_account_info(init_data, emit_update=False)
         self.atlas_connector.connector.register(
-            MessageEndpoints.account(), cb=self._handle_account_info, parent=self
+            MessageEndpoints.account(), cb=self._handle_account_info
         )
 
     def _start_deployment_info_subscription(self):
@@ -55,39 +55,37 @@ class AtlasMetadataHandler:
         self.atlas_connector.redis_atlas.register(
             MessageEndpoints.atlas_deployment_info(self.atlas_connector.deployment_name),
             cb=self._update_deployment_info,
-            parent=self,
             from_start=True,
         )
 
     def _start_scan_subscription(self):
         self._scan_status_register = self.atlas_connector.connector.register(
-            MessageEndpoints.scan_status(), cb=self._handle_scan_status, parent=self
+            MessageEndpoints.scan_status(), cb=self._handle_scan_status
         )
 
     def _start_scan_history_subscription(self):
         self._scan_history_register = self.atlas_connector.connector.register(
-            MessageEndpoints.scan_history(), cb=self._handle_scan_history, parent=self
+            MessageEndpoints.scan_history(), cb=self._handle_scan_history
         )
 
     def _start_messaging_subscription(self):
         self.atlas_connector.connector.register(
-            MessageEndpoints.message_service_queue(), cb=self._handle_messaging, parent=self
+            MessageEndpoints.message_service_queue(), cb=self._handle_messaging
         )
 
     def _start_feedback_subscription(self):
         self.atlas_connector.connector.register(
-            MessageEndpoints.user_feedback(), cb=self._handle_feedback, parent=self
+            MessageEndpoints.user_feedback(), cb=self._handle_feedback
         )
 
-    @staticmethod
     def _update_deployment_info(
-        msg: dict[str, messages.DeploymentInfoMessage], *, parent: AtlasMetadataHandler, **_kwargs
+        self, msg: dict[str, messages.DeploymentInfoMessage], **_kwargs
     ) -> None:
         if not isinstance(msg, dict) or "data" not in msg:
             logger.error(f"Invalid deployment info message received: {msg}")
             return
 
-        parent.update_deployment_info(msg["data"])
+        self.update_deployment_info(msg["data"])
 
     def update_deployment_info(self, info: messages.DeploymentInfoMessage) -> None:
         """
@@ -159,10 +157,7 @@ class AtlasMetadataHandler:
             return
         self.send_atlas_update({"account": self._account})
 
-    @staticmethod
-    def _handle_account_info(
-        msg, *, parent: AtlasMetadataHandler, emit_update=True, **_kwargs
-    ) -> None:
+    def _handle_account_info(self, msg, emit_update=True, **_kwargs) -> None:
         """
         Called if the account info is updated from the local redis instance.
         It forwards the account info to Atlas if it differs from the current one and emit_update is True.
@@ -176,38 +171,35 @@ class AtlasMetadataHandler:
             logger.error(f"Invalid account message received: {msg}")
             return
         msg = cast(messages.VariableMessage, msg["data"])
-        if msg.value == parent._account:
+        if msg.value == self._account:
             # Account is the same as the current one, no need to update
             return
-        parent._account = msg.value
+        self._account = msg.value
         if emit_update:
-            parent.send_atlas_update({"account": msg})
-        logger.info(f"Updated account to: {parent._account}")
+            self.send_atlas_update({"account": msg})
+        logger.info(f"Updated account to: {self._account}")
 
-    @staticmethod
-    def _handle_scan_status(msg, *, parent: AtlasMetadataHandler, **_kwargs) -> None:
+    def _handle_scan_status(self, msg, **_kwargs) -> None:
         msg = msg.value
         try:
-            parent.send_atlas_update({"scan_status": msg})
+            self.send_atlas_update({"scan_status": msg})
         # pylint: disable=broad-except
         except Exception:
             content = traceback.format_exc()
             logger.exception(f"Failed to update scan status: {content}")
 
-    @staticmethod
-    def _handle_scan_history(msg, *, parent: AtlasMetadataHandler, **_kwargs) -> None:
+    def _handle_scan_history(self, msg, **_kwargs) -> None:
         msg = msg["data"]
         try:
-            parent.send_atlas_update({"scan_history": msg})
+            self.send_atlas_update({"scan_history": msg})
         # pylint: disable=broad-except
         except Exception:
             content = traceback.format_exc()
             logger.exception(f"Failed to update scan history: {content}")
 
-    @staticmethod
-    def _handle_messaging(msg, *, parent: AtlasMetadataHandler, **_kwargs) -> None:
+    def _handle_messaging(self, msg, **_kwargs) -> None:
         try:
-            parent.atlas_connector.ingest_message(msg)
+            self.atlas_connector.ingest_message(msg)
         # pylint: disable=broad-except
         except Exception:
             content = traceback.format_exc()
@@ -219,23 +211,20 @@ class AtlasMetadataHandler:
         """
         self.atlas_connector.ingest_data(msg)
 
-    @staticmethod
-    def _handle_feedback(
-        msg_obj: MessageObject, *, parent: AtlasMetadataHandler, **_kwargs
-    ) -> None:
+    def _handle_feedback(self, msg_obj: MessageObject, **_kwargs) -> None:
         msg: messages.FeedbackMessage = msg_obj.value
         content = msg.model_dump()
-        if parent._deployment_info:
+        if self._deployment_info:
             if (
-                parent._deployment_info.active_session
-                and parent._deployment_info.active_session.experiment
+                self._deployment_info.active_session
+                and self._deployment_info.active_session.experiment
             ):
-                content["experiment_id"] = parent._deployment_info.active_session.experiment.pgroup
-                content["realm_id"] = parent._deployment_info.active_session.experiment.realm_id
-            content["deployment_id"] = parent._deployment_info.deployment_id
+                content["experiment_id"] = self._deployment_info.active_session.experiment.pgroup
+                content["realm_id"] = self._deployment_info.active_session.experiment.realm_id
+            content["deployment_id"] = self._deployment_info.deployment_id
         try:
             enriched_msg: messages.FeedbackMessage = messages.FeedbackMessage(**content)
-            parent.atlas_connector.ingest_data({"user_feedback": enriched_msg})
+            self.atlas_connector.ingest_data({"user_feedback": enriched_msg})
         # pylint: disable=broad-except
         except Exception:
             traceback_info = traceback.format_exc()

--- a/bec_server/bec_server/scihub/service_handler/service_handler.py
+++ b/bec_server/bec_server/scihub/service_handler/service_handler.py
@@ -21,15 +21,12 @@ class ServiceHandler:
         self.command = f"{sys.executable} -m bec_server.bec_server_utils.launch"
 
     def start(self):
-        self.connector.register(
-            MessageEndpoints.service_request(), cb=self.handle_service_request, parent=self
-        )
+        self.connector.register(MessageEndpoints.service_request(), cb=self.handle_service_request)
 
-    @staticmethod
-    def handle_service_request(msg: MessageObject, parent: ServiceHandler) -> None:
+    def handle_service_request(self, msg: MessageObject) -> None:
         message: messages.ServiceRequestMessage = msg.value
         if message.action == "restart":
-            parent.on_restart()
+            self.on_restart()
 
     def on_restart(self):
         logger.info("Restarting services through service handler")

--- a/bec_server/tests/tests_device_server/test_config_handler.py
+++ b/bec_server/tests/tests_device_server/test_config_handler.py
@@ -170,7 +170,7 @@ def test_device_config_callback_normal_request(dm_with_devices):
         mock_future = mock.MagicMock()
         submit.return_value = mock_future
 
-        ConfigUpdateHandler._device_config_callback(msg_mock, parent=handler)
+        handler._device_config_callback(msg_mock)
 
         # Verify executor.submit was called with parse_config_request
         submit.assert_called_once()
@@ -198,7 +198,7 @@ def test_device_config_callback_cancel_request(dm_with_devices):
     )
 
     with mock.patch.object(handler, "_cancel_config_request") as cancel_request:
-        ConfigUpdateHandler._device_config_callback(msg_mock, parent=handler)
+        handler._device_config_callback(msg_mock)
 
         # Verify _cancel_config_request was called
         cancel_request.assert_called_once_with(msg_mock.value)

--- a/bec_server/tests/tests_file_writer/test_file_writer_manager.py
+++ b/bec_server/tests/tests_file_writer/test_file_writer_manager.py
@@ -72,7 +72,7 @@ def test_scan_segment_callback(file_writer_manager_mock):
     with mock.patch.object(
         file_writer_manager_mock, "check_storage_status"
     ) as mock_check_storage_status:
-        file_manager._scan_segment_callback(msg_raw, parent=file_manager)
+        file_manager._scan_segment_callback(msg_raw)
         assert mock_check_storage_status.call_args == mock.call(scan_id="scan_id")
         assert file_manager.scan_storage["scan_id"].scan_segments[1] == {"data": "data"}
 
@@ -92,7 +92,7 @@ def test_scan_status_callback(file_writer_manager_mock):
     with mock.patch.object(
         file_writer_manager_mock, "check_storage_status"
     ) as mock_check_storage_status:
-        file_manager._scan_status_callback(msg_raw, parent=file_manager)
+        file_manager._scan_status_callback(msg_raw)
         assert mock_check_storage_status.call_args == mock.call(scan_id="scan_id")
         assert file_manager.scan_storage["scan_id"].status_msg == msg
         assert file_manager.scan_storage["scan_id"].scan_finished is True
@@ -308,9 +308,7 @@ def test_file_writer_manager_update_configuration(file_writer_manager_mock):
         topic=MessageEndpoints.device_read_configuration("samx").endpoint, value=msg
     )
     with mock.patch.object(file_writer_manager_mock, "update_device_configuration") as mock_update:
-        file_writer_manager_mock._device_configuration_callback(
-            msg_obj, parent=file_writer_manager_mock
-        )
+        file_writer_manager_mock._device_configuration_callback(msg_obj)
         mock_update.assert_called_once_with("samx", msg)
 
 
@@ -326,9 +324,7 @@ def test_file_writer_manager_update_available_beamline_states(file_writer_manage
         ]
     )
 
-    file_writer_manager_mock._update_available_beamline_states(
-        {"data": msg}, parent=file_writer_manager_mock
-    )
+    file_writer_manager_mock._update_available_beamline_states({"data": msg})
     assert "State1" in file_writer_manager_mock.beamline_state_subscriptions
 
     msg = messages.AvailableBeamlineStatesMessage(
@@ -341,9 +337,7 @@ def test_file_writer_manager_update_available_beamline_states(file_writer_manage
             )
         ]
     )
-    file_writer_manager_mock._update_available_beamline_states(
-        {"data": msg}, parent=file_writer_manager_mock
-    )
+    file_writer_manager_mock._update_available_beamline_states({"data": msg})
     assert "State1" not in file_writer_manager_mock.beamline_state_subscriptions
     assert "State2" in file_writer_manager_mock.beamline_state_subscriptions
 
@@ -389,7 +383,7 @@ def test_file_writer_manager_removes_beamline_state_subscription(file_writer_man
             )
         ]
     )
-    file_manager._update_available_beamline_states({"data": msg}, parent=file_manager)
+    file_manager._update_available_beamline_states({"data": msg})
     assert "State1" in file_manager.beamline_state_subscriptions
 
     state_msg = messages.BeamlineStateMessage(name="State1", status="valid", label="Shutter")
@@ -399,6 +393,6 @@ def test_file_writer_manager_removes_beamline_state_subscription(file_writer_man
 
     # Remove the state by sending an empty list of states
     msg = messages.AvailableBeamlineStatesMessage(states=[])
-    file_manager._update_available_beamline_states({"data": msg}, parent=file_manager)
+    file_manager._update_available_beamline_states({"data": msg})
     assert "State1" not in file_manager.beamline_state_subscriptions
     assert "State1" not in file_manager.beamline_states

--- a/bec_server/tests/tests_scan_server/test_beamline_state_manager.py
+++ b/bec_server/tests/tests_scan_server/test_beamline_state_manager.py
@@ -49,7 +49,6 @@ def test_state_manager_fetches_states(dm_with_devices):
     connector.register.assert_called_once_with(
         MessageEndpoints.available_beamline_states(),
         cb=state_manager._handle_state_update,
-        parent=state_manager,
         from_start=True,
     )
 

--- a/bec_server/tests/tests_scan_server/test_scan_guard.py
+++ b/bec_server/tests/tests_scan_server/test_scan_guard.py
@@ -226,7 +226,7 @@ def test_scan_queue_request_callback(scan_guard_mock):
     )
     msg_obj = MessageObject(MessageEndpoints.scan_queue_request("default").endpoint, msg)
     with mock.patch.object(sg, "_handle_scan_request") as handle:
-        sg._scan_queue_request_callback(msg_obj, sg)
+        sg._scan_queue_request_callback(msg_obj)
         handle.assert_called_once_with(msg, username="default")
 
 
@@ -237,7 +237,7 @@ def test_scan_queue_modification_request_callback(scan_guard_mock):
     )
     msg_obj = MessageObject(MessageEndpoints.scan_queue_modification(), msg)
     with mock.patch.object(sg, "_handle_scan_modification_request") as handle:
-        sg._scan_queue_modification_request_callback(msg_obj, sg)
+        sg._scan_queue_modification_request_callback(msg_obj)
         handle.assert_called_once_with(msg)
 
 
@@ -458,7 +458,7 @@ def test_check_queue_order_callback(scan_guard_mock, msg, queue_paused, valid, r
 
     sg.parent.queue_manager.queues = {"primary": MockQueue()}
     msg_obj = MessageObject(MessageEndpoints.scan_queue_order_change_request(), msg)
-    sg._scan_queue_order_callback(msg_obj, sg)
+    sg._scan_queue_order_callback(msg_obj)
     success_call = mock.call(MessageEndpoints.scan_queue_order_change(), msg)
     if valid:
         assert success_call in sg.device_manager.connector.send.mock_calls

--- a/bec_server/tests/tests_scan_server/test_scan_server_queue.py
+++ b/bec_server/tests/tests_scan_server/test_scan_server_queue.py
@@ -160,7 +160,7 @@ def test_queuemanager_scan_queue_callback(queuemanager_mock):
     obj = MessageObject("scan_queue", msg)
     with mock.patch.object(queue_manager, "add_to_queue") as add_to_queue:
         with mock.patch.object(queue_manager, "send_queue_status") as send_queue_status:
-            queue_manager._scan_queue_callback(obj, queue_manager)
+            queue_manager._scan_queue_callback(obj)
             add_to_queue.assert_called_once_with("primary", msg)
             send_queue_status.assert_called_once()
 
@@ -173,7 +173,7 @@ def test_scan_queue_modification_callback(queuemanager_mock):
     obj = MessageObject("scan_queue_modification", msg)
     with mock.patch.object(queue_manager, "scan_interception") as scan_interception:
         with mock.patch.object(queue_manager, "send_queue_status") as send_queue_status:
-            queue_manager._scan_queue_modification_callback(obj, queue_manager)
+            queue_manager._scan_queue_modification_callback(obj)
             scan_interception.assert_called_once_with(msg)
             send_queue_status.assert_called_once()
 

--- a/bec_server/tests/tests_scihub/test_atlas_config_handler.py
+++ b/bec_server/tests/tests_scihub/test_atlas_config_handler.py
@@ -513,7 +513,7 @@ def test_config_handler_remove_devices_from_redis(config_handler):
             set_config.assert_called_once_with([{"name": "samy", "deviceConfig": {}}])
 
 
-def test_config_handler_add_to_config(config_handler):
+def test_config_handler_add_to_config(config_handler: ConfigHandler):
     config = {
         "new_samx": {
             "deviceConfig": {},


### PR DESCRIPTION
Refactors all old-style `staticmethod` redis subcription callbacks to be instance methods.