### PR TITLE
chore(dependabot): merge shared python dependencies into single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,15 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directory: "/bec_lib"
+    directories:
+      - "/bec_lib"
+      - "/bec_server"
+      - "/bec_ipython_client"
+      - "/pytest_bec_e2e"
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "pip"
-    directory: "/bec_server"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "pip"
-    directory: "/bec_ipython_client"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "pip"
-    directory: "/pytest_bec_e2e"
-    schedule:
-      interval: "weekly"
+    groups:
+      shared-python-dependencies:
+        patterns:
+          - "*"
+        group-by: "dependency-name"


### PR DESCRIPTION
Consolidate pip directories for Dependabot updates and group shared dependencies.