### PR TITLE
fix: remove unused kwargs in subscription

### DIFF
--- a/bec_server/bec_server/scan_bundler/scan_bundler.py
+++ b/bec_server/bec_server/scan_bundler/scan_bundler.py
@@ -34,12 +34,7 @@ class ScanBundler(BECService):
             cb=self._device_read_callback,
             name="device_read_register",
         )
-        self.connector.register(
-            MessageEndpoints.scan_status(),
-            cb=self._scan_status_callback,
-            group_id="scan_bundler",
-            name="scan_status_register",
-        )
+        self.connector.register(MessageEndpoints.scan_status(), cb=self._scan_status_callback)
 
         self.sync_storage = {}
         self.monitored_devices = {}


### PR DESCRIPTION
Somehow this came up in the e2e tests in bec_docs! These kwargs were never originally used in the callback (https://github.com/bec-project/bec/blob/a53b9e86fa4ecc80a85bb3b8919c5bb08702d823/bec_server/bec_server/scan_bundler/scan_bundler.py#L84-L86).

https://github.com/bec-project/bec_docs/actions/runs/24456307624/job/71457921462