### PR TITLE
feat(device): support wildcard '*' in device name expansion

### DIFF
--- a/bec_lib/bec_lib/devicemanager.py
+++ b/bec_lib/bec_lib/devicemanager.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 import collections
 import contextlib
 import copy
+import fnmatch
 import functools
-import re
 import threading
 import time
 import traceback
@@ -317,25 +317,30 @@ class DeviceContainer(dict):
         return [dev for dev in set(devices) if dev not in excluded_devices]
 
     def _expand_device_name(self, device_name: str) -> list[str]:
-        try:
-            regex = re.compile(device_name)
-        except re.error:
-            return [device_name]
-        return [dev for dev in self.keys() if regex.match(dev)]
+        if any(char in device_name for char in "*?[]"):
+            return fnmatch.filter(self.keys(), device_name)
+        return [device_name]
 
     def wm(self, device_names: list[str | DeviceBase | None] = None, *args):
-        """Get the current position of one or more devices.
+        """
+        Get the current position of one or more devices.
+        The device name can be specified either as a string or as a Device object.
+        If no device names are provided, the positions of all devices will be returned.
+        If the device name contains wildcard characters (*, ?, []), it will be expanded
+        to match all device names that fit the pattern.
 
         Args:
             device_names (list): List of device names or Device objects
 
         Examples:
-            >>> dev.wm()
-            >>> dev.wm('sam*')
-            >>> dev.wm('samx')
-            >>> dev.wm(['samx', 'samy'])
-            >>> dev.wm(dev.monitored_devices())
-            >>> dev.wm(dev.get_devices_with_tags('user motors'))
+            >>> dev.wm() # returns the position of all devices
+            >>> dev.wm('sam*') # returns all devices with names starting with 'sam'
+            >>> dev.wm('sam[xy]') # returns all devices with names 'samx' and 'samy'
+            >>> dev.wm('sam?') # returns all devices with names starting with 'sam' and followed by one character (e.g. 'samx', 'samy', but not 'sam' or 'samxy')
+            >>> dev.wm('samx') # returns the position of device 'samx'
+            >>> dev.wm(['samx', 'samy']) # returns the positions of devices 'samx' and 'samy'
+            >>> dev.wm(dev.monitored_devices()) # returns the positions of all monitored devices
+            >>> dev.wm(dev.get_devices_with_tags('user motors')) # returns the positions of all devices with the tag 'user motors'
 
         """
         if not device_names:

--- a/bec_lib/tests/test_devices.py
+++ b/bec_lib/tests/test_devices.py
@@ -583,6 +583,33 @@ def test_device_container_wm(dev_container, capsys):
         assert "1.0000" in captured.out
 
 
+def test_device_container_wm_supports_all_wildcard(dev_container, dm_with_override, capsys):
+    dev_container["other"] = Device(name="other", config=BASIC_CONFIG, parent=dm_with_override)
+    with (
+        mock.patch.object(dev_container.test, "read", return_value={"test": {"value": 1}}),
+        mock.patch.object(dev_container.other, "read", return_value={"other": {"value": 2}}),
+    ):
+        dev_container.wm("*")
+        captured = capsys.readouterr()
+        assert "test" in captured.out
+        assert "other" in captured.out
+        assert "1.0000" in captured.out
+        assert "2.0000" in captured.out
+
+
+def test_device_container_wm_uses_glob_matching(dev_container, dm_with_override, capsys):
+    dev_container["samy"] = Device(name="samy", config=BASIC_CONFIG, parent=dm_with_override)
+    dev_container["samytb"] = Device(name="samytb", config=BASIC_CONFIG, parent=dm_with_override)
+    with (
+        mock.patch.object(dev_container.samy, "read", return_value={"samy": {"value": 1}}),
+        mock.patch.object(dev_container.samytb, "read", return_value={"samytb": {"value": 2}}),
+    ):
+        dev_container.wm("s*?y")
+        captured = capsys.readouterr()
+        assert "samy" in captured.out
+        assert "samytb" not in captured.out
+
+
 def test_device_container_wm_read_contains_None(dev_container, capsys):
     with mock.patch.object(
         dev_container.test, "read", return_value={"test": {"value": None}}


### PR DESCRIPTION
`"sam*"` was working but `"*"` is not a valid regex and was thus treated as a device. This PR fixes it to resolve `"*"` to all devices