### PR TITLE
Feature/v4 scan plugins

### DIFF
--- a/bec_ipython_client/tests/end-2-end/test_scans_v4_lib_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_scans_v4_lib_e2e.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 import time
+import uuid
+from pathlib import Path
+from unittest.mock import patch
 
 import numpy as np
 import pytest
+from typer.testing import CliRunner
 
+from bec_lib.endpoints import MessageEndpoints
+from bec_lib.plugin_helper import plugin_repo_path
+from bec_lib.utils.plugin_manager import create as plugin_create
 from bec_server.scan_server.scans import position_generators
 
 
@@ -79,6 +86,38 @@ def _wait_for_queue_status(bec, queue_name: str, expected_status: str, timeout: 
             return
         time.sleep(0.1)
     raise TimeoutError(f"Timed out waiting for queue status {expected_status!r}.")
+
+
+def _plugin_scan_paths(scan_name: str) -> tuple[Path, Path]:
+    repo = Path(plugin_repo_path())
+    scans_dir = repo / repo.name / "scans"
+    return scans_dir / f"{scan_name}.py", scans_dir / "__init__.py"
+
+
+def _remove_scan_export(init_file: Path, scan_name: str):
+    import_line = (
+        f"from .{scan_name} import {''.join(part.capitalize() for part in scan_name.split('_'))}\n"
+    )
+    if not init_file.exists():
+        return
+    content = init_file.read_text(encoding="utf-8")
+    if import_line not in content:
+        return
+    init_file.write_text(content.replace(import_line, ""), encoding="utf-8")
+
+
+def _wait_for_v4_scan_registration(bec, scan_name: str, timeout: float = 60):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        available_scans = bec.connector.get(MessageEndpoints.available_scans())
+        if available_scans and scan_name in available_scans.resource:
+            if hasattr(bec.scans, scan_name):
+                return getattr(bec.scans, scan_name)
+        time.sleep(1)
+    available_scans = dir(bec.scans)
+    raise TimeoutError(
+        f"Timed out waiting for scan {scan_name!r} to become available. Available scans: {available_scans}"
+    )
 
 
 @pytest.mark.timeout(120)
@@ -279,3 +318,47 @@ def test_v4_scan_lib_stop_resolves_cleanly(bec_client_lib):
     status.cancel()
 
     _wait_for_queue_status(bec, "primary", "RUNNING", timeout=15)
+
+
+@pytest.mark.timeout(180)
+def test_v4_generated_scan_e2e(bec_client_lib):
+    bec = bec_client_lib
+    scan_name = f"e2e_generated_scan_{uuid.uuid4().hex[:8]}"
+    try:
+        scan_file, init_file = _plugin_scan_paths(scan_name)
+    except ValueError as exc:
+        pytest.skip(f"Generated scan e2e requires an editable plugin install: {exc}")
+    runner = CliRunner()
+
+    try:
+        with (
+            patch("bec_lib.utils.plugin_manager.create.scan.run_formatters"),
+            patch(
+                "bec_lib.utils.plugin_manager.create.scan._select_option",
+                return_value="SOFTWARE_TRIGGERED",
+            ),
+        ):
+            result = runner.invoke(
+                plugin_create._app,
+                ["scan", scan_name],
+                input="E2E generated scan.\nE2E generated scan.\nn\nn\n",
+            )
+        assert result.exit_code == 0, result.output
+        assert scan_file.exists()
+
+        bec._request_scan_reload()
+        scan_runner = _wait_for_v4_scan_registration(bec, scan_name)
+
+        bec.metadata.update({"unit_test": "test_v4_generated_scan_e2e"})
+        status = scan_runner()
+        status.wait(timeout=60, num_points=False, file_written=True)
+
+        assert status.scan is not None
+        assert status.request is not None
+        assert status.request.request.content["scan_type"] == scan_name
+    finally:
+        if scan_file.exists():
+            scan_file.unlink()
+        _remove_scan_export(init_file, scan_name)
+        bec._request_scan_reload()
+        time.sleep(2)

--- a/bec_lib/bec_lib/plugin_helper.py
+++ b/bec_lib/bec_lib/plugin_helper.py
@@ -4,6 +4,7 @@ import importlib
 import importlib.metadata
 import inspect
 import json
+import pkgutil
 import sys
 from functools import cache, lru_cache
 from typing import TYPE_CHECKING, Any, Literal, Type
@@ -12,6 +13,7 @@ from bec_lib.logger import bec_logger
 
 if TYPE_CHECKING:  # pragma: no cover
     from bec_lib.metadata_schema import BasicScanMetadata
+    from bec_server.scan_server.scans.scan_components import ScanComponents
     from bec_server.scan_server.scans.scan_modifier import ScanModifier
 
 
@@ -92,6 +94,41 @@ def get_scan_modifier_plugin() -> Type[ScanModifier] | None:
     return None
 
 
+def get_scan_component_plugins() -> list[Type[ScanComponents]]:
+    """
+    Load all scan component plugin classes from the installed plugin's
+    ``scans.scan_customization`` package.
+
+    Returns:
+        list[Type[ScanComponents]]: All discovered ScanComponents subclasses.
+    """
+    from bec_server.scan_server.scans.scan_components import ScanComponents
+
+    package_name = plugin_package_name()
+    try:
+        customization_package = _import_module(f"{package_name}.scans.scan_customization")
+    except ModuleNotFoundError:
+        return []
+
+    modules = [customization_package]
+    package_path = getattr(customization_package, "__path__", None)
+    if package_path is not None:
+        modules.extend(
+            _import_module(module_info.name)
+            for module_info in pkgutil.iter_modules(
+                package_path, prefix=f"{customization_package.__name__}."
+            )
+        )
+
+    component_plugins = []
+    for module in modules:
+        mods = inspect.getmembers(module, predicate=_filter_plugins)
+        for _, mod_cls in mods:
+            if issubclass(mod_cls, ScanComponents) and mod_cls is not ScanComponents:
+                component_plugins.append(mod_cls)
+    return component_plugins
+
+
 def get_file_writer_plugins() -> dict:
     """
     Load all file writer plugins.
@@ -168,6 +205,7 @@ def module_dist_info(name: str) -> dict[str, Any]:
     return json.loads(dist.read_text("direct_url.json") or "{}")
 
 
+@lru_cache()
 def plugin_repo_path() -> str:
     """Get the path on disk of the installed plugin repository. Raises ValueError if no plugin is
     installed or more than one plugin is installed. Raises ValueError if the installed plugin is not

--- a/bec_lib/bec_lib/plugin_helper.py
+++ b/bec_lib/bec_lib/plugin_helper.py
@@ -233,7 +233,18 @@ def reload_plugin_modules() -> None:
         if name == plugin_module.__name__ or name.startswith(f"{plugin_module.__name__}.")
     ]
     for module_name in sorted(module_names, key=lambda name: name.count("."), reverse=True):
-        importlib.reload(sys.modules[module_name])
+        module = sys.modules.get(module_name)
+        if module is None:
+            continue
+        try:
+            importlib.reload(module)
+        except ModuleNotFoundError as exc:
+            if exc.name != module_name:
+                raise
+            logger.warning(
+                f"Skipping reload for stale plugin module {module_name!r}; module spec is no longer available."
+            )
+            sys.modules.pop(module_name, None)
 
 
 def _filter_plugins(module) -> bool:

--- a/bec_lib/bec_lib/utils/plugin_manager/_util.py
+++ b/bec_lib/bec_lib/utils/plugin_manager/_util.py
@@ -40,3 +40,15 @@ def git_stage_files(directory: Path, filenames: list[str] = []):
 def make_commit(repo: Path, message: str):
     with _goto_dir(repo):
         subprocess.call(["git", "commit", "-m", message])
+
+
+def run_formatters(directory: Path, filenames: list[str]) -> None:
+    """Run isort and black on the given files relative to `directory`."""
+    with _goto_dir(directory):
+        for command in (["isort", *filenames], ["black", *filenames]):
+            result = subprocess.run(command, capture_output=True, text=True, check=False)
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"Formatter {' '.join(command)} failed with exit code {result.returncode}:\n"
+                    f"{result.stdout}\n{result.stderr}"
+                )

--- a/bec_lib/bec_lib/utils/plugin_manager/create/scan.py
+++ b/bec_lib/bec_lib/utils/plugin_manager/create/scan.py
@@ -1,9 +1,595 @@
+from __future__ import annotations
+
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Annotated, Any, get_args, get_origin
+
+import jinja2
+import questionary
 import typer
 
+from bec_lib.logger import bec_logger
+from bec_lib.plugin_helper import get_scan_component_plugins, plugin_package_name, plugin_repo_path
+from bec_lib.scan_args import DefaultArgType, ScanArgument, Units
+from bec_lib.utils.copier_jinja_filters import CopierFilters
+from bec_lib.utils.plugin_manager._util import run_formatters
+
+logger = bec_logger.logger
 _app = typer.Typer(rich_markup_mode="rich")
+_ARGUMENT_TYPES = ("float", "int", "bool", "str", "DeviceBase")
+_SCAN_TYPES = ("SOFTWARE_TRIGGERED", "HARDWARE_TRIGGERED")
+_QUESTIONARY_STYLE = questionary.Style(
+    [
+        ("qmark", "fg:#e76f51 bold"),
+        ("question", "fg:#f4a261 bold"),
+        ("answer", "fg:#2a9d8f bold"),
+        ("pointer", "fg:#e9c46a bold"),
+        ("highlighted", "fg:#ffffff bg:#264653 bold"),
+        ("selected", "fg:#2a9d8f bold"),
+        ("separator", "fg:#6c757d"),
+        ("instruction", "fg:#8d99ae italic"),
+        ("text", "fg:#f8f9fa"),
+    ]
+)
+_HIDDEN_BUILTIN_ARGUMENT_NAMES = frozenset(
+    {"num_points", "num_monitored_readouts", "positions", "run_on_exception_hook"}
+)
+
+
+def _select_option(prompt: str, choices: list[str] | tuple[str, ...]) -> str:
+    """Prompt the user to select one option from a list of choices."""
+    selected = questionary.select(prompt, choices=list(choices), style=_QUESTIONARY_STYLE).ask()
+    if selected is None:
+        raise typer.Exit(code=1)
+    return selected
+
+
+def _scan_argument_metadata(annotation: Any) -> tuple[Any, ScanArgument]:
+    """Extract the base type and :class:`ScanArgument` metadata from an annotation."""
+    if get_origin(annotation) is not Annotated:
+        raise ValueError(f"Expected Annotated type, got {annotation!r}")
+
+    base_type, *metadata = get_args(annotation)
+    for item in metadata:
+        if isinstance(item, ScanArgument):
+            return base_type, item
+    raise ValueError(f"No ScanArgument metadata found in {annotation!r}")
+
+
+def _python_type_name(annotation: Any) -> str:
+    """Return a readable Python type name for docstrings and prompt labels."""
+    if annotation is type(None):
+        return "None"
+    return getattr(annotation, "__name__", repr(annotation))
+
+
+@dataclass(frozen=True)
+class BaseArgumentSpec:
+    """Common interface for template-rendered scan arguments."""
+
+    name: str
+    default: str | None = None
+    gui_group: str = "Scan Parameters"
+
+    @property
+    def requires_default_arg_type_import(self) -> bool:
+        return False
+
+    @property
+    def requires_scan_argument_import(self) -> bool:
+        return False
+
+    @property
+    def requires_units_import(self) -> bool:
+        return False
+
+    @property
+    def unit_expression(self) -> str | None:
+        """Return the generated ``Units`` expression for the configured unit.
+
+        Returns:
+            str | None: Python expression using ``Units.<name>`` attributes, or ``None``.
+        """
+        units = getattr(self, "units", None)
+        if not units:
+            return None
+
+        parsed_unit = Units.parse_units(units)
+        numerator: list[str] = []
+        denominator: list[str] = []
+        for unit_name, exponent in parsed_unit._units.items():
+            compact_name = f"{Units.parse_units(unit_name):~P}"
+            unit_term = f"Units.{compact_name}"
+            if abs(exponent) != 1:
+                unit_term = f"{unit_term} ** {abs(exponent)}"
+            target = numerator if exponent > 0 else denominator
+            target.append(unit_term)
+
+        expression = " * ".join(numerator) if numerator else "1"
+        if denominator:
+            expression += " / " + " / ".join(denominator)
+        return expression
+
+    @property
+    def annotation(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def display_name(self) -> str:
+        """Return a title-cased label derived from the argument name.
+
+        Returns:
+            str: Display label for prompts and generated metadata.
+        """
+        return self.name.replace("_", " ").title()
+
+    @property
+    def doc_type(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def doc_line(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def parameter(self) -> str:
+        """Render the full parameter definition for the template.
+
+        Returns:
+            str: Function parameter including annotation and optional default.
+        """
+        parameter = f"{self.name}: {self.annotation}"
+        if self.default is not None:
+            parameter += f" = {self.default}"
+        return parameter
+
+    @property
+    def selection_label(self) -> str:
+        """Return the label shown in the built-in argument selector.
+
+        Returns:
+            str: Human-readable label for interactive selection prompts.
+        """
+        return f"{self.name} ({self.type}): {self.doc_line}"
+
+
+@dataclass(frozen=True)
+class CustomArgumentSpec(BaseArgumentSpec):
+    """User-defined scan argument rendered as ``Annotated[..., ScanArgument(...)]``."""
+
+    type: str = "float"
+    doc: str | None = None
+    units: str | None = None
+
+    @property
+    def requires_scan_argument_import(self) -> bool:
+        return True
+
+    @property
+    def requires_units_import(self) -> bool:
+        return self.units is not None
+
+    @property
+    def annotation(self) -> str:
+        units = f", units={self.unit_expression}" if self.unit_expression else ""
+        annotations = {
+            "float": (
+                f"Annotated[float, ScanArgument(display_name={self.display_name!r}, "
+                f"description={self.doc_line!r}{units})]"
+            ),
+            "int": (
+                f"Annotated[int, ScanArgument(display_name={self.display_name!r}, "
+                f"description={self.doc_line!r}{units})]"
+            ),
+            "bool": (
+                f"Annotated[bool, ScanArgument(display_name={self.display_name!r}, "
+                f"description={self.doc_line!r})]"
+            ),
+            "str": (
+                f"Annotated[str, ScanArgument(display_name={self.display_name!r}, "
+                f"description={self.doc_line!r})]"
+            ),
+            "DeviceBase": (
+                f"Annotated[DeviceBase, ScanArgument(display_name={self.display_name!r}, "
+                f"description={self.doc_line!r})]"
+            ),
+        }
+        return annotations[self.type]
+
+    @property
+    def doc_type(self) -> str:
+        return self.type
+
+    @property
+    def doc_line(self) -> str:
+        return self.doc or f"{self.display_name}."
+
+
+@dataclass(frozen=True)
+class BuiltinArgumentSpec(BaseArgumentSpec):
+    """Builtin scan argument backed directly by :class:`DefaultArgType`."""
+
+    default_arg_type: str = ""
+
+    @property
+    def requires_default_arg_type_import(self) -> bool:
+        return True
+
+    @property
+    def default_annotation(self) -> Any:
+        return getattr(DefaultArgType, self.default_arg_type)
+
+    @property
+    def type(self) -> str:
+        base_type, _ = _scan_argument_metadata(self.default_annotation)
+        return _python_type_name(base_type)
+
+    @property
+    def metadata(self) -> ScanArgument:
+        _, metadata = _scan_argument_metadata(self.default_annotation)
+        return metadata
+
+    @property
+    def annotation(self) -> str:
+        return f"DefaultArgType.{self.default_arg_type}"
+
+    @property
+    def display_name(self) -> str:
+        return self.metadata.display_name or super().display_name
+
+    @property
+    def doc_type(self) -> str:
+        return self.type
+
+    @property
+    def doc_line(self) -> str:
+        return self.metadata.description or f"{self.display_name}."
+
+
+@dataclass(frozen=True)
+class ScanConfig:
+    """Collect the values required to render a new scan template.
+
+    Args:
+        name (str): Snake-case scan name used for the file, class, and scan identifier.
+        description (str): Module docstring description for the generated scan.
+        scan_type (str): Selected v4 scan type enum member name.
+        template_arguments (list[BaseArgumentSpec]): Arguments rendered into the template.
+        plugin_components_class (str | None): Optional plugin-local ScanComponents subclass.
+        plugin_components_import (str | None): Import path for the plugin-local ScanComponents subclass.
+    """
+
+    name: str
+    description: str
+    scan_type: str
+    template_arguments: list[BaseArgumentSpec]
+    plugin_components_class: str | None = None
+    plugin_components_import: str | None = None
+
+
+def _render_scan(template_dir: Path, config: ScanConfig) -> str:
+    """Render the v4 scan template for the provided configuration."""
+    environment = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(template_dir),
+        extensions=[CopierFilters],
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+    template = environment.get_template("v4_scan.py.jinja")
+    return (
+        template.render(
+            name=config.name,
+            description=config.description,
+            scan_type=config.scan_type,
+            arguments=config.template_arguments,
+            plugin_components_class=config.plugin_components_class,
+            plugin_components_import=config.plugin_components_import,
+        ).rstrip()
+        + "\n"
+    )
+
+
+def _get_plugin_components_config() -> tuple[str | None, str | None]:
+    """Return the plugin-local ScanComponents subclass and absolute import path."""
+    component_plugins = get_scan_component_plugins()
+    if not component_plugins:
+        return None, None
+
+    plugin_package = plugin_package_name()
+    for component_cls in component_plugins:
+        module_name = component_cls.__module__
+        if not module_name.startswith(f"{plugin_package}."):
+            continue
+        return component_cls.__name__, module_name
+    return None, None
+
+
+_BUILTIN_ARGUMENTS = (
+    BuiltinArgumentSpec(
+        name="exp_time",
+        default_arg_type="ExposureTime",
+        default="0",
+        gui_group="Acquisition Parameters",
+    ),
+    BuiltinArgumentSpec(
+        name="frames_per_trigger",
+        default_arg_type="FramesPerTrigger",
+        default="1",
+        gui_group="Acquisition Parameters",
+    ),
+    BuiltinArgumentSpec(
+        name="settling_time",
+        default_arg_type="SettlingTime",
+        default="0",
+        gui_group="Acquisition Parameters",
+    ),
+    BuiltinArgumentSpec(
+        name="settling_time_after_trigger",
+        default_arg_type="SettlingTimeAfterTrigger",
+        default="0",
+        gui_group="Acquisition Parameters",
+    ),
+    BuiltinArgumentSpec(
+        name="readout_time",
+        default_arg_type="ReadoutTime",
+        default="0",
+        gui_group="Acquisition Parameters",
+    ),
+    BuiltinArgumentSpec(
+        name="burst_at_each_point",
+        default_arg_type="BurstAtEachPoint",
+        default="1",
+        gui_group="Acquisition Parameters",
+    ),
+    BuiltinArgumentSpec(name="relative", default_arg_type="Relative", gui_group="Scan Parameters"),
+)
+_RESERVED_ARGUMENT_NAMES = frozenset(argument.name for argument in _BUILTIN_ARGUMENTS) | (
+    _HIDDEN_BUILTIN_ARGUMENT_NAMES
+)
+
+
+def _snake_to_pascal(value: str) -> str:
+    """Convert a snake-case identifier to PascalCase.
+
+    Args:
+        value (str): Identifier in snake_case.
+
+    Returns:
+        str: PascalCase version of ``value``.
+    """
+    return "".join(part.capitalize() for part in value.split("_"))
+
+
+def _normalize_identifier(name: str, target: str) -> str:
+    """Normalize and validate a user-provided identifier.
+
+    Args:
+        name (str): Raw identifier entered by the user.
+        target (str): Human-readable target name for error messages.
+
+    Returns:
+        str: Lowercase identifier with dashes replaced by underscores.
+
+    Raises:
+        typer.Exit: If the normalized name is not a valid Python identifier.
+    """
+    formatted_name = name.lower().replace("-", "_")
+    if formatted_name != name:
+        logger.warning(f"Adjusting {target} name from {name} to {formatted_name}")
+    if not formatted_name.isidentifier():
+        logger.error(
+            f"{name} is not a valid name for a {target} (even after converting to {formatted_name}). "
+            "Please enter a valid Python identifier using only letters, numbers and underscores, and not "
+            "starting with a number, e.g. 'my_scan', 'scan1', 'my_scan_v2', ..."
+        )
+        raise typer.Exit(code=1)
+    return formatted_name
+
+
+def _normalize_unit(unit: str) -> str | None:
+    """Validate and normalize a user-provided unit string.
+
+    Args:
+        unit (str): Raw unit text entered by the user.
+
+    Returns:
+        str | None: Unit attribute name from :class:`Units`, or ``None`` if omitted.
+
+    Raises:
+        typer.Exit: If the provided unit does not exist on :class:`Units`.
+    """
+    stripped = unit.strip()
+    if not stripped or stripped.lower() == "none":
+        return None
+
+    try:
+        parsed_unit = Units.parse_units(stripped)
+    except Exception:
+        logger.error(f"{unit} is not a valid unit.")
+        raise typer.Exit(code=1) from None
+
+    return f"{parsed_unit:~P}"
+
+
+def _prompt_for_builtin_arguments() -> list[BuiltinArgumentSpec]:
+    """Prompt the user to select built-in scan arguments.
+
+    Returns:
+        list[BuiltinArgumentSpec]: Selected built-in argument specifications.
+
+    Raises:
+        typer.Exit: If the interactive questionary prompt is cancelled.
+    """
+    if not typer.confirm(
+        "Do you want to include built-in scan arguments (e.g. exp_time, relative, ...)?",
+        default=False,
+    ):
+        return []
+
+    selected = questionary.checkbox(
+        "Select built-in scan arguments",
+        choices=[
+            questionary.Choice(title=argument.selection_label, value=argument)
+            for argument in _BUILTIN_ARGUMENTS
+        ],
+        style=_QUESTIONARY_STYLE,
+        instruction="Use space to toggle, arrows to move, enter to confirm",
+    ).ask()
+    if selected is None:
+        raise typer.Exit(code=1)
+
+    # we need to sort the selected arguments based on default arguments as we have to specify
+    # kwargs without defaults before kwargs with defaults in the generated function signature
+    selected.sort(key=lambda argument: argument.default is not None)
+    return selected
+
+
+def _prompt_for_custom_arguments() -> list[CustomArgumentSpec]:
+    """Prompt the user for custom scan arguments.
+
+    Returns:
+        list[CustomArgumentSpec]: Custom argument specifications in prompt order.
+
+    Raises:
+        typer.Exit: If the user provides an invalid name, duplicate name, invalid unit,
+            or cancels one of the interactive selectors.
+    """
+    arguments: list[CustomArgumentSpec] = []
+    if not typer.confirm("Do you want to set up scan arguments?", default=True):
+        return arguments
+
+    while True:
+        while True:
+            try:
+                arg_name = _normalize_identifier(typer.prompt("Enter argument name"), "argument")
+            except typer.Exit:
+                continue
+            if arg_name in _RESERVED_ARGUMENT_NAMES:
+                logger.error(
+                    f"Argument {arg_name} is already provided as a built-in scan argument."
+                )
+                continue
+            if any(existing.name == arg_name for existing in arguments):
+                logger.error(f"Argument {arg_name} already exists.")
+                continue
+            break
+        arg_type = _select_option("Select argument type", _ARGUMENT_TYPES)
+        arg_units = None
+        if arg_type in {"float", "int"}:
+            while True:
+                try:
+                    arg_units = _normalize_unit(
+                        typer.prompt(
+                            "Enter argument units, e.g. 's', 'microns', 'mm', 'T/min', ...",
+                            default="None",
+                        )
+                    )
+                except typer.Exit:
+                    continue
+                break
+        arg_description = typer.prompt(
+            "Enter argument description", default=arg_name.replace("_", " ").capitalize() + "."
+        )
+        arguments.append(
+            CustomArgumentSpec(name=arg_name, type=arg_type, doc=arg_description, units=arg_units)
+        )
+        if not typer.confirm("Add another argument?", default=False):
+            return arguments
+
+
+def _ensure_scan_export(init_file: Path, name: str) -> None:
+    """Ensure that the generated scan is exported from the scans package.
+
+    Args:
+        init_file (Path): Path to the package ``__init__.py`` file.
+        name (str): Snake-case scan name to export.
+    """
+    class_name = _snake_to_pascal(name)
+    import_line = f"from .{name} import {class_name}\n"
+    if init_file.exists():
+        content = init_file.read_text(encoding="utf-8")
+    else:
+        content = ""
+
+    if import_line in content.splitlines(keepends=True):
+        return
+
+    new_content = content
+    if new_content and not new_content.endswith("\n"):
+        new_content += "\n"
+    new_content += import_line
+    init_file.parent.mkdir(parents=True, exist_ok=True)
+    init_file.write_text(new_content, encoding="utf-8")
+
+
+def verify_dependencies() -> None:
+    """
+    Verify that all dependencies for scan creation are available.
+
+    We verify the dependencies manually to avoid that the user writes the
+    scan and only finds out at the end that they forgot to install one of the required packages.
+    """
+    try:
+        # pylint: disable=import-outside-toplevel,unused-import
+        import black
+        import isort
+    except ImportError as e:
+        logger.error(f"Missing dependency: {e.name}. Please install it to use this command.")
+        raise typer.Exit(code=1) from None
 
 
 @_app.command()
-def scan(name: str):
-    """Create a new scan plugin with the given name."""
-    raise NotImplementedError()
+def scan(
+    name: Annotated[
+        str | None, typer.Argument(help="Enter a name for your scan in snake_case")
+    ] = None,
+):
+    """Create a new v4 scan plugin.
+
+    Args:
+        name (str | None): Optional scan name in snake_case. If omitted, the command
+            prompts for it interactively.
+
+    Raises:
+        typer.Exit: If the user cancels an interactive prompt or provides invalid input.
+    """
+    try:
+        verify_dependencies()
+        repo = Path(plugin_repo_path())
+        template_dir = Path(__file__).with_name("templates")
+        plugin_components_class, plugin_components_import = _get_plugin_components_config()
+        scan_name = _normalize_identifier(name or typer.prompt("Scan name"), "scan")
+        scans_dir = repo / repo.name / "scans"
+        scan_file = scans_dir / f"{scan_name}.py"
+        init_file = scans_dir / "__init__.py"
+        if scan_file.exists():
+            if not typer.confirm(f"Scan {scan_name} already exists. Override it?", default=False):
+                raise typer.Exit(code=1)
+
+        description = typer.prompt("Scan description", default="Scan implementation.")
+        scan_type = _select_option("Scan type", _SCAN_TYPES)
+        builtin_arguments = _prompt_for_builtin_arguments()
+        custom_arguments = _prompt_for_custom_arguments()
+        config = ScanConfig(
+            name=scan_name,
+            description=description,
+            scan_type=scan_type,
+            template_arguments=custom_arguments + builtin_arguments,
+            plugin_components_class=plugin_components_class,
+            plugin_components_import=plugin_components_import,
+        )
+
+        logger.info(f"Adding new scan {config.name}...")
+        scan_file.parent.mkdir(parents=True, exist_ok=True)
+        scan_file.write_text(_render_scan(template_dir, config), encoding="utf-8")
+        _ensure_scan_export(init_file, config.name)
+        run_formatters(repo, [str(scan_file.relative_to(repo)), str(init_file.relative_to(repo))])
+    except typer.Exit:
+        raise
+    except Exception:
+        logger.error(traceback.format_exc())
+        logger.error("exiting...")
+        raise typer.Exit(code=1) from None
+
+    logger.success(f"Added scan {config.name}!")

--- a/bec_lib/bec_lib/utils/plugin_manager/create/templates/v4_scan.py.jinja
+++ b/bec_lib/bec_lib/utils/plugin_manager/create/templates/v4_scan.py.jinja
@@ -1,0 +1,248 @@
+"""
+{{ description | default("Scan implementation.") }}
+
+Scan procedure:
+    - prepare_scan
+    - open_scan
+    - stage
+    - pre_scan
+    - scan_core
+        - at_each_point (optionally called by scan_core)
+    - post_scan
+    - unstage
+    - close_scan
+    - on_exception (called if any exception is raised during the scan)
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import numpy as np
+
+{% if arguments | selectattr("type", "equalto", "DeviceBase") | list %}
+from bec_lib.device import DeviceBase
+
+{% endif %}
+{% set arguments_needing_default_arg_type = arguments | selectattr("requires_default_arg_type_import") | list %}
+{% set arguments_needing_scan_argument = arguments | selectattr("requires_scan_argument_import") | list %}
+{% set arguments_needing_units = arguments | selectattr("requires_units_import") | list %}
+{% set builtin_arguments = arguments | selectattr("requires_default_arg_type_import") | list %}
+{% set device_arguments = arguments | selectattr("type", "equalto", "DeviceBase") | list %}
+{% set scan_args_imports = [] %}
+{% if arguments_needing_default_arg_type %}{% set _ = scan_args_imports.append("DefaultArgType") %}{% endif %}
+{% if arguments_needing_scan_argument %}{% set _ = scan_args_imports.append("ScanArgument") %}{% endif %}
+{% if arguments_needing_units %}{% set _ = scan_args_imports.append("Units") %}{% endif %}
+{% if arguments_needing_default_arg_type or arguments_needing_scan_argument %}
+from bec_lib.scan_args import {{ scan_args_imports | join(", ") }}
+{% endif %}
+{% if plugin_components_class %}
+from {{ plugin_components_import }} import {{ plugin_components_class }}
+
+{% endif %}
+from bec_server.scan_server.scans import position_generators
+from bec_server.scan_server.scans.scan_base import ScanBase, ScanType
+from bec_server.scan_server.scans.scan_modifier import scan_hook
+
+
+class {{ name | snake_to_pascal }}(ScanBase):
+    # Scan Type: Hardware triggered or software triggered?
+    # If the main trigger and readout logic is done within the at_each_point method in scan_core, choose SOFTWARE_TRIGGERED.
+    # If the main trigger and readout logic is implemented on a device that is simply kicked off in this scan, choose HARDWARE_TRIGGERED.
+    # This primarily serves as information for devices: The device may need to react differently if a software trigger is expected
+    # for every point.
+    scan_type = ScanType.{{ scan_type | default("SOFTWARE_TRIGGERED") }}
+
+    # Scan name: This is the name of the scan, e.g. "line_scan". This is used for display purposes and to identify the scan type in user interfaces.
+    # Choose a descriptive name that does not conflict with existing scan names.
+    # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
+    scan_name = "{{ name }}"
+
+{% set scan_parameter_arguments = arguments | selectattr("gui_group", "equalto", "Scan Parameters") | list %}
+{% set acquisition_arguments = arguments | selectattr("gui_group", "equalto", "Acquisition Parameters") | list %}
+{% if scan_parameter_arguments or acquisition_arguments %}
+    gui_config = {
+{% if scan_parameter_arguments %}
+        "Scan Parameters": [{% for argument in scan_parameter_arguments %}"{{ argument.name }}"{% if not loop.last %}, {% endif %}{% endfor %}],
+{% endif %}
+{% if acquisition_arguments %}
+        "Acquisition Parameters": [{% for argument in acquisition_arguments %}"{{ argument.name }}"{% if not loop.last %}, {% endif %}{% endfor %}],
+{% endif %}
+    }
+{% endif %}
+
+    def __init__(
+        self,
+{% for argument in arguments | default([]) %}
+        {{ argument.parameter }},
+{% endfor %}
+        **kwargs,
+    ):
+        """
+        {{ description | default("Scan implementation.") }}
+
+        Args:
+{% for argument in arguments | default([]) %}
+            {{ argument.name }} ({{ argument.doc_type }}): {{ argument.doc_line }}
+{% endfor %}
+
+        Returns:
+            ScanReport
+        """
+        super().__init__(**kwargs)
+{% if plugin_components_class %}
+        self.components = {{ plugin_components_class }}(self)
+{% endif %}
+        self._baseline_readout_status = None
+{% for argument in arguments | default([]) %}
+        self.{{ argument.name }} = {{ argument.name }}
+{% endfor %}
+{% if device_arguments %}
+        self.motors = [{% for argument in device_arguments %}{{ argument.name }}{% if not loop.last %}, {% endif %}{% endfor %}]
+{% endif %}
+
+{% if device_arguments %}
+        # TODO: If the scan motors (self.motors) are step-scanned, and we want e.g. GUIs 
+        # to pick them up automatically, add them as scan_report_devices to the 
+        # update_scan_info call below (scan_report_devices=self.motors). 
+        # Delete the comment if not needed.
+{% endif %}
+
+        self.update_scan_info(
+{% if builtin_arguments %}
+{% for argument in builtin_arguments %}
+            {{ argument.name }}={{ argument.name }},
+{% endfor %}
+{% endif %}
+        )
+{% if device_arguments %}
+        # TODO: If the scan motors (self.motors) are step-scanned, we have to elevate 
+        # their readout priority to "monitored" to ensure that their positions are 
+        # included in every readout of the step scan. 
+        # Uncomment the line below as necessary or delete it if not needed.
+        
+        # self.actions.set_device_readout_priority(self.motors, priority="monitored")
+{% endif %}
+
+    @scan_hook
+    def prepare_scan(self):
+        """
+        Prepare the scan. This can include any steps that need to be executed
+        before the scan is opened, such as preparing the positions (if not done already)
+        or setting up the devices.
+        """
+
+        #TODO: If necessary, prepare the positions for the scan here and update the scan 
+        # info with the updated num_points and num_monitored_readouts using self.update_scan_info().
+        # Take the following example of a hexagonal scan as a reference:
+
+        # self.positions = position_generators.hex_grid_2d(
+        #     [
+        #         (self.start_motor1, self.stop_motor1, self.step_motor1),
+        #         (self.start_motor2, self.stop_motor2, self.step_motor2),
+        #     ],
+        #     snaked=self.snaked,
+        # )
+
+        # if self.relative:
+        #     self.start_positions = self.components.get_start_positions(self.motors)
+        #     self.positions += self.start_positions
+
+        # self.components.check_limits(self.motors, self.positions)
+
+        # self.update_scan_info(
+        #     positions=self.positions,
+        #     num_points=len(self.positions),
+        #     num_monitored_readouts=len(self.positions) * self.burst_at_each_point,
+        # )
+
+        # Delete the comment if not needed.
+
+        self.actions.add_scan_report_instruction_scan_progress(
+            points=self.scan_info.num_monitored_readouts, show_table=False
+        )
+        self._baseline_readout_status = self.actions.read_baseline_devices(wait=False)
+
+    @scan_hook
+    def open_scan(self):
+        """
+        Open the scan.
+        This step must call self.actions.open_scan() to ensure that a new scan is
+        opened. Make sure to prepare the scan metadata before, either in
+        prepare_scan() or in open_scan() itself and call self.update_scan_info(...)
+        to update the scan metadata if needed.
+        """
+        self.actions.open_scan()
+
+    @scan_hook
+    def stage(self):
+        """
+        Stage the devices for the upcoming scan. The stage logic is typically
+        implemented on the device itself (i.e. by the device's stage method).
+        However, if there are any additional steps that need to be executed before
+        staging the devices, they can be implemented here.
+        """
+        self.actions.stage_all_devices()
+
+    @scan_hook
+    def pre_scan(self):
+        """
+        Pre-scan steps to be executed before the main scan logic.
+        This is typically the last chance to prepare the devices before the core scan
+        logic is executed. For example, this is a good place to initialize time-criticial
+        devices, e.g. devices that have a short timeout.
+        The pre-scan logic is typically implemented on the device itself.
+        """
+        self.actions.pre_scan_all_devices()
+
+    @scan_hook
+    def scan_core(self):
+        """
+        Core scan logic to be executed during the scan.
+        This is where the main scan logic should be implemented.
+        """
+
+        # TODO: Implement the core scan logic here. If applicable, we recommend to call 
+        # self.at_each_point() at each acquisition point in the scan to allow scan modifiers
+        # to extend the behavior of the scan at each point.
+        # Delete the comment if not needed.
+
+    @scan_hook
+    def at_each_point(self):
+        """
+        Logic to be executed at each acquisition point during the scan.
+        """
+
+    @scan_hook
+    def post_scan(self):
+        """
+        Post-scan steps to be executed after the main scan logic.
+        """
+        self.actions.complete_all_devices()
+
+    @scan_hook
+    def unstage(self):
+        """Unstage the scan by executing post-scan steps."""
+        self.actions.unstage_all_devices()
+
+    @scan_hook
+    def close_scan(self):
+        """Close the scan."""
+        if self._baseline_readout_status is not None:
+            self._baseline_readout_status.wait()
+        self.actions.close_scan()
+        self.actions.check_for_unchecked_statuses()
+
+    @scan_hook
+    def on_exception(self, exception: Exception):
+        """
+        Handle exceptions that occur during the scan.
+        This is a good place to implement any cleanup logic that needs to be executed in case of an exception,
+        such as returning the devices to a safe state or moving the motors back to their starting position.
+        """
+
+    #######################################################
+    ######### Helper methods for the scan logic ###########
+    #######################################################
+
+    # Implement scan-specific helper methods below.

--- a/bec_lib/pyproject.toml
+++ b/bec_lib/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "pint~=0.25",
     "python-dotenv~=1.0",
     "python-slugify~=8.0",
+    "questionary~=2.0",
 ]
 
 

--- a/bec_lib/tests/test_plugin_helper.py
+++ b/bec_lib/tests/test_plugin_helper.py
@@ -67,6 +67,37 @@ def test_reload_plugin_modules_reloads_plugin_tree():
     importlib_mock.reload.assert_any_call(plugin_scan_submodule)
 
 
+def test_reload_plugin_modules_skips_stale_modules():
+    plugin_module = mock.MagicMock()
+    plugin_module.__name__ = "bec_plugin"
+    stale_module = mock.MagicMock()
+    stale_module.__name__ = "bec_plugin.scans.deleted_scan"
+    importlib_mock = mock.MagicMock()
+    importlib_mock.import_module.return_value = plugin_module
+    missing_spec_error = ModuleNotFoundError(
+        "spec not found for the module 'bec_plugin.scans.deleted_scan'"
+    )
+    missing_spec_error.name = stale_module.__name__
+    importlib_mock.reload.side_effect = [missing_spec_error, None]
+
+    with (
+        mock.patch("bec_lib.plugin_helper.plugin_package_name", return_value="bec_plugin"),
+        mock.patch.object(plugin_helper, "importlib", importlib_mock),
+        mock.patch("bec_lib.plugin_helper.logger.warning") as logger_warning,
+        mock.patch.dict(
+            sys.modules,
+            {plugin_module.__name__: plugin_module, stale_module.__name__: stale_module},
+            clear=False,
+        ),
+    ):
+        plugin_helper.reload_plugin_modules()
+        assert stale_module.__name__ not in sys.modules
+
+    logger_warning.assert_called_once()
+    importlib_mock.reload.assert_any_call(plugin_module)
+    importlib_mock.reload.assert_any_call(stale_module)
+
+
 def test_get_scan_component_plugins(monkeypatch):
     from bec_server.scan_server.scans.scan_components import ScanComponents
 

--- a/bec_lib/tests/test_plugin_helper.py
+++ b/bec_lib/tests/test_plugin_helper.py
@@ -1,4 +1,5 @@
 import sys
+from types import ModuleType, SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -64,3 +65,30 @@ def test_reload_plugin_modules_reloads_plugin_tree():
     importlib_mock.reload.assert_any_call(plugin_module)
     importlib_mock.reload.assert_any_call(plugin_scans_module)
     importlib_mock.reload.assert_any_call(plugin_scan_submodule)
+
+
+def test_get_scan_component_plugins(monkeypatch):
+    from bec_server.scan_server.scans.scan_components import ScanComponents
+
+    package = ModuleType("example_plugin.scans.scan_customization")
+    package.__path__ = ["fake_path"]
+
+    module = ModuleType("example_plugin.scans.scan_customization.scan_components")
+    plugin_components = type("PluginComponents", (ScanComponents,), {"__module__": module.__name__})
+    module.PluginComponents = plugin_components
+
+    monkeypatch.setattr(plugin_helper, "plugin_package_name", lambda: "example_plugin")
+    monkeypatch.setattr(
+        plugin_helper,
+        "_import_module",
+        lambda name: {package.__name__: package, module.__name__: module}[name],
+    )
+    monkeypatch.setattr(
+        plugin_helper.pkgutil,
+        "iter_modules",
+        lambda path, prefix: [SimpleNamespace(name=module.__name__)],
+    )
+
+    result = plugin_helper.get_scan_component_plugins()
+
+    assert result == [plugin_components]

--- a/bec_lib/tests/test_plugin_manager.py
+++ b/bec_lib/tests/test_plugin_manager.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import sys
 from importlib import reload
+from pathlib import Path
 from textwrap import dedent
 from unittest.mock import MagicMock, patch
 
@@ -78,14 +79,480 @@ def test_plugin_manager_create_subapp_needs_extra_command(runner, app_none):
     assert "Missing command." in result.output
 
 
-def test_plugin_manager_create_subapp_wo_bw(runner, create_app):
-    result = runner.invoke(create_app, ["scan", "test"])
-    assert result.exit_code == 1
-    assert type(result.exception) is NotImplementedError
+def test_plugin_manager_create_subapp_wo_bw(runner, create_app, plugin_repo):
+    with (
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.plugin_repo_path",
+            return_value=str(plugin_repo),
+        ),
+        patch("bec_lib.utils.plugin_manager.create.scan.run_formatters"),
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.questionary.select",
+            return_value=MagicMock(ask=MagicMock(return_value="SOFTWARE_TRIGGERED")),
+        ),
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.questionary.checkbox",
+            return_value=MagicMock(ask=MagicMock(return_value=[])),
+        ),
+    ):
+        result = runner.invoke(
+            create_app,
+            ["scan", "test"],
+            input="V4 scan implementation.\nDescribe the scan here.\nn\nn\n",
+        )
+    assert result.exit_code == 0
 
     result = runner.invoke(create_app, ["device", "test"])
     assert result.exit_code == 1
     assert type(result.exception) is NotImplementedError
+
+
+@pytest.fixture
+def plugin_repo(tmp_path):
+    repo = tmp_path / "example_plugin"
+    scans_dir = repo / repo.name / "scans"
+    scans_dir.mkdir(parents=True)
+    (scans_dir / "__init__.py").write_text("", encoding="utf-8")
+    return repo
+
+
+def test_plugin_manager_create_scan(runner, create_app, plugin_repo):
+    with (
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.plugin_repo_path",
+            return_value=str(plugin_repo),
+        ),
+        patch("bec_lib.utils.plugin_manager.create.scan.run_formatters") as run_formatters,
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.questionary.select",
+            side_effect=[
+                MagicMock(ask=MagicMock(return_value="SOFTWARE_TRIGGERED")),
+                MagicMock(ask=MagicMock(return_value="float")),
+            ],
+        ),
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.questionary.checkbox",
+            return_value=MagicMock(ask=MagicMock(return_value=[])),
+        ),
+    ):
+        result = runner.invoke(
+            create_app,
+            ["scan"],
+            input=(
+                "example_scan\n"
+                "Example scan description\n"
+                "n\n"
+                "y\n"
+                "start_pos\n"
+                "None\n"
+                "Start position.\n"
+                "n\n"
+            ),
+        )
+
+    assert result.exit_code == 0
+    scan_file = plugin_repo / plugin_repo.name / "scans" / "example_scan.py"
+    init_file = plugin_repo / plugin_repo.name / "scans" / "__init__.py"
+    scan_content = scan_file.read_text(encoding="utf-8")
+    assert scan_file.exists()
+    assert "Example scan description" in scan_content
+    assert "class ExampleScan(ScanBase):" in scan_content
+    assert 'scan_name = "example_scan"' in scan_content
+    assert "scan_type = ScanType.SOFTWARE_TRIGGERED" in scan_content
+    assert '"Scan Parameters": ["start_pos"]' in scan_content
+    assert "start_pos: Annotated[float, ScanArgument(" in scan_content
+    assert "display_name='Start Pos'" in scan_content
+    assert "description='Start position.'" in scan_content
+    assert "start_pos=start_pos," not in scan_content
+    assert "points=self.scan_info.num_monitored_readouts," in scan_content
+    assert "self.actions.pre_scan_all_devices()" in scan_content
+    assert init_file.read_text(encoding="utf-8") == "from .example_scan import ExampleScan\n"
+    run_formatters.assert_called_once_with(
+        plugin_repo,
+        [
+            str(Path(plugin_repo.name) / "scans" / "example_scan.py"),
+            str(Path(plugin_repo.name) / "scans" / "__init__.py"),
+        ],
+    )
+
+
+def test_plugin_manager_create_scan_rejects_duplicate(runner, create_app, plugin_repo):
+    existing_scan = plugin_repo / plugin_repo.name / "scans" / "example_scan.py"
+    existing_scan.write_text("existing", encoding="utf-8")
+
+    with (
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.plugin_repo_path",
+            return_value=str(plugin_repo),
+        ),
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.questionary.select",
+            return_value=MagicMock(ask=MagicMock(return_value="SOFTWARE_TRIGGERED")),
+        ),
+    ):
+        result = runner.invoke(create_app, ["scan", "example_scan"], input="n\n")
+
+    assert result.exit_code == 1
+    assert existing_scan.read_text(encoding="utf-8") == "existing"
+
+
+def test_plugin_manager_create_scan_reprompts_for_invalid_argument_name(
+    runner, create_app, plugin_repo
+):
+    with (
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.plugin_repo_path",
+            return_value=str(plugin_repo),
+        ),
+        patch("bec_lib.utils.plugin_manager.create.scan.run_formatters"),
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.questionary.select",
+            side_effect=[
+                MagicMock(ask=MagicMock(return_value="SOFTWARE_TRIGGERED")),
+                MagicMock(ask=MagicMock(return_value="float")),
+            ],
+        ),
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.questionary.checkbox",
+            return_value=MagicMock(ask=MagicMock(return_value=[])),
+        ),
+    ):
+        result = runner.invoke(
+            create_app,
+            ["scan", "example_scan"],
+            input=(
+                "Example scan description\n"
+                "n\n"
+                "y\n"
+                "asdlkj lkjasd \n"
+                "start_pos\n"
+                "None\n"
+                "Start position.\n"
+                "n\n"
+            ),
+        )
+
+    assert result.exit_code == 0
+    scan_content = (plugin_repo / plugin_repo.name / "scans" / "example_scan.py").read_text(
+        encoding="utf-8"
+    )
+    assert "start_pos: Annotated[float, ScanArgument(" in scan_content
+
+
+def test_plugin_manager_create_scan_skips_units_for_device_argument(
+    runner, create_app, plugin_repo
+):
+    with (
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.plugin_repo_path",
+            return_value=str(plugin_repo),
+        ),
+        patch("bec_lib.utils.plugin_manager.create.scan.run_formatters"),
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.questionary.select",
+            side_effect=[
+                MagicMock(ask=MagicMock(return_value="SOFTWARE_TRIGGERED")),
+                MagicMock(ask=MagicMock(return_value="DeviceBase")),
+            ],
+        ),
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.questionary.checkbox",
+            return_value=MagicMock(ask=MagicMock(return_value=[])),
+        ),
+    ):
+        result = runner.invoke(
+            create_app,
+            ["scan", "device_scan"],
+            input=("Device scan description\n" "n\n" "y\n" "motor\n" "Motor device.\n" "n\n"),
+        )
+
+    assert result.exit_code == 0
+    scan_content = (plugin_repo / plugin_repo.name / "scans" / "device_scan.py").read_text(
+        encoding="utf-8"
+    )
+    assert "motor: Annotated[DeviceBase, ScanArgument(" in scan_content
+    assert "self.motors = [motor]" in scan_content
+    assert "units=Units." not in scan_content
+    assert (
+        "# TODO: If the scan motors (self.motors) are step-scanned, we have to elevate"
+        in scan_content
+    )
+    assert (
+        '# self.actions.set_device_readout_priority(self.motors, priority="monitored")'
+        in scan_content
+    )
+
+
+def test_plugin_manager_create_scan_renders_builtin_arguments_after_custom_inputs(
+    runner, create_app, plugin_repo
+):
+    from bec_lib.utils.plugin_manager.create.scan import _BUILTIN_ARGUMENTS
+
+    exp_time_argument = next(
+        argument for argument in _BUILTIN_ARGUMENTS if argument.name == "exp_time"
+    )
+
+    with (
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.plugin_repo_path",
+            return_value=str(plugin_repo),
+        ),
+        patch("bec_lib.utils.plugin_manager.create.scan.run_formatters"),
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.questionary.select",
+            side_effect=[
+                MagicMock(ask=MagicMock(return_value="SOFTWARE_TRIGGERED")),
+                MagicMock(ask=MagicMock(return_value="float")),
+            ],
+        ),
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.questionary.checkbox",
+            return_value=MagicMock(ask=MagicMock(return_value=[exp_time_argument])),
+        ),
+    ):
+        result = runner.invoke(
+            create_app,
+            ["scan", "ordered_scan"],
+            input=(
+                "Ordered scan description\n"
+                "y\n"
+                "y\n"
+                "start_pos\n"
+                "None\n"
+                "Start position.\n"
+                "n\n"
+            ),
+        )
+
+    assert result.exit_code == 0
+    scan_content = (plugin_repo / plugin_repo.name / "scans" / "ordered_scan.py").read_text(
+        encoding="utf-8"
+    )
+    assert scan_content.index("start_pos: Annotated[float, ScanArgument(") < scan_content.index(
+        "exp_time: DefaultArgType.ExposureTime = 0"
+    )
+    assert "from bec_lib.scan_args import DefaultArgType, ScanArgument" in scan_content
+    assert "exp_time=exp_time," in scan_content
+    assert "start_pos=start_pos," not in scan_content
+
+
+def test_plugin_manager_create_scan_renders_imports_on_separate_lines(
+    runner, create_app, plugin_repo
+):
+    from bec_lib.utils.plugin_manager.create.scan import _BUILTIN_ARGUMENTS
+
+    exp_time_argument = next(
+        argument for argument in _BUILTIN_ARGUMENTS if argument.name == "exp_time"
+    )
+
+    with (
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.plugin_repo_path",
+            return_value=str(plugin_repo),
+        ),
+        patch("bec_lib.utils.plugin_manager.create.scan.run_formatters"),
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.questionary.select",
+            side_effect=[
+                MagicMock(ask=MagicMock(return_value="SOFTWARE_TRIGGERED")),
+                MagicMock(ask=MagicMock(return_value="str")),
+            ],
+        ),
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.questionary.checkbox",
+            return_value=MagicMock(ask=MagicMock(return_value=[exp_time_argument])),
+        ),
+    ):
+        result = runner.invoke(
+            create_app,
+            ["scan", "text_scan"],
+            input=("Text scan description\n" "y\n" "y\n" "text\n" "Text.\n" "n\n"),
+        )
+
+    assert result.exit_code == 0
+    scan_content = (plugin_repo / plugin_repo.name / "scans" / "text_scan.py").read_text(
+        encoding="utf-8"
+    )
+    assert "from bec_lib.scan_args import DefaultArgType, ScanArgument" in scan_content
+    assert "\nfrom bec_server.scan_server.scans.scan_modifier import scan_hook" in scan_content
+    assert "ScanArgumentfrom bec_server" not in scan_content
+
+
+def test_plugin_manager_create_scan_uses_plugin_scan_components(runner, create_app, plugin_repo):
+    plugin_components_cls = type(
+        "PluginComponents",
+        (),
+        {"__module__": f"{plugin_repo.name}.scans.scan_customization.scan_components"},
+    )
+
+    with (
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.plugin_repo_path",
+            return_value=str(plugin_repo),
+        ),
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.get_scan_component_plugins",
+            return_value=[plugin_components_cls],
+        ),
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.plugin_package_name",
+            return_value=plugin_repo.name,
+        ),
+        patch("bec_lib.utils.plugin_manager.create.scan.run_formatters"),
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.questionary.select",
+            return_value=MagicMock(ask=MagicMock(return_value="SOFTWARE_TRIGGERED")),
+        ),
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.questionary.checkbox",
+            return_value=MagicMock(ask=MagicMock(return_value=[])),
+        ),
+    ):
+        result = runner.invoke(
+            create_app,
+            ["scan", "custom_components_scan"],
+            input="Custom components scan description\nn\nn\n",
+        )
+
+    assert result.exit_code == 0
+    scan_content = (
+        plugin_repo / plugin_repo.name / "scans" / "custom_components_scan.py"
+    ).read_text(encoding="utf-8")
+    assert (
+        f"from {plugin_repo.name}.scans.scan_customization.scan_components import PluginComponents"
+        in scan_content
+    )
+    assert "self.components = PluginComponents(self)" in scan_content
+
+
+def test_plugin_manager_create_scan_accepts_compound_pint_unit(runner, create_app, plugin_repo):
+    with (
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.plugin_repo_path",
+            return_value=str(plugin_repo),
+        ),
+        patch("bec_lib.utils.plugin_manager.create.scan.run_formatters"),
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.questionary.select",
+            side_effect=[
+                MagicMock(ask=MagicMock(return_value="SOFTWARE_TRIGGERED")),
+                MagicMock(ask=MagicMock(return_value="float")),
+            ],
+        ),
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.questionary.checkbox",
+            return_value=MagicMock(ask=MagicMock(return_value=[])),
+        ),
+    ):
+        result = runner.invoke(
+            create_app,
+            ["scan", "unit_scan"],
+            input=(
+                "Unit scan description\n" "n\n" "y\n" "ramp_rate\n" "T/min\n" "Ramp rate.\n" "n\n"
+            ),
+        )
+
+    assert result.exit_code == 0
+    scan_content = (plugin_repo / plugin_repo.name / "scans" / "unit_scan.py").read_text(
+        encoding="utf-8"
+    )
+    assert "units=Units.T / Units.min" in scan_content
+
+
+def test_plugin_manager_create_scan_accepts_compound_pint_unit_with_power(
+    runner, create_app, plugin_repo
+):
+    with (
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.plugin_repo_path",
+            return_value=str(plugin_repo),
+        ),
+        patch("bec_lib.utils.plugin_manager.create.scan.run_formatters"),
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.questionary.select",
+            side_effect=[
+                MagicMock(ask=MagicMock(return_value="SOFTWARE_TRIGGERED")),
+                MagicMock(ask=MagicMock(return_value="float")),
+            ],
+        ),
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.questionary.checkbox",
+            return_value=MagicMock(ask=MagicMock(return_value=[])),
+        ),
+    ):
+        result = runner.invoke(
+            create_app,
+            ["scan", "unit_power_scan"],
+            input=(
+                "Unit power scan description\n"
+                "n\n"
+                "y\n"
+                "ramp_rate\n"
+                "T/min**2\n"
+                "Ramp rate.\n"
+                "n\n"
+            ),
+        )
+
+    assert result.exit_code == 0
+    scan_content = (plugin_repo / plugin_repo.name / "scans" / "unit_power_scan.py").read_text(
+        encoding="utf-8"
+    )
+    assert "units=Units.T / Units.min ** 2" in scan_content
+
+
+def test_plugin_manager_create_scan_builtin_relative_is_scan_parameter(
+    runner, create_app, plugin_repo
+):
+    from bec_lib.utils.plugin_manager.create.scan import _BUILTIN_ARGUMENTS
+
+    relative_argument = next(
+        argument for argument in _BUILTIN_ARGUMENTS if argument.name == "relative"
+    )
+
+    with (
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.plugin_repo_path",
+            return_value=str(plugin_repo),
+        ),
+        patch("bec_lib.utils.plugin_manager.create.scan.run_formatters"),
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.questionary.select",
+            return_value=MagicMock(ask=MagicMock(return_value="SOFTWARE_TRIGGERED")),
+        ),
+        patch(
+            "bec_lib.utils.plugin_manager.create.scan.questionary.checkbox",
+            return_value=MagicMock(ask=MagicMock(return_value=[relative_argument])),
+        ),
+    ):
+        result = runner.invoke(
+            create_app, ["scan", "relative_scan"], input="Built-in relative scan.\ny\nn\n"
+        )
+
+    assert result.exit_code == 0
+    scan_content = (plugin_repo / plugin_repo.name / "scans" / "relative_scan.py").read_text(
+        encoding="utf-8"
+    )
+    assert '"Scan Parameters": ["relative"]' in scan_content
+    assert '"Acquisition Parameters"' not in scan_content
+    assert "relative: DefaultArgType.Relative," in scan_content
+
+
+def test_plugin_manager_create_scan_appends_export(plugin_repo):
+    from bec_lib.utils.plugin_manager.create.scan import _ensure_scan_export
+
+    init_file = plugin_repo / plugin_repo.name / "scans" / "__init__.py"
+    init_file.write_text(
+        "from .z_scan import ZScan\nfrom .alpha_scan import AlphaScan\n", encoding="utf-8"
+    )
+
+    _ensure_scan_export(init_file, "middle_scan")
+
+    assert init_file.read_text(encoding="utf-8") == (
+        "from .z_scan import ZScan\n"
+        "from .alpha_scan import AlphaScan\n"
+        "from .middle_scan import MiddleScan\n"
+    )
 
 
 def test_plugin_manager_adds_found_command(runner, app_with_bw):


### PR DESCRIPTION
This PR extends the `bec-plugin-manager` to also support the creation of v4-type scans:

```bash
bec-plugin-manager create scan
```

Optionally, you can pass in the scan name directly (otherwise, it will ask for it):

```bash
bec-plugin-manager create scan my_scan
```

## How to test

- install the bec_testing_plugin repo or any other bec plugin and create a new scan with the above command

## Additional comments

I've went back and forth with option to track created scans through copier. For now, I've opted out but please let me know what you think, especially if you have a strong opinion about it

Also, we should probably merge this one soon: https://github.com/bec-project/plugin_copier_template/pull/23 