### PR TITLE
Fix/bec startup

### DIFF
--- a/bec_ipython_client/bec_ipython_client/bec_startup.py
+++ b/bec_ipython_client/bec_ipython_client/bec_startup.py
@@ -81,7 +81,10 @@ else:
             base = os.path.dirname(plugin["module"].__file__)
             with open(os.path.join(base, "post_startup.py"), "r", encoding="utf-8") as file:
                 # pylint: disable=exec-used
-                exec(file.read())
+                try:
+                    exec(file.read())
+                except Exception as exc:
+                    logger.error(f"Error running `post startup` for plugin {name}: {exc}")
 
     else:
         bec._ip.prompts.status = 1

--- a/bec_ipython_client/bec_ipython_client/bec_startup.py
+++ b/bec_ipython_client/bec_ipython_client/bec_startup.py
@@ -89,8 +89,6 @@ else:
     else:
         bec._ip.prompts.status = 1
 
-    if not bec._hli_funcs:
-        bec.load_high_level_interface("bec_hli")
 
 if _main_dict["startup_file"]:
     with open(_main_dict["startup_file"], "r", encoding="utf-8") as file:

--- a/bec_lib/bec_lib/client.py
+++ b/bec_lib/bec_lib/client.py
@@ -259,6 +259,7 @@ class BECClient(BECService):
                 EventType.NAMESPACE_UPDATE, action="add", ns_objects=default_namespace
             )
             self.messaging = MessagingContainer(self.connector)
+            self.load_high_level_interface("bec_hli")
             logger.info("Starting new client")
             self.status = BECStatus.RUNNING
         except redis.exceptions.ConnectionError:

--- a/bec_lib/bec_lib/client.py
+++ b/bec_lib/bec_lib/client.py
@@ -218,6 +218,7 @@ class BECClient(BECService):
             builtins.bec = self._parent
             self.macros = UserMacros(self)
             self.builtin_actors = BuiltinActorHli(self)
+            self.load_high_level_interface("bec_hli")
             self._start_services()
             self.proc = ProcedureHli(self.connector) if self._init_procedure_hli else None
             default_namespace = {"dev": self.device_manager.devices, "scans": self.scans_namespace}
@@ -228,6 +229,8 @@ class BECClient(BECService):
             logger.info("Starting new client")
             self.status = BECStatus.RUNNING
         except redis.exceptions.ConnectionError:
+            # We still want to load the HLI even if Redis is not available
+            self.load_high_level_interface("bec_hli")
             logger.error("Failed to start the client: Could not connect to Redis server.")
             self.shutdown()
 


### PR DESCRIPTION
two changes: 
* Put the post startup into a try-except block to ensure that the client starts even if the post-startup file is messed up
* Put the hli startup to the bec lib client to give users the same interface in both versions