### PR TITLE
fix: fetch a last value from redis before resolving the progressbar

### DIFF
--- a/bec_ipython_client/bec_ipython_client/callbacks/move_device.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/move_device.py
@@ -102,8 +102,14 @@ class ReadbackDataHandler:
         self.requests_done.set()
         self._unregister_callbacks()
 
-    def get_device_values(self) -> list:
+    def get_device_values(self, force: bool = False) -> list:
         """get the current device values
+
+        Args:
+            force (bool): if True, it fetches again the device values from redis,
+                even if they were already received before. This is to check the last
+                values after the request is marked as done, as sometimes the request
+                done message is delivered before the last readback messages.
 
         Returns:
             list: list of device values
@@ -111,7 +117,7 @@ class ReadbackDataHandler:
         values = []
         for dev in self.devices:
             val = self.data.get(dev)
-            if val is None:
+            if val is None or force:
                 signal_data = self.device_manager.devices[dev].read(cached=True)
             else:
                 signal_data = val.signals
@@ -206,6 +212,8 @@ class LiveUpdatesReadbackProgressbar(LiveUpdatesBase):
 
                 for dev, (done, success) in data_source.device_states().items():
                     if done and success:
+                        values = data_source.get_device_values(force=True)
+                        progress.update(values=values)
                         progress.set_finished(dev)
                 # pylint: disable=protected-access
                 progress._progress.refresh()

--- a/bec_ipython_client/tests/client_tests/test_move_callback.py
+++ b/bec_ipython_client/tests/client_tests/test_move_callback.py
@@ -30,7 +30,7 @@ def test_move_callback(bec_client_mock):
     readback = collections.deque()
     readback.extend([[-10], [0], [10]])
 
-    def mock_readback(*args):
+    def mock_readback(*args, **kwargs):
         if len(readback) > 1:
             return readback.popleft()
         return readback[0]
@@ -74,7 +74,7 @@ def test_move_callback_with_report_instruction(bec_client_mock):
         "readback": {"RID": "something", "devices": ["samx"], "start": [0], "end": [10]}
     }
 
-    def mock_readback(*args):
+    def mock_readback(*args, **kwargs):
         if len(readback) > 1:
             return readback.popleft()
         return readback[0]

--- a/bec_ipython_client/tests/end-2-end/test_scans_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_scans_e2e.py
@@ -524,9 +524,7 @@ def test_scan_def_callback(capsys, bec_ipython_client_fixture):
         current_pos_samy = dev.samy.read(cached=True)["samy"]["value"]
         captured = capsys.readouterr()
         assert f"Starting scan {scan_number}" in captured.out
-        ref_out_samy = (
-            f"━━━━━━━━━━━━━━━ {current_pos_samy:10.2f} /       5.00 / 100 % 0:00:00 0:00:00"
-        )
+        ref_out_samy = f"━━━━━━━━━━━━━━━ {current_pos_samy:10.2f} /       5.00 / 100 %"
         assert ref_out_samy in captured.out
         scans.line_scan(dev.samx, -5, 5, steps=10, exp_time=0.1, relative=False)
     captured = capsys.readouterr()


### PR DESCRIPTION
## Description

The device progressbar unsubscribes from the readback endpoint the moment the device status resolves. However, there is a risk that for fast and frequent updates, the device readback propagated through the redis connector dispatcher thread has not yet delivered the message to the `data_source` container. 
We know that redis has seen the last message as the device publishes them in order from the same thread. To ensure that we are up to date with the last message, this PR adds another poll once the status resolves to fetch the most recent readback message from redis. 

An alternative could have been to not unsubscribe on status resolution, however, I would not know for what to wait afterwards. 

## How to test

- Run unit and e2e tests

## Potential side effects

There is a slight overhead introduced with this patch but I think it is acceptable.
