### PR TITLE
Fix/startup lazy gui and dap

### DIFF
--- a/bec_ipython_client/bec_ipython_client/bec_startup.py
+++ b/bec_ipython_client/bec_ipython_client/bec_startup.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import threading
 
 import numpy as np  # not needed but always nice to have
 
@@ -11,12 +10,46 @@ from bec_lib.acl_login import BECAuthenticationError
 from bec_lib.logger import bec_logger as _bec_logger
 from bec_lib.redis_connector import RedisConnector as _RedisConnector
 
-try:
-    from bec_widgets.cli.client_utils import BECGuiClient
-except ImportError:
-    BECGuiClient = None
-
 logger = _bec_logger.logger
+
+
+class _LazyBECGuiClient:
+    """Defer BEC Widgets import while preserving the interactive ``gui`` object."""
+
+    def __init__(self, gui_id: str | None = None):
+        self._gui_id = gui_id
+        self._client = None
+
+    def _materialize(self):
+        if self._client is None:
+            try:
+                from bec_widgets.cli.client_utils import BECGuiClient
+            except ImportError:
+                logger.warning("BEC Widgets is not available; skipping GUI startup.")
+                bec.gui = None
+                globals().pop("gui", None)
+                raise
+
+            self._client = BECGuiClient()
+            if self._gui_id:
+                self._client.connect_to_gui_server(self._gui_id)
+            bec.gui = self._client
+            globals()["gui"] = self._client
+        return self._client
+
+    def __getattr__(self, name):
+        return getattr(self._materialize(), name)
+
+    def __setattr__(self, name, value):
+        if name.startswith("_"):
+            return super().__setattr__(name, value)
+        return setattr(self._materialize(), name, value)
+
+    def __repr__(self) -> str:
+        if self._client is None:
+            return "LazyBECGuiClient(uninitialized)"
+        return repr(self._client)
+
 
 bec = _BECIPythonClient(
     _main_dict["config"], _RedisConnector, wait_for_server=_main_dict["wait_for_server"]
@@ -32,12 +65,14 @@ except (BECAuthenticationError, KeyboardInterrupt) as exc:
 except Exception:
     sys.excepthook(*sys.exc_info())
 else:
-    if bec.started and BECGuiClient is not None:
-        gui = bec.gui = BECGuiClient()
-        if _main_dict["args"].gui_id:
-            gui.connect_to_gui_server(_main_dict["args"].gui_id)
+    if bec.started:
+        gui = bec.gui = _LazyBECGuiClient(gui_id=_main_dict["args"].gui_id)
         if not _main_dict["args"].nogui:
-            gui.show()
+            try:
+                gui.show()
+            except ImportError:
+                logger.warning("BEC Widgets is not available")
+                pass
 
     _available_plugins = plugin_helper.get_ipython_client_startup_plugins(state="post")
     if _available_plugins:

--- a/bec_lib/bec_lib/client.py
+++ b/bec_lib/bec_lib/client.py
@@ -9,6 +9,7 @@ import builtins
 import getpass
 import importlib
 import inspect
+import threading
 import time
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, TypedDict
@@ -38,6 +39,42 @@ from bec_lib.user_macros import UserMacros
 from bec_lib.utils.import_utils import lazy_import_from
 
 logger = bec_logger.logger
+
+
+class LazyDAPPlugins:
+    """Lazily materialize DAP plugins on first access."""
+
+    def __init__(self, parent: "BECClient", dap_plugins_cls: Any = DAPPlugins):
+        self._parent = parent
+        self._dap_plugins_cls = dap_plugins_cls
+        self._dap_plugins: DAPPlugins | None = None
+        self._lock = threading.Lock()
+
+    def _ensure(self) -> DAPPlugins:
+        if self._dap_plugins is not None:
+            return self._dap_plugins
+        with self._lock:
+            if self._dap_plugins is None:
+                self._dap_plugins = self._dap_plugins_cls(self._parent)
+        return self._dap_plugins
+
+    def refresh(self):
+        return self._ensure().refresh()
+
+    def __getattr__(self, name):
+        return getattr(self._ensure(), name)
+
+    def __dir__(self):
+        names = set(object.__dir__(self))
+        if self._dap_plugins is not None:
+            names.update(dir(self._dap_plugins))
+        return sorted(names)
+
+    def __repr__(self) -> str:
+        if self._dap_plugins is None:
+            return "LazyDAPPlugins(uninitialized)"
+        return repr(self._dap_plugins)
+
 
 if TYPE_CHECKING:  # pragma: no cover
     from bec_lib.messages import BECStatus, ServiceRequestMessage, VariableMessage
@@ -237,7 +274,7 @@ class BECClient(BECService):
         self.macros.load_all_user_macros()
         self.config = ConfigHelperUser(self.device_manager)
         self.history = ScanHistory(client=self)
-        self.dap = DAPPlugins(self)
+        self.dap = LazyDAPPlugins(self, DAPPlugins)
         self.device_monitor = DeviceMonitorPlugin(self.connector)
         self._update_username()
         self.beamline_states = BeamlineStateManager(client=self)

--- a/bec_lib/tests/test_client.py
+++ b/bec_lib/tests/test_client.py
@@ -1,8 +1,12 @@
 """This module tests the bec_lib.client module."""
 
+from types import SimpleNamespace
+
 import pytest
 
-from bec_lib.client import SystemConfig
+import bec_lib.client as client_module
+from bec_lib.client import BECClient, LazyDAPPlugins, SystemConfig
+from bec_lib.service_config import ServiceConfig
 from bec_lib.tests.fixtures import bec_client_mock
 
 
@@ -30,3 +34,83 @@ def test_show_all_commands(bec_client_mock, capsys):
     captured = capsys.readouterr()
     assert "User macros" in captured.out
     assert "Scans" in captured.out
+
+
+def test_lazy_dap_plugins_uses_captured_factory():
+    """Lazy DAP initialization must preserve patched/injected DAP factories."""
+
+    class DummyDAPPlugins:
+        def __init__(self, parent):
+            self.parent = parent
+            self.GaussianModel = object()
+            self.refresh_called = False
+
+        def refresh(self):
+            self.refresh_called = True
+
+    parent = object()
+    dap = LazyDAPPlugins(parent, DummyDAPPlugins)
+
+    assert "uninitialized" in repr(dap)
+    assert dap.GaussianModel is dap._dap_plugins.GaussianModel
+    assert dap._dap_plugins.parent is parent
+
+    dap.refresh()
+    assert dap._dap_plugins.refresh_called is True
+
+
+def test_lazy_dap_plugins_dir_does_not_materialize():
+    """Tab completion/introspection must not trigger DAP plugin initialization."""
+
+    class FailingDAPPlugins:
+        def __init__(self, parent):
+            raise AssertionError("DAPPlugins should not be initialized by dir()")
+
+    dap = LazyDAPPlugins(object(), FailingDAPPlugins)
+
+    assert "_dap_plugins" in dir(dap)
+    assert dap._dap_plugins is None
+
+
+def test_start_services_keeps_dap_lazy_until_first_access(monkeypatch):
+    """Starting client services should not import DAP plugins eagerly."""
+
+    constructed = []
+
+    class DummyDAPPlugins:
+        def __init__(self, parent):
+            constructed.append(parent)
+            self.GaussianModel = object()
+            self.refresh_called = False
+
+        def refresh(self):
+            self.refresh_called = True
+
+    client = BECClient(
+        forced=True, config=ServiceConfig(config={"redis": {"host": "localhost", "port": 1}})
+    )
+    client.connector = object()
+    client.device_manager = object()
+    client.macros = SimpleNamespace(load_all_user_macros=lambda: None)
+
+    monkeypatch.setattr(client, "_load_scans", lambda: None)
+    monkeypatch.setattr(client, "_start_device_manager", lambda: None)
+    monkeypatch.setattr(client, "_start_scan_queue", lambda: None)
+    monkeypatch.setattr(client, "_start_alarm_handler", lambda: None)
+    monkeypatch.setattr(client, "_update_username", lambda: None)
+    monkeypatch.setattr(client_module, "ConfigHelperUser", lambda device_manager: object())
+    monkeypatch.setattr(client_module, "ScanHistory", lambda client: object())
+    monkeypatch.setattr(client_module, "DeviceMonitorPlugin", lambda connector: object())
+    monkeypatch.setattr(client_module, "BeamlineStateManager", lambda client: object())
+    monkeypatch.setattr(client_module, "DAPPlugins", DummyDAPPlugins)
+
+    client._start_services()
+
+    assert isinstance(client.dap, LazyDAPPlugins)
+    assert constructed == []
+
+    dir(client.dap)
+    assert constructed == []
+
+    assert client.dap.GaussianModel is client.dap._dap_plugins.GaussianModel
+    assert constructed == [client]


### PR DESCRIPTION
## Description

This PR reduces `bec --nogui` startup time by deferring two startup-heavy paths that are not required immediately for a non-GUI shell session.

The GUI client is now created lazily when BEC starts with `--nogui`. The public `gui` object is still available, but BEC Widgets is not imported until the user actually calls something like `gui.show()` or `gui.new()`.

DAP plugin initialization is also deferred. `bec.dap` remains available, but the expensive DAP plugin setup is performed only when DAP functionality is first accessed.

In local benchmarking, this reduced `bec --nogui` startup time by about `2x`:

```bash
===== bec startup --nogui =====
Cases: bec
BEC branches: main,fix/startup-lazy-gui-and-dap
BEC Widgets branches: main
Benchmark 1: main
  Time (mean ± σ):      2.622 s ±  0.152 s    [User: 2.188 s, System: 0.346 s]
  Range (min … max):    2.495 s …  2.939 s    8 runs

Benchmark 2: fix/startup-lazy-gui-and-dap
  Time (mean ± σ):      1.319 s ±  0.009 s    [User: 1.130 s, System: 0.150 s]
  Range (min … max):    1.305 s …  1.333 s    8 runs


Summary
  fix/startup-lazy-gui-and-dap ran
    1.99 ± 0.12 times faster than main
```

## Type of Change

- Defer BEC Widgets GUI client import/creation for `bec --nogui` while keeping `gui` available.
- Defer DAP plugin initialization until first `bec.dap` access.

## How to test

- Run the existing unit tests for `bec_lib` and `bec_ipython_client`.
- Start `bec --nogui` and verify the client starts normally.
- From a `bec --nogui` session, call `gui.new()` or `gui.show()` and verify that the GUI can still be started on demand.
- Access `bec.dap` functionality and verify that DAP plugins still initialize when needed.

Startup benchmark with `hyperfine`:

Run this on `main`, record the result, then checkout this branch and run the same command again (I have the whole hyperfine wrapper, but this is minimal command to test it locally):

```bash
HOOK=$(mktemp /tmp/bec-startup-hook.XXXXXX.py)

cat > "$HOOK" <<'PY'
import os
import signal

print("BEC_BENCH_READY", flush=True)
os.kill(os.getpid(), signal.SIGTERM)
PY

hyperfine --warmup 2 --runs 8 --ignore-failure \
  "bec --nogui --dont-wait-for-server --post-startup-file $HOOK"

rm -f "$HOOK"
```

The benchmark starts `bec --nogui`, waits until the post-startup hook is executed, prints a marker, and then terminates the process. The non-zero exit code is expected because the hook intentionally stops the interactive process.

## Visual Demonstration

### Main
![startup_main](https://github.com/user-attachments/assets/5fb40f6f-4ba1-4e75-b8c6-ca244a71232c)

### Fixed
![startup_fix](https://github.com/user-attachments/assets/77438f7e-70e1-40b8-9ffb-28964829c8a1)



## Potential side effects

In `--nogui` sessions, `gui` is initially a lazy proxy instead of an eagerly constructed `BECGuiClient`. Normal usage such as `gui.show()` and `gui.new()` should continue to work, but code that checks the exact type of `gui` before first use may observe the proxy type.

If BEC Widgets is unavailable or broken, the error is now raised when GUI functionality is first used rather than during `bec --nogui` startup.

`bec.dap` is initially a lazy wrapper. Normal DAP access should initialize the real DAP plugins transparently, but strict type checks or introspection may observe the lazy wrapper before first use.

## Additional Comments

This PR intentionally targets non-GUI shell startup. It does not change the default GUI startup behavior, except that GUI-related imports are avoided when starting with `--nogui`.