### PR TITLE
Fix/v4 required kwargs

### DIFF
--- a/bec_lib/bec_lib/scan_input_validator.py
+++ b/bec_lib/bec_lib/scan_input_validator.py
@@ -452,7 +452,7 @@ class ScanInputValidator:
             ScanInputValidationError: If bounds are configured on a non-scalar annotation or the
                 value violates one of the configured bounds.
         """
-        if get_origin(self._strip_annotation_metadata(annotation)) is not None:
+        if not self._supports_scalar_bounds(annotation):
             self._raise_validation_error(
                 f"Invalid bounds configuration for scan argument '{arg_name}': "
                 "ScanArgument bounds are only supported for scalar annotations."
@@ -468,6 +468,30 @@ class ScanInputValidator:
                 continue
             if not self._satisfies_bound(value, operator_name, limit):
                 self._raise_bound_error(arg_name, value, operator_name, limit)
+
+    def _supports_scalar_bounds(self, annotation: Any) -> bool:
+        """Return whether ``ScanArgument`` numeric bounds are valid for an annotation.
+
+        Args:
+            annotation (Any): Annotation to inspect.
+
+        Returns:
+            bool: ``True`` for scalar-like annotations such as plain types, ``Literal`` values,
+                and unions of scalar types. ``False`` for container annotations.
+        """
+        annotation = self._strip_annotation_metadata(annotation)
+        origin = get_origin(annotation)
+
+        if origin is None or origin is Literal:
+            return True
+
+        if origin in {Union, types.UnionType}:
+            return all(self._supports_scalar_bounds(arg) for arg in get_args(annotation))
+
+        if origin in {list, dict, tuple, Sequence, Mapping, set, frozenset}:
+            return False
+
+        return True
 
     def _raise_bound_error(
         self, arg_name: str, value: Any, operator_name: str, limit: float

--- a/bec_server/bec_server/scan_server/scan_manager.py
+++ b/bec_server/bec_server/scan_server/scan_manager.py
@@ -137,7 +137,7 @@ class ScanManager:
                 "class": scan_cls.__name__,
                 "base_class": base_cls,
                 "arg_input": self.convert_arg_input(scan_cls.arg_input),
-                "required_kwargs": scan_cls.required_kwargs,
+                "required_kwargs": getattr(scan_cls, "required_kwargs", []),
                 "arg_bundle_size": scan_cls.arg_bundle_size,
                 "doc": scan_cls.__doc__ or scan_cls.__init__.__doc__,
                 "signature": signature_to_dict(scan_cls.__init__),

--- a/bec_server/bec_server/scan_server/scans/cont_line_scan.py
+++ b/bec_server/bec_server/scan_server/scans/cont_line_scan.py
@@ -39,7 +39,6 @@ class ContLineScan(ScanBase):
     # Choose a descriptive name that does not conflict with existing scan names.
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
     scan_name = "_v4_cont_line_scan"
-    required_kwargs = ["steps", "relative"]
     gui_config = {
         "Device": ["device", "start", "stop"],
         "Movement Parameters": ["steps", "relative", "offset", "atol"],
@@ -56,6 +55,8 @@ class ContLineScan(ScanBase):
             float, ScanArgument(display_name="Stop Position", reference_units="device")
         ],
         steps: Annotated[int, ScanArgument(display_name="Number of Steps", ge=1)],
+        *,
+        relative: bool,
         offset: Annotated[
             float | None, ScanArgument(display_name="Offset", reference_units="device")
         ] = None,
@@ -71,7 +72,6 @@ class ContLineScan(ScanBase):
         frames_per_trigger: Annotated[
             int, ScanArgument(display_name="Frames per Trigger", ge=1)
         ] = 1,
-        relative: bool = False,
         **kwargs,
     ):
         """
@@ -82,17 +82,20 @@ class ContLineScan(ScanBase):
             device (DeviceBase): motor to move continuously
             start (float): start position
             stop (float): stop position
-            offset (float | None): optional trigger offset from the nominal positions.
-            atol (float | None): optional tolerance used for position matching.
+            steps (int): number of acquisition points.
+            relative (bool): If True, interpret start and stop relative to the
+                current motor position.
+            offset (float | None): optional trigger offset from the nominal positions. If not provided,
+                it will be calculated based on the motor acceleration and velocity to ensure smooth triggering.
+            atol (float | None): optional tolerance used for position matching. If not provided,
+                it will be calculated based on the motor velocity and the exposure time.
             exp_time (Annotated[float, Units.s]): exposure time in seconds. Default is 0.
-            steps (int): number of acquisition points. Default is 10.
-            relative (bool): if True, interpret start and stop relative to the current motor position.
 
         Returns:
             ScanReport
 
         Examples:
-            >>> scans.cont_line_scan(dev.motor1, -5, 5, steps=20, exp_time=0.05, relative=True)
+            >>> scans.cont_line_scan(dev.motor1, -5, 5, 20, relative=True, exp_time=0.05)
         """
         super().__init__(**kwargs)
         self.device = device

--- a/bec_server/bec_server/scan_server/scans/fermat_scan.py
+++ b/bec_server/bec_server/scan_server/scans/fermat_scan.py
@@ -44,8 +44,6 @@ class FermatSpiralScan(ScanBase):
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
     scan_name = "_v4_fermat_scan"
 
-    required_kwargs = ["relative"]
-
     gui_config = {
         "Device 1": ["motor1", "start_motor1", "stop_motor1"],
         "Device 2": ["motor2", "start_motor2", "stop_motor2"],
@@ -76,9 +74,9 @@ class FermatSpiralScan(ScanBase):
         stop_motor2: Annotated[
             float, ScanArgument(display_name="Stop Position", reference_units="motor2")
         ],
-        step: Annotated[
-            float, ScanArgument(display_name="Step Size", reference_units="motor1")
-        ] = 0.1,
+        step: Annotated[float, ScanArgument(display_name="Step Size", reference_units="motor1")],
+        *,
+        relative: bool,
         exp_time: Annotated[
             float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
         ] = 0,
@@ -94,7 +92,6 @@ class FermatSpiralScan(ScanBase):
         readout_time: Annotated[
             float, ScanArgument(display_name="Readout Time", units=Units.s, ge=0)
         ] = 0,
-        relative: bool = False,
         spiral_type: Annotated[
             float,
             ScanArgument(
@@ -127,13 +124,14 @@ class FermatSpiralScan(ScanBase):
             motor2 (DeviceBase): second motor
             start_motor2 (float): start position motor 2
             stop_motor2 (float): end position motor 2
-            step (float): step size in motor units. Default is 0.1.
+            step (float): step size in motor units.
+            relative (bool): If True, the motors will be moved relative to their
+                current position.
             exp_time (float): exposure time in seconds. Default is 0.
             frames_per_trigger (int): number of frames acquired per trigger. Default is 1.
             settling_time (float): settling time in seconds. Default is 0.
             settling_time_after_trigger (float): settling time after trigger in seconds. Default is 0.
             readout_time (float): readout time in seconds. Default is 0.
-            relative (bool): if True, the motors will be moved relative to their current position.
             burst_at_each_point (int): number of exposures at each point. Default is 1.
             spiral_type (float): Angular offset (e.g. 0, 0.25,... ) in radians that determines the shape of the spiral. Default is 0.
             optim_trajectory (str): trajectory optimization method. Default is None. Options are "corridor", "shell", "nearest".
@@ -142,7 +140,7 @@ class FermatSpiralScan(ScanBase):
             ScanReport
 
         Examples:
-            >>> scans.fermat_scan(dev.motor1, -5, 5, dev.motor2, -5, 5, step=0.5, exp_time=0.1, relative=True, optim_trajectory="corridor")
+            >>> scans.fermat_scan(dev.motor1, -5, 5, dev.motor2, -5, 5, 0.5, relative=True, exp_time=0.1, optim_trajectory="corridor")
 
         """
         super().__init__(**kwargs)

--- a/bec_server/bec_server/scan_server/scans/grid_scan.py
+++ b/bec_server/bec_server/scan_server/scans/grid_scan.py
@@ -57,8 +57,6 @@ class GridScan(ScanBase):
         "steps": Annotated[int, ScanArgument(display_name="Number of Steps", ge=1)],
     }
     arg_bundle_size = {"bundle": len(arg_input), "min": 2, "max": None}
-    required_kwargs = ["relative"]
-
     gui_config = {
         "Movement Parameters": ["relative", "snaked"],
         "Acquisition Parameters": [
@@ -74,6 +72,7 @@ class GridScan(ScanBase):
     def __init__(
         self,
         *args,
+        relative: bool,
         exp_time: Annotated[
             float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
         ] = 0,
@@ -89,7 +88,6 @@ class GridScan(ScanBase):
         readout_time: Annotated[
             float, ScanArgument(display_name="Readout Time", units=Units.s, ge=0)
         ] = 0,
-        relative: bool = False,
         snaked: bool = True,
         burst_at_each_point: Annotated[
             int, ScanArgument(display_name="Burst at Each Point", ge=1)
@@ -101,12 +99,13 @@ class GridScan(ScanBase):
 
         Args:
             *args (Device, float, float, int): pairs of device / start / stop / steps arguments
+            relative (bool): If True, the motors will be moved relative to their
+                current position.
             exp_time (Annotated[float, Units.s]): exposure time in seconds. Default is 0.
             frames_per_trigger (int): number of frames acquired per trigger. Default is 1.
             settling_time (Annotated[float, Units.s]): settling time in seconds. Default is 0.
             settling_time_after_trigger (Annotated[float, Units.s]): settling time after trigger in seconds. Default is 0.
             readout_time (Annotated[float, Units.s]): readout time in seconds. Default is 0.
-            relative (bool): if True, the motors will be moved relative to their current position. Default is False.
             burst_at_each_point (int): number of exposures at each point. Default is 1.
             snaked (bool): if True, the scan will be snaked. Default is True.
 

--- a/bec_server/bec_server/scan_server/scans/hexagonal_scan.py
+++ b/bec_server/bec_server/scan_server/scans/hexagonal_scan.py
@@ -39,8 +39,6 @@ class HexagonalScan(ScanBase):
     # Choose a descriptive name that does not conflict with existing scan names.
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
     scan_name = "_v4_hexagonal_scan"
-    required_kwargs = ["relative"]
-
     gui_config = {
         "Device 1": ["motor1", "start_motor1", "stop_motor1", "step_motor1"],
         "Device 2": ["motor2", "start_motor2", "stop_motor2", "step_motor2"],
@@ -77,6 +75,8 @@ class HexagonalScan(ScanBase):
         step_motor2: Annotated[
             float, ScanArgument(display_name="Step Size", reference_units="motor2", gt=0)
         ],
+        *,
+        relative: bool,
         exp_time: Annotated[
             float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
         ] = 0,
@@ -92,7 +92,6 @@ class HexagonalScan(ScanBase):
         readout_time: Annotated[
             float, ScanArgument(display_name="Readout Time", units=Units.s, ge=0)
         ] = 0,
-        relative: bool = False,
         burst_at_each_point: Annotated[
             int, ScanArgument(display_name="Burst at Each Point", ge=1)
         ] = 1,
@@ -115,12 +114,13 @@ class HexagonalScan(ScanBase):
             start_motor2 (float): start position of the second motor
             stop_motor2 (float): stop position of the second motor
             step_motor2 (float): step size of the second motor
+            relative (bool): If True, interpret the scan positions relative to the
+                current motor positions.
             exp_time (Annotated[float, Units.s]): exposure time in seconds. Default is 0.
             frames_per_trigger (int): number of frames acquired per trigger. Default is 1.
             settling_time (Annotated[float, Units.s]): settling time in seconds. Default is 0.
             settling_time_after_trigger (Annotated[float, Units.s]): settling time after trigger in seconds. Default is 0.
             readout_time (Annotated[float, Units.s]): readout time in seconds. Default is 0.
-            relative (bool): if True, interpret the scan positions relative to the current motor positions.
             burst_at_each_point (int): number of exposures at each point. Default is 1.
             snaked (bool): if True, alternate the traversal direction between neighboring rows.
 

--- a/bec_server/bec_server/scan_server/scans/line_scan.py
+++ b/bec_server/bec_server/scan_server/scans/line_scan.py
@@ -52,8 +52,6 @@ class LineScan(ScanBase):
         ],
     }
     arg_bundle_size = {"bundle": len(arg_input), "min": 1, "max": None}
-    required_kwargs = ["steps", "relative"]
-
     gui_config = {
         "Movement Parameters": ["steps", "relative"],
         "Acquisition Parameters": [
@@ -70,6 +68,7 @@ class LineScan(ScanBase):
         self,
         *args,
         steps: Annotated[int, ScanArgument(display_name="Number of Steps", gt=0)],
+        relative: bool,
         exp_time: Annotated[
             float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
         ] = 0,
@@ -85,7 +84,6 @@ class LineScan(ScanBase):
         readout_time: Annotated[
             float, ScanArgument(display_name="Readout Time", units=Units.s, ge=0)
         ] = 0,
-        relative: bool = False,
         burst_at_each_point: Annotated[
             int, ScanArgument(display_name="Burst at Each Point", ge=1)
         ] = 1,
@@ -96,13 +94,14 @@ class LineScan(ScanBase):
 
         Args:
             *args (Device, float, float): pairs of device / start / stop arguments
-            steps (int): number of points along the line
+            steps (int): number of points along the line.
+            relative (bool): If True, the motors will be moved relative to their
+                current position.
             exp_time (Annotated[float, Units.s]): exposure time in seconds. Default is 0.
             frames_per_trigger (int): number of frames acquired per trigger. Default is 1.
             settling_time (Annotated[float, Units.s]): settling time in seconds. Default is 0.
             settling_time_after_trigger (Annotated[float, Units.s]): settling time after trigger in seconds. Default is 0.
             readout_time (Annotated[float, Units.s]): readout time in seconds. Default is 0.
-            relative (bool): if True, the motors will be moved relative to their current position. Default is False.
             burst_at_each_point (int): number of exposures at each point. Default is 1.
 
         Returns:

--- a/bec_server/bec_server/scan_server/scans/line_sweep_scan.py
+++ b/bec_server/bec_server/scan_server/scans/line_sweep_scan.py
@@ -42,7 +42,6 @@ class LineSweepScan(ScanBase):
     # Choose a descriptive name that does not conflict with existing scan names.
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
     scan_name = "_v4_line_sweep_scan"
-    required_kwargs = ["relative"]
     gui_config = {
         "Device": ["device", "start", "stop"],
         "Scan Parameters": ["min_update", "relative"],
@@ -57,6 +56,8 @@ class LineSweepScan(ScanBase):
         stop: Annotated[
             float, ScanArgument(display_name="Stop Position", reference_units="device")
         ],
+        *,
+        relative: bool,
         exp_time: Annotated[
             float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
         ] = 0,
@@ -69,7 +70,6 @@ class LineSweepScan(ScanBase):
         max_update: Annotated[
             float, ScanArgument(display_name="Maximum Update", units=Units.s, ge=0)
         ] = 0,
-        relative: bool = False,
         **kwargs,
     ):
         """
@@ -82,11 +82,12 @@ class LineSweepScan(ScanBase):
             device (DeviceBase): monitored device
             start (float): start position
             stop (float): stop position
+            relative (bool): If True, the start and stop positions are relative to
+                the current position.
             exp_time (float): exposure time. Default is 0.
             frames_per_trigger (int): number of frames per trigger. Default is 1.
             min_update (float): minimum delay between readout updates. Default is 0.
             max_update (float): maximum delay between readout updates. Default is 0.
-            relative (bool): if True, the start and stop positions are relative to the current position. Default is False.
 
         Returns:
             ScanReport

--- a/bec_server/bec_server/scan_server/scans/list_scan.py
+++ b/bec_server/bec_server/scan_server/scans/list_scan.py
@@ -43,8 +43,6 @@ class ListScan(ScanBase):
     # For scans with a fixed set of parameters (e.g. Fermat spiral), these can be simply removed.
     arg_input = {"device": DeviceBase, "positions": list[float]}
     arg_bundle_size = {"bundle": len(arg_input), "min": 1, "max": None}
-    required_kwargs = ["relative"]
-
     gui_config = {
         "Movement Parameters": ["relative"],
         "Acquisition Parameters": [
@@ -60,6 +58,7 @@ class ListScan(ScanBase):
     def __init__(
         self,
         *args,
+        relative: bool,
         exp_time: Annotated[
             float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
         ] = 0,
@@ -75,7 +74,6 @@ class ListScan(ScanBase):
         readout_time: Annotated[
             float, ScanArgument(display_name="Readout Time", units=Units.s, ge=0)
         ] = 0,
-        relative: bool = False,
         burst_at_each_point: Annotated[
             int, ScanArgument(display_name="Burst at Each Point", ge=1)
         ] = 1,
@@ -87,12 +85,13 @@ class ListScan(ScanBase):
 
         Args:
             *args (Device, list[float]): pairs of device / positions arguments
+            relative (bool): If True, the positions will be moved relative to their
+                current position.
             exp_time (float): exposure time in seconds. Default is 0.
             frames_per_trigger (int): number of frames acquired per trigger. Default is 1.
             settling_time (float): settling time in seconds. Default is 0.
             settling_time_after_trigger (float): settling time after trigger in seconds. Default is 0.
             readout_time (float): readout time in seconds. Default is 0.
-            relative (bool): if True, the positions will be moved relative to their current position. Default is False.
             burst_at_each_point (int): number of exposures at each point. Default is 1.
 
         Returns:

--- a/bec_server/bec_server/scan_server/scans/log_scan.py
+++ b/bec_server/bec_server/scan_server/scans/log_scan.py
@@ -52,8 +52,6 @@ class LogScan(ScanBase):
         ],
     }
     arg_bundle_size = {"bundle": len(arg_input), "min": 1, "max": None}
-    required_kwargs = ["steps", "relative"]
-
     gui_config = {
         "Movement Parameters": ["steps", "relative"],
         "Acquisition Parameters": [
@@ -69,7 +67,8 @@ class LogScan(ScanBase):
     def __init__(
         self,
         *args,
-        steps: Annotated[int, ScanArgument(display_name="Steps", ge=1)] = 1,
+        steps: Annotated[int, ScanArgument(display_name="Steps", ge=1)],
+        relative: bool,
         exp_time: Annotated[
             float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
         ] = 0,
@@ -85,7 +84,6 @@ class LogScan(ScanBase):
         readout_time: Annotated[
             float, ScanArgument(display_name="Readout Time", units=Units.s, ge=0)
         ] = 0,
-        relative: bool = False,
         burst_at_each_point: Annotated[
             int, ScanArgument(display_name="Burst at Each Point", ge=1)
         ] = 1,
@@ -96,13 +94,14 @@ class LogScan(ScanBase):
 
         Args:
             *args (Device, float, float): pairs of device / start / stop arguments
-            steps (int): number of points along the trajectory
+            steps (int): number of points along the trajectory.
+            relative (bool): If True, the positions are interpreted relative to the
+                current position.
             exp_time (float): exposure time in seconds. Default is 0.
             frames_per_trigger (int): number of frames acquired per trigger. Default is 1.
             settling_time (float): settling time in seconds. Default is 0.
             settling_time_after_trigger (float): settling time after trigger in seconds. Default is 0.
             readout_time (float): readout time in seconds. Default is 0.
-            relative (bool): if True, the positions are interpreted relative to the current position. Default is False.
             burst_at_each_point (int): number of exposures at each point. Default is 1.
 
         Returns:

--- a/bec_server/bec_server/scan_server/scans/move.py
+++ b/bec_server/bec_server/scan_server/scans/move.py
@@ -42,12 +42,10 @@ class MoveScan(ScanBase):
     # For scans with a fixed set of parameters (e.g. Fermat spiral), these can be simply removed.
     arg_input = {"device": DeviceBase, "target": float}
     arg_bundle_size = {"bundle": len(arg_input), "min": 1, "max": None}
-    required_kwargs = ["relative"]
-
     # We set is_scan to False to separate this class from the other scans in the user interface
     is_scan = False
 
-    def __init__(self, *args, relative: bool = False, **kwargs):
+    def __init__(self, *args, relative: bool, **kwargs):
         """
         Simple move command that moves one or more motors to the specified positions.
         The mv command gives back control to the user immediately after sending the command. For a blocking call
@@ -56,7 +54,8 @@ class MoveScan(ScanBase):
 
         Args:
             *args (Device, float): pairs of device / target position arguments
-            relative (bool): if True, the motors will be moved relative to their current position.
+            relative (bool): If True, the motors will be moved relative to their
+                current position.
 
         Returns:
             ScanReport

--- a/bec_server/bec_server/scan_server/scans/multi_region_grid_scan.py
+++ b/bec_server/bec_server/scan_server/scans/multi_region_grid_scan.py
@@ -40,8 +40,6 @@ class MultiRegionGridScan(ScanBase):
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
     scan_name = "_v4_multi_region_grid_scan"
 
-    required_kwargs = ["regions", "relative"]
-
     gui_config = {
         "Motors": ["motor1", "motor2"],
         "Movement Parameters": ["regions", "relative", "snaked"],
@@ -54,6 +52,7 @@ class MultiRegionGridScan(ScanBase):
         motor2: DeviceBase,
         *,
         regions: list[tuple[tuple[float, float, int], tuple[float, float, int]]],
+        relative: bool,
         exp_time: Annotated[
             float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
         ] = 0,
@@ -69,7 +68,6 @@ class MultiRegionGridScan(ScanBase):
         readout_time: Annotated[
             float, ScanArgument(display_name="Readout Time", units=Units.s, ge=0)
         ] = 0,
-        relative: bool = False,
         snaked: bool = True,
         burst_at_each_point: Annotated[
             int, ScanArgument(display_name="Burst at Each Point", ge=1)
@@ -90,13 +88,13 @@ class MultiRegionGridScan(ScanBase):
             regions (list[tuple[tuple[float, float, int], tuple[float, float, int]]]):
                 sequence of paired region definitions. Each entry contains one
                 ``(start, stop, steps)`` tuple for ``motor1`` and one for ``motor2``.
+            relative (bool): If True, the generated positions are interpreted
+                relative to the current motor positions.
             exp_time (float): exposure time in seconds. Default is 0.
             frames_per_trigger (int): number of frames acquired per trigger. Default is 1.
             settling_time (float): settling time in seconds. Default is 0.
             settling_time_after_trigger (float): settling time after trigger in seconds. Default is 0.
             readout_time (float): readout time in seconds. Default is 0.
-            relative (bool): if True, the generated positions are interpreted relative to the
-                current motor positions. Default is False.
             snaked (bool): if True, the second axis is traversed in alternating directions
                 within each sub-grid. Default is True.
             burst_at_each_point (int): number of exposures at each point. Default is 1.

--- a/bec_server/bec_server/scan_server/scans/multi_region_line_scan.py
+++ b/bec_server/bec_server/scan_server/scans/multi_region_line_scan.py
@@ -40,8 +40,6 @@ class MultiRegionLineScan(ScanBase):
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
     scan_name = "_v4_multi_region_line_scan"
 
-    required_kwargs = ["regions", "relative"]
-
     gui_config = {
         "Movement Parameters": ["regions", "relative"],
         "Acquisition Parameters": [
@@ -59,6 +57,7 @@ class MultiRegionLineScan(ScanBase):
         motor: DeviceBase,
         *,
         regions: list[tuple[float, float, int]],
+        relative: bool,
         exp_time: Annotated[
             float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
         ] = 0,
@@ -74,7 +73,6 @@ class MultiRegionLineScan(ScanBase):
         readout_time: Annotated[
             float, ScanArgument(display_name="Readout Time", units=Units.s, ge=0)
         ] = 0,
-        relative: bool = False,
         burst_at_each_point: Annotated[
             int, ScanArgument(display_name="Burst at Each Point", ge=1)
         ] = 1,
@@ -92,13 +90,13 @@ class MultiRegionLineScan(ScanBase):
             motor (DeviceBase): motor to move
             regions (list[tuple[float, float, int]]): sequence of ``(start, stop, steps)``
                 region definitions
+            relative (bool): If True, the generated positions are interpreted
+                relative to the current motor position.
             exp_time (float): exposure time in seconds. Default is 0.
             frames_per_trigger (int): number of frames acquired per trigger. Default is 1.
             settling_time (float): settling time in seconds. Default is 0.
             settling_time_after_trigger (float): settling time after trigger in seconds. Default is 0.
             readout_time (float): readout time in seconds. Default is 0.
-            relative (bool): if True, the generated positions are interpreted relative to the
-                current motor position. Default is False.
             burst_at_each_point (int): number of exposures at each point. Default is 1.
 
         Returns:

--- a/bec_server/bec_server/scan_server/scans/round_roi_scan.py
+++ b/bec_server/bec_server/scan_server/scans/round_roi_scan.py
@@ -39,8 +39,6 @@ class RoundROIScan(ScanBase):
     # Choose a descriptive name that does not conflict with existing scan names.
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
     scan_name = "_v4_round_roi_scan"
-    required_kwargs = ["shell_spacing", "pos_in_first_ring", "relative"]
-
     gui_config = {
         "Motor 1": ["motor_1", "start_motor_1", "stop_motor_1", "center_1"],
         "Motor 2": ["motor_2", "start_motor_2", "stop_motor_2", "center_2"],
@@ -74,10 +72,12 @@ class RoundROIScan(ScanBase):
         ],
         shell_spacing: Annotated[
             float, ScanArgument(display_name="Shell Spacing", reference_units="motor_1", gt=0)
-        ] = 1,
+        ],
         pos_in_first_ring: Annotated[
             int, ScanArgument(display_name="Number of Points in First Shell", ge=1)
-        ] = 5,
+        ],
+        *,
+        relative: bool,
         exp_time: Annotated[
             float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
         ] = 0,
@@ -93,7 +93,6 @@ class RoundROIScan(ScanBase):
         readout_time: Annotated[
             float, ScanArgument(display_name="Readout Time", units=Units.s, ge=0)
         ] = 0,
-        relative: bool = False,
         center_1: Annotated[
             float, ScanArgument(display_name="Center Motor 1", reference_units="motor_1")
         ] = 0,
@@ -115,14 +114,14 @@ class RoundROIScan(ScanBase):
             motor_2 (DeviceBase): second motor
             start_motor_2 (float): start position of the ROI for motor_2
             stop_motor_2 (float): stop position of the ROI for motor_2
-            shell_spacing (float): shell width. Default is 1.
-            pos_in_first_ring (int): number of points in the first shell. Default is 5.
+            shell_spacing (float): shell width.
+            pos_in_first_ring (int): number of points in the first shell.
+            relative (bool): If True, start from a relative position.
             exp_time (float): exposure time in seconds. Default is 0.
             frames_per_trigger (int): number of frames acquired per trigger. Default is 1.
             settling_time (float): settling time in seconds. Default is 0.
             settling_time_after_trigger (float): settling time after trigger in seconds. Default is 0.
             readout_time (float): readout time in seconds. Default is 0.
-            relative (bool): Start from an absolute or relative position. Default is False.
             center_1 (float): center position for motor_1. The center may be outside the ROI.
                 Default is 0.
             center_2 (float): center position for motor_2. The center may be outside the ROI.
@@ -133,7 +132,7 @@ class RoundROIScan(ScanBase):
             ScanReport
 
         Examples:
-            >>> scans.round_roi_scan(dev.motor1, -10, 10, dev.motor2, -10, 10, shell_spacing=2, pos_in_first_ring=3, exp_time=0.1)
+            >>> scans.round_roi_scan(dev.motor1, -10, 10, dev.motor2, -10, 10, 2, 3, relative=False, exp_time=0.1)
         """
         super().__init__(**kwargs)
         self.motors = [motor_1, motor_2]

--- a/bec_server/bec_server/scan_server/scans/round_scan.py
+++ b/bec_server/bec_server/scan_server/scans/round_scan.py
@@ -39,8 +39,6 @@ class RoundScan(ScanBase):
     # Choose a descriptive name that does not conflict with existing scan names.
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
     scan_name = "_v4_round_scan"
-    required_kwargs = ["relative"]
-
     gui_config = {
         "Motors": ["motor_1", "motor_2"],
         "Ring Parameters": [
@@ -76,6 +74,8 @@ class RoundScan(ScanBase):
         pos_in_first_ring: Annotated[
             int, ScanArgument(display_name="Positions in First Ring", ge=1)
         ],
+        *,
+        relative: bool,
         exp_time: Annotated[
             float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
         ] = 0,
@@ -91,7 +91,6 @@ class RoundScan(ScanBase):
         readout_time: Annotated[
             float, ScanArgument(display_name="Readout Time", units=Units.s, ge=0)
         ] = 0,
-        relative: bool = False,
         center_1: Annotated[
             float, ScanArgument(display_name="Center Motor 1", reference_units="motor_1")
         ] = 0,
@@ -114,12 +113,13 @@ class RoundScan(ScanBase):
             outer_radius (float): outer radius
             number_of_rings (int): number of rings
             pos_in_first_ring (int): number of positions in the first ring
+            relative (bool): If True, the motors will be moved relative to their
+                current position.
             exp_time (Annotated[float, Units.s]): exposure time in seconds. Default is 0.
             frames_per_trigger (Annotated[int]): number of frames acquired per trigger. Default is 1.
             settling_time (Annotated[float, Units.s]): settling time in seconds. Default is 0.
             settling_time_after_trigger (Annotated[float, Units.s]): settling time after trigger in seconds. Default is 0.
             readout_time (Annotated[float, Units.s]): readout time in seconds. Default is 0.
-            relative (bool): if True, the motors will be moved relative to their current position. Default is False.
             center_1 (float): center position for motor_1. Default is 0.
             center_2 (float): center position for motor_2. Default is 0.
             burst_at_each_point (int): number of exposures at each point. Default is 1.

--- a/bec_server/bec_server/scan_server/scans/scans_v4.py
+++ b/bec_server/bec_server/scan_server/scans/scans_v4.py
@@ -152,7 +152,6 @@ class ScanInfo(BaseModel):
 class ScanBase:
     scan_type = ScanType.SOFTWARE_TRIGGERED
     scan_name = "_v4_base_scan"
-    required_kwargs = []
     arg_input = {}
     arg_bundle_size = {"bundle": len(arg_input), "min": None, "max": None}
     is_scan = True

--- a/bec_server/bec_server/scan_server/scans/updated_move.py
+++ b/bec_server/bec_server/scan_server/scans/updated_move.py
@@ -42,12 +42,10 @@ class UpdatedMoveScan(ScanBase):
     # For scans with a fixed set of parameters (e.g. Fermat spiral), these can be simply removed.
     arg_input = {"device": DeviceBase, "target": float}
     arg_bundle_size = {"bundle": len(arg_input), "min": 1, "max": None}
-    required_kwargs = ["relative"]
-
     # We set is_scan to False to separate this class from the other scans in the user interface
     is_scan = False
 
-    def __init__(self, *args, relative: bool = False, **kwargs):
+    def __init__(self, *args, relative: bool, **kwargs):
         """
         Simple move command that moves one or more motors to the specified positions.
         The umv command is the blocking version of the mv command.
@@ -56,7 +54,8 @@ class UpdatedMoveScan(ScanBase):
 
         Args:
             *args (Device, float): pairs of device / target position arguments
-            relative (bool): if True, the motors will be moved relative to their current position. Default is False.
+            relative (bool): If True, the motors will be moved relative to their
+                current position.
 
         Returns:
             ScanReport


### PR DESCRIPTION
This PR removes the `required_kwargs` class attribute and instead relies on the scan signature to enforce kwargs. The scan signatures and examples have been adjusted to reflect the change in order. 

It does not change the functionality but simplifies the system a bit. 

Note that the PR targets the v4 branch, not main. If we merge v4 to main first, I will change it to main.