### PR TITLE
Use TypeAlias in scan inputs

### DIFF
--- a/bec_lib/bec_lib/scan_args.py
+++ b/bec_lib/bec_lib/scan_args.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal, TypeAlias
 
 import pint
 from pint.facets.plain import PlainQuantity
@@ -89,3 +89,61 @@ class ScanArgument(BaseModel):
         if self.units is not None and self.reference_units is not None:
             raise ValueError("units and reference_units are mutually exclusive")
         return self
+
+
+################################################
+######### Frequently used ScanArguments ########
+################################################
+class DefaultArgType:
+    """Namespace for reusable scan argument type aliases."""
+
+    Relative: TypeAlias = Annotated[
+        bool,
+        ScanArgument(
+            display_name="Relative",
+            description="Whether the positions are relative to the current position",
+        ),
+    ]
+    Snaked: TypeAlias = Annotated[
+        bool,
+        ScanArgument(
+            display_name="Snaked",
+            description="Whether to snake the scan, i.e. reverse the direction of every other line",
+        ),
+    ]
+    ExposureTime: TypeAlias = Annotated[
+        float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
+    ]
+    FramesPerTrigger: TypeAlias = Annotated[
+        int, ScanArgument(display_name="Frames per Trigger", ge=1)
+    ]
+    SettlingTime: TypeAlias = Annotated[
+        float, ScanArgument(display_name="Settling Time", units=Units.s, ge=0)
+    ]
+    SettlingTimeAfterTrigger: TypeAlias = Annotated[
+        float, ScanArgument(display_name="Settling Time After Trigger", units=Units.s, ge=0)
+    ]
+    ReadoutTime: TypeAlias = Annotated[
+        float, ScanArgument(display_name="Readout Time", units=Units.s, ge=0)
+    ]
+    BurstAtEachPoint: TypeAlias = Annotated[
+        int, ScanArgument(display_name="Burst at Each Point", ge=1)
+    ]
+    OptimizeTrajectory: TypeAlias = Annotated[
+        Literal["corridor", "shell", "nearest", None],
+        ScanArgument(
+            display_name="Optimize Trajectory",
+            description="Method for optimizing the scan trajectory",
+        ),
+    ]
+
+
+Relative = DefaultArgType.Relative
+Snaked = DefaultArgType.Snaked
+ExposureTime = DefaultArgType.ExposureTime
+FramesPerTrigger = DefaultArgType.FramesPerTrigger
+SettlingTime = DefaultArgType.SettlingTime
+SettlingTimeAfterTrigger = DefaultArgType.SettlingTimeAfterTrigger
+ReadoutTime = DefaultArgType.ReadoutTime
+BurstAtEachPoint = DefaultArgType.BurstAtEachPoint
+OptimizeTrajectory = DefaultArgType.OptimizeTrajectory

--- a/bec_server/bec_server/scan_server/scans/acquire.py
+++ b/bec_server/bec_server/scan_server/scans/acquire.py
@@ -16,11 +16,9 @@ Scan procedure:
 
 from __future__ import annotations
 
-from typing import Annotated
-
 import numpy as np
 
-from bec_lib.scan_args import ScanArgument, Units
+from bec_lib.scan_args import DefaultArgType
 from bec_server.scan_server.scans.scan_base import ScanBase, ScanType
 from bec_server.scan_server.scans.scan_modifier import scan_hook
 
@@ -51,24 +49,12 @@ class Acquire(ScanBase):
 
     def __init__(
         self,
-        exp_time: Annotated[
-            float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
-        ] = 0,
-        frames_per_trigger: Annotated[
-            int, ScanArgument(display_name="Frames per Trigger", ge=1)
-        ] = 1,
-        settling_time: Annotated[
-            float, ScanArgument(display_name="Settling Time", units=Units.s, ge=0)
-        ] = 0,
-        settling_time_after_trigger: Annotated[
-            float, ScanArgument(display_name="Settling Time After Trigger", units=Units.s, ge=0)
-        ] = 0,
-        readout_time: Annotated[
-            float, ScanArgument(display_name="Readout Time", units=Units.s, ge=0)
-        ] = 0,
-        burst_at_each_point: Annotated[
-            int, ScanArgument(display_name="Burst at Each Point", ge=1)
-        ] = 1,
+        exp_time: DefaultArgType.ExposureTime = 0,
+        frames_per_trigger: DefaultArgType.FramesPerTrigger = 1,
+        settling_time: DefaultArgType.SettlingTime = 0,
+        settling_time_after_trigger: DefaultArgType.SettlingTimeAfterTrigger = 0,
+        readout_time: DefaultArgType.ReadoutTime = 0,
+        burst_at_each_point: DefaultArgType.BurstAtEachPoint = 1,
         **kwargs,
     ):
         """

--- a/bec_server/bec_server/scan_server/scans/cont_line_scan.py
+++ b/bec_server/bec_server/scan_server/scans/cont_line_scan.py
@@ -21,7 +21,7 @@ from typing import Annotated
 import numpy as np
 
 from bec_lib.device import DeviceBase
-from bec_lib.scan_args import ScanArgument, Units
+from bec_lib.scan_args import DefaultArgType, ScanArgument
 from bec_server.scan_server.errors import LimitError, ScanAbortion
 from bec_server.scan_server.scans.scan_base import ScanBase, ScanType
 from bec_server.scan_server.scans.scan_modifier import scan_hook
@@ -56,22 +56,16 @@ class ContLineScan(ScanBase):
         ],
         steps: Annotated[int, ScanArgument(display_name="Number of Steps", ge=1)],
         *,
-        relative: bool,
+        relative: DefaultArgType.Relative,
         offset: Annotated[
             float | None, ScanArgument(display_name="Offset", reference_units="device")
         ] = None,
         atol: Annotated[
             float | None, ScanArgument(display_name="Tolerance", reference_units="device")
         ] = None,
-        exp_time: Annotated[
-            float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
-        ] = 0,
-        readout_time: Annotated[
-            float, ScanArgument(display_name="Readout Time", units=Units.s, ge=0)
-        ] = 0,
-        frames_per_trigger: Annotated[
-            int, ScanArgument(display_name="Frames per Trigger", ge=1)
-        ] = 1,
+        exp_time: DefaultArgType.ExposureTime = 0,
+        readout_time: DefaultArgType.ReadoutTime = 0,
+        frames_per_trigger: DefaultArgType.FramesPerTrigger = 1,
         **kwargs,
     ):
         """
@@ -89,7 +83,7 @@ class ContLineScan(ScanBase):
                 it will be calculated based on the motor acceleration and velocity to ensure smooth triggering.
             atol (float | None): optional tolerance used for position matching. If not provided,
                 it will be calculated based on the motor velocity and the exposure time.
-            exp_time (Annotated[float, Units.s]): exposure time in seconds. Default is 0.
+            exp_time (float): exposure time in seconds. Default is 0.
 
         Returns:
             ScanReport

--- a/bec_server/bec_server/scan_server/scans/fermat_scan.py
+++ b/bec_server/bec_server/scan_server/scans/fermat_scan.py
@@ -16,13 +16,13 @@ Scan procedure:
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from typing import Annotated
 
 import numpy as np
 
 from bec_lib.device import DeviceBase
 from bec_lib.logger import bec_logger
-from bec_lib.scan_args import ScanArgument, Units
+from bec_lib.scan_args import DefaultArgType, ScanArgument, Units
 from bec_server.scan_server.scans import position_generators
 from bec_server.scan_server.scans.scan_base import ScanBase, ScanType
 from bec_server.scan_server.scans.scan_modifier import scan_hook
@@ -76,22 +76,14 @@ class FermatSpiralScan(ScanBase):
         ],
         step: Annotated[float, ScanArgument(display_name="Step Size", reference_units="motor1")],
         *,
-        relative: bool,
-        exp_time: Annotated[
-            float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
-        ] = 0,
-        frames_per_trigger: Annotated[
-            int, ScanArgument(display_name="Frames per Trigger", ge=1)
-        ] = 1,
-        settling_time: Annotated[
-            float, ScanArgument(display_name="Settling Time", units=Units.s, ge=0)
-        ] = 0,
-        settling_time_after_trigger: Annotated[
-            float, ScanArgument(display_name="Settling Time After Trigger", units=Units.s, ge=0)
-        ] = 0,
-        readout_time: Annotated[
-            float, ScanArgument(display_name="Readout Time", units=Units.s, ge=0)
-        ] = 0,
+        relative: DefaultArgType.Relative,
+        exp_time: DefaultArgType.ExposureTime = 0,
+        frames_per_trigger: DefaultArgType.FramesPerTrigger = 1,
+        settling_time: DefaultArgType.SettlingTime = 0,
+        settling_time_after_trigger: DefaultArgType.SettlingTimeAfterTrigger = 0,
+        readout_time: DefaultArgType.ReadoutTime = 0,
+        optim_trajectory: DefaultArgType.OptimizeTrajectory = None,
+        burst_at_each_point: DefaultArgType.BurstAtEachPoint = 1,
         spiral_type: Annotated[
             float,
             ScanArgument(
@@ -102,16 +94,6 @@ class FermatSpiralScan(ScanBase):
                 units=Units.rad,
             ),
         ] = 0,
-        optim_trajectory: Annotated[
-            Literal["corridor", "shell", "nearest", None],
-            ScanArgument(
-                display_name="Trajectory Optimization Method",
-                description="Method for optimizing the scan trajectory",
-            ),
-        ] = None,
-        burst_at_each_point: Annotated[
-            int, ScanArgument(display_name="Burst at Each Point", ge=1)
-        ] = 1,
         **kwargs,
     ):
         """

--- a/bec_server/bec_server/scan_server/scans/grid_scan.py
+++ b/bec_server/bec_server/scan_server/scans/grid_scan.py
@@ -22,7 +22,7 @@ import numpy as np
 
 from bec_lib.device import DeviceBase
 from bec_lib.logger import bec_logger
-from bec_lib.scan_args import ScanArgument, Units
+from bec_lib.scan_args import DefaultArgType, ScanArgument
 from bec_server.scan_server.scans import position_generators
 from bec_server.scan_server.scans.scan_base import ScanBase, ScanType, bundle_args
 from bec_server.scan_server.scans.scan_modifier import scan_hook
@@ -72,26 +72,14 @@ class GridScan(ScanBase):
     def __init__(
         self,
         *args,
-        relative: bool,
-        exp_time: Annotated[
-            float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
-        ] = 0,
-        frames_per_trigger: Annotated[
-            int, ScanArgument(display_name="Frames per Trigger", ge=1)
-        ] = 1,
-        settling_time: Annotated[
-            float, ScanArgument(display_name="Settling Time", units=Units.s, ge=0)
-        ] = 0,
-        settling_time_after_trigger: Annotated[
-            float, ScanArgument(display_name="Settling Time After Trigger", units=Units.s, ge=0)
-        ] = 0,
-        readout_time: Annotated[
-            float, ScanArgument(display_name="Readout Time", units=Units.s, ge=0)
-        ] = 0,
-        snaked: bool = True,
-        burst_at_each_point: Annotated[
-            int, ScanArgument(display_name="Burst at Each Point", ge=1)
-        ] = 1,
+        relative: DefaultArgType.Relative,
+        exp_time: DefaultArgType.ExposureTime = 0,
+        frames_per_trigger: DefaultArgType.FramesPerTrigger = 1,
+        settling_time: DefaultArgType.SettlingTime = 0,
+        settling_time_after_trigger: DefaultArgType.SettlingTimeAfterTrigger = 0,
+        readout_time: DefaultArgType.ReadoutTime = 0,
+        snaked: DefaultArgType.Snaked = True,
+        burst_at_each_point: DefaultArgType.BurstAtEachPoint = 1,
         **kwargs,
     ):
         """
@@ -101,11 +89,11 @@ class GridScan(ScanBase):
             *args (Device, float, float, int): pairs of device / start / stop / steps arguments
             relative (bool): If True, the motors will be moved relative to their
                 current position.
-            exp_time (Annotated[float, Units.s]): exposure time in seconds. Default is 0.
+            exp_time (float): exposure time in seconds. Default is 0.
             frames_per_trigger (int): number of frames acquired per trigger. Default is 1.
-            settling_time (Annotated[float, Units.s]): settling time in seconds. Default is 0.
-            settling_time_after_trigger (Annotated[float, Units.s]): settling time after trigger in seconds. Default is 0.
-            readout_time (Annotated[float, Units.s]): readout time in seconds. Default is 0.
+            settling_time (float): settling time in seconds. Default is 0.
+            settling_time_after_trigger (float): settling time after trigger in seconds. Default is 0.
+            readout_time (float): readout time in seconds. Default is 0.
             burst_at_each_point (int): number of exposures at each point. Default is 1.
             snaked (bool): if True, the scan will be snaked. Default is True.
 

--- a/bec_server/bec_server/scan_server/scans/hexagonal_scan.py
+++ b/bec_server/bec_server/scan_server/scans/hexagonal_scan.py
@@ -21,7 +21,7 @@ from typing import Annotated
 import numpy as np
 
 from bec_lib.device import DeviceBase
-from bec_lib.scan_args import ScanArgument, Units
+from bec_lib.scan_args import DefaultArgType, ScanArgument
 from bec_server.scan_server.scans import position_generators
 from bec_server.scan_server.scans.scan_base import ScanBase, ScanType
 from bec_server.scan_server.scans.scan_modifier import scan_hook
@@ -76,26 +76,14 @@ class HexagonalScan(ScanBase):
             float, ScanArgument(display_name="Step Size", reference_units="motor2", gt=0)
         ],
         *,
-        relative: bool,
-        exp_time: Annotated[
-            float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
-        ] = 0,
-        frames_per_trigger: Annotated[
-            int, ScanArgument(display_name="Frames per Trigger", ge=1)
-        ] = 1,
-        settling_time: Annotated[
-            float, ScanArgument(display_name="Settling Time", units=Units.s, ge=0)
-        ] = 0,
-        settling_time_after_trigger: Annotated[
-            float, ScanArgument(display_name="Settling Time After Trigger", units=Units.s, ge=0)
-        ] = 0,
-        readout_time: Annotated[
-            float, ScanArgument(display_name="Readout Time", units=Units.s, ge=0)
-        ] = 0,
-        burst_at_each_point: Annotated[
-            int, ScanArgument(display_name="Burst at Each Point", ge=1)
-        ] = 1,
-        snaked: bool = True,
+        relative: DefaultArgType.Relative,
+        exp_time: DefaultArgType.ExposureTime = 0,
+        frames_per_trigger: DefaultArgType.FramesPerTrigger = 1,
+        settling_time: DefaultArgType.SettlingTime = 0,
+        settling_time_after_trigger: DefaultArgType.SettlingTimeAfterTrigger = 0,
+        readout_time: DefaultArgType.ReadoutTime = 0,
+        burst_at_each_point: DefaultArgType.BurstAtEachPoint = 1,
+        snaked: DefaultArgType.Snaked = True,
         **kwargs,
     ):
         """
@@ -116,11 +104,11 @@ class HexagonalScan(ScanBase):
             step_motor2 (float): step size of the second motor
             relative (bool): If True, interpret the scan positions relative to the
                 current motor positions.
-            exp_time (Annotated[float, Units.s]): exposure time in seconds. Default is 0.
+            exp_time (float): exposure time in seconds. Default is 0.
             frames_per_trigger (int): number of frames acquired per trigger. Default is 1.
-            settling_time (Annotated[float, Units.s]): settling time in seconds. Default is 0.
-            settling_time_after_trigger (Annotated[float, Units.s]): settling time after trigger in seconds. Default is 0.
-            readout_time (Annotated[float, Units.s]): readout time in seconds. Default is 0.
+            settling_time (float): settling time in seconds. Default is 0.
+            settling_time_after_trigger (float): settling time after trigger in seconds. Default is 0.
+            readout_time (float): readout time in seconds. Default is 0.
             burst_at_each_point (int): number of exposures at each point. Default is 1.
             snaked (bool): if True, alternate the traversal direction between neighboring rows.
 

--- a/bec_server/bec_server/scan_server/scans/line_scan.py
+++ b/bec_server/bec_server/scan_server/scans/line_scan.py
@@ -21,7 +21,7 @@ from typing import Annotated
 import numpy as np
 
 from bec_lib.device import DeviceBase
-from bec_lib.scan_args import ScanArgument, Units
+from bec_lib.scan_args import DefaultArgType, ScanArgument
 from bec_server.scan_server.scans import position_generators
 from bec_server.scan_server.scans.scan_base import ScanBase, ScanType, bundle_args
 from bec_server.scan_server.scans.scan_modifier import scan_hook
@@ -68,25 +68,13 @@ class LineScan(ScanBase):
         self,
         *args,
         steps: Annotated[int, ScanArgument(display_name="Number of Steps", gt=0)],
-        relative: bool,
-        exp_time: Annotated[
-            float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
-        ] = 0,
-        frames_per_trigger: Annotated[
-            int, ScanArgument(display_name="Frames per Trigger", ge=1)
-        ] = 1,
-        settling_time: Annotated[
-            float, ScanArgument(display_name="Settling Time", units=Units.s, ge=0)
-        ] = 0,
-        settling_time_after_trigger: Annotated[
-            float, ScanArgument(display_name="Settling Time After Trigger", units=Units.s, ge=0)
-        ] = 0,
-        readout_time: Annotated[
-            float, ScanArgument(display_name="Readout Time", units=Units.s, ge=0)
-        ] = 0,
-        burst_at_each_point: Annotated[
-            int, ScanArgument(display_name="Burst at Each Point", ge=1)
-        ] = 1,
+        relative: DefaultArgType.Relative,
+        exp_time: DefaultArgType.ExposureTime = 0,
+        frames_per_trigger: DefaultArgType.FramesPerTrigger = 1,
+        settling_time: DefaultArgType.SettlingTime = 0,
+        settling_time_after_trigger: DefaultArgType.SettlingTimeAfterTrigger = 0,
+        readout_time: DefaultArgType.ReadoutTime = 0,
+        burst_at_each_point: DefaultArgType.BurstAtEachPoint = 1,
         **kwargs,
     ):
         """
@@ -97,11 +85,11 @@ class LineScan(ScanBase):
             steps (int): number of points along the line.
             relative (bool): If True, the motors will be moved relative to their
                 current position.
-            exp_time (Annotated[float, Units.s]): exposure time in seconds. Default is 0.
+            exp_time (float): exposure time in seconds. Default is 0.
             frames_per_trigger (int): number of frames acquired per trigger. Default is 1.
-            settling_time (Annotated[float, Units.s]): settling time in seconds. Default is 0.
-            settling_time_after_trigger (Annotated[float, Units.s]): settling time after trigger in seconds. Default is 0.
-            readout_time (Annotated[float, Units.s]): readout time in seconds. Default is 0.
+            settling_time (float): settling time in seconds. Default is 0.
+            settling_time_after_trigger (float): settling time after trigger in seconds. Default is 0.
+            readout_time (float): readout time in seconds. Default is 0.
             burst_at_each_point (int): number of exposures at each point. Default is 1.
 
         Returns:

--- a/bec_server/bec_server/scan_server/scans/line_sweep_scan.py
+++ b/bec_server/bec_server/scan_server/scans/line_sweep_scan.py
@@ -25,7 +25,7 @@ import numpy as np
 from bec_lib.connector import MessageObject
 from bec_lib.device import DeviceBase
 from bec_lib.endpoints import MessageEndpoints
-from bec_lib.scan_args import ScanArgument, Units
+from bec_lib.scan_args import DefaultArgType, ScanArgument, Units
 from bec_server.scan_server.scans.scan_base import ScanBase, ScanType
 from bec_server.scan_server.scans.scan_modifier import scan_hook
 
@@ -57,13 +57,9 @@ class LineSweepScan(ScanBase):
             float, ScanArgument(display_name="Stop Position", reference_units="device")
         ],
         *,
-        relative: bool,
-        exp_time: Annotated[
-            float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
-        ] = 0,
-        frames_per_trigger: Annotated[
-            int, ScanArgument(display_name="Frames per Trigger", ge=1)
-        ] = 1,
+        relative: DefaultArgType.Relative,
+        exp_time: DefaultArgType.ExposureTime = 0,
+        frames_per_trigger: DefaultArgType.FramesPerTrigger = 1,
         min_update: Annotated[
             float, ScanArgument(display_name="Minimum Update", units=Units.s, ge=0)
         ] = 0,

--- a/bec_server/bec_server/scan_server/scans/list_scan.py
+++ b/bec_server/bec_server/scan_server/scans/list_scan.py
@@ -16,12 +16,10 @@ Scan procedure:
 
 from __future__ import annotations
 
-from typing import Annotated
-
 import numpy as np
 
 from bec_lib.device import DeviceBase
-from bec_lib.scan_args import ScanArgument, Units
+from bec_lib.scan_args import DefaultArgType
 from bec_server.scan_server.scans.scan_base import ScanBase, ScanType, bundle_args
 from bec_server.scan_server.scans.scan_modifier import scan_hook
 
@@ -58,25 +56,13 @@ class ListScan(ScanBase):
     def __init__(
         self,
         *args,
-        relative: bool,
-        exp_time: Annotated[
-            float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
-        ] = 0,
-        frames_per_trigger: Annotated[
-            int, ScanArgument(display_name="Frames per Trigger", ge=1)
-        ] = 1,
-        settling_time: Annotated[
-            float, ScanArgument(display_name="Settling Time", units=Units.s, ge=0)
-        ] = 0,
-        settling_time_after_trigger: Annotated[
-            float, ScanArgument(display_name="Settling Time After Trigger", units=Units.s, ge=0)
-        ] = 0,
-        readout_time: Annotated[
-            float, ScanArgument(display_name="Readout Time", units=Units.s, ge=0)
-        ] = 0,
-        burst_at_each_point: Annotated[
-            int, ScanArgument(display_name="Burst at Each Point", ge=1)
-        ] = 1,
+        relative: DefaultArgType.Relative,
+        exp_time: DefaultArgType.ExposureTime = 0,
+        frames_per_trigger: DefaultArgType.FramesPerTrigger = 1,
+        settling_time: DefaultArgType.SettlingTime = 0,
+        settling_time_after_trigger: DefaultArgType.SettlingTimeAfterTrigger = 0,
+        readout_time: DefaultArgType.ReadoutTime = 0,
+        burst_at_each_point: DefaultArgType.BurstAtEachPoint = 1,
         **kwargs,
     ):
         """

--- a/bec_server/bec_server/scan_server/scans/log_scan.py
+++ b/bec_server/bec_server/scan_server/scans/log_scan.py
@@ -21,7 +21,7 @@ from typing import Annotated
 import numpy as np
 
 from bec_lib.device import DeviceBase
-from bec_lib.scan_args import ScanArgument, Units
+from bec_lib.scan_args import DefaultArgType, ScanArgument
 from bec_server.scan_server.scans import position_generators
 from bec_server.scan_server.scans.scan_base import ScanBase, ScanType, bundle_args
 from bec_server.scan_server.scans.scan_modifier import scan_hook
@@ -68,25 +68,13 @@ class LogScan(ScanBase):
         self,
         *args,
         steps: Annotated[int, ScanArgument(display_name="Steps", ge=1)],
-        relative: bool,
-        exp_time: Annotated[
-            float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
-        ] = 0,
-        frames_per_trigger: Annotated[
-            int, ScanArgument(display_name="Frames per Trigger", ge=1)
-        ] = 1,
-        settling_time: Annotated[
-            float, ScanArgument(display_name="Settling Time", units=Units.s, ge=0)
-        ] = 0,
-        settling_time_after_trigger: Annotated[
-            float, ScanArgument(display_name="Settling Time After Trigger", units=Units.s, ge=0)
-        ] = 0,
-        readout_time: Annotated[
-            float, ScanArgument(display_name="Readout Time", units=Units.s, ge=0)
-        ] = 0,
-        burst_at_each_point: Annotated[
-            int, ScanArgument(display_name="Burst at Each Point", ge=1)
-        ] = 1,
+        relative: DefaultArgType.Relative,
+        exp_time: DefaultArgType.ExposureTime = 0,
+        frames_per_trigger: DefaultArgType.FramesPerTrigger = 1,
+        settling_time: DefaultArgType.SettlingTime = 0,
+        settling_time_after_trigger: DefaultArgType.SettlingTimeAfterTrigger = 0,
+        readout_time: DefaultArgType.ReadoutTime = 0,
+        burst_at_each_point: DefaultArgType.BurstAtEachPoint = 1,
         **kwargs,
     ):
         """

--- a/bec_server/bec_server/scan_server/scans/move.py
+++ b/bec_server/bec_server/scan_server/scans/move.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from bec_lib.device import DeviceBase
 from bec_lib.logger import bec_logger
+from bec_lib.scan_args import DefaultArgType
 from bec_server.scan_server.scans.scan_base import ScanBase, bundle_args
 from bec_server.scan_server.scans.scan_modifier import scan_hook
 
@@ -45,7 +46,7 @@ class MoveScan(ScanBase):
     # We set is_scan to False to separate this class from the other scans in the user interface
     is_scan = False
 
-    def __init__(self, *args, relative: bool, **kwargs):
+    def __init__(self, *args, relative: DefaultArgType.Relative, **kwargs):
         """
         Simple move command that moves one or more motors to the specified positions.
         The mv command gives back control to the user immediately after sending the command. For a blocking call

--- a/bec_server/bec_server/scan_server/scans/multi_region_grid_scan.py
+++ b/bec_server/bec_server/scan_server/scans/multi_region_grid_scan.py
@@ -16,12 +16,10 @@ Scan procedure:
 
 from __future__ import annotations
 
-from typing import Annotated
-
 import numpy as np
 
 from bec_lib.device import DeviceBase
-from bec_lib.scan_args import ScanArgument, Units
+from bec_lib.scan_args import DefaultArgType
 from bec_server.scan_server.scans import position_generators
 from bec_server.scan_server.scans.scan_base import ScanBase, ScanType
 from bec_server.scan_server.scans.scan_modifier import scan_hook
@@ -52,26 +50,14 @@ class MultiRegionGridScan(ScanBase):
         motor2: DeviceBase,
         *,
         regions: list[tuple[tuple[float, float, int], tuple[float, float, int]]],
-        relative: bool,
-        exp_time: Annotated[
-            float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
-        ] = 0,
-        frames_per_trigger: Annotated[
-            int, ScanArgument(display_name="Frames per Trigger", ge=1)
-        ] = 1,
-        settling_time: Annotated[
-            float, ScanArgument(display_name="Settling Time", units=Units.s, ge=0)
-        ] = 0,
-        settling_time_after_trigger: Annotated[
-            float, ScanArgument(display_name="Settling Time After Trigger", units=Units.s, ge=0)
-        ] = 0,
-        readout_time: Annotated[
-            float, ScanArgument(display_name="Readout Time", units=Units.s, ge=0)
-        ] = 0,
-        snaked: bool = True,
-        burst_at_each_point: Annotated[
-            int, ScanArgument(display_name="Burst at Each Point", ge=1)
-        ] = 1,
+        relative: DefaultArgType.Relative,
+        exp_time: DefaultArgType.ExposureTime = 0,
+        frames_per_trigger: DefaultArgType.FramesPerTrigger = 1,
+        settling_time: DefaultArgType.SettlingTime = 0,
+        settling_time_after_trigger: DefaultArgType.SettlingTimeAfterTrigger = 0,
+        readout_time: DefaultArgType.ReadoutTime = 0,
+        snaked: DefaultArgType.Snaked = True,
+        burst_at_each_point: DefaultArgType.BurstAtEachPoint = 1,
         **kwargs,
     ):
         """

--- a/bec_server/bec_server/scan_server/scans/multi_region_line_scan.py
+++ b/bec_server/bec_server/scan_server/scans/multi_region_line_scan.py
@@ -16,12 +16,10 @@ Scan procedure:
 
 from __future__ import annotations
 
-from typing import Annotated
-
 import numpy as np
 
 from bec_lib.device import DeviceBase
-from bec_lib.scan_args import ScanArgument, Units
+from bec_lib.scan_args import DefaultArgType
 from bec_server.scan_server.scans import position_generators
 from bec_server.scan_server.scans.scan_base import ScanBase, ScanType
 from bec_server.scan_server.scans.scan_modifier import scan_hook
@@ -57,25 +55,13 @@ class MultiRegionLineScan(ScanBase):
         motor: DeviceBase,
         *,
         regions: list[tuple[float, float, int]],
-        relative: bool,
-        exp_time: Annotated[
-            float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
-        ] = 0,
-        frames_per_trigger: Annotated[
-            int, ScanArgument(display_name="Frames per Trigger", ge=1)
-        ] = 1,
-        settling_time: Annotated[
-            float, ScanArgument(display_name="Settling Time", units=Units.s, ge=0)
-        ] = 0,
-        settling_time_after_trigger: Annotated[
-            float, ScanArgument(display_name="Settling Time After Trigger", units=Units.s, ge=0)
-        ] = 0,
-        readout_time: Annotated[
-            float, ScanArgument(display_name="Readout Time", units=Units.s, ge=0)
-        ] = 0,
-        burst_at_each_point: Annotated[
-            int, ScanArgument(display_name="Burst at Each Point", ge=1)
-        ] = 1,
+        relative: DefaultArgType.Relative,
+        exp_time: DefaultArgType.ExposureTime = 0,
+        frames_per_trigger: DefaultArgType.FramesPerTrigger = 1,
+        settling_time: DefaultArgType.SettlingTime = 0,
+        settling_time_after_trigger: DefaultArgType.SettlingTimeAfterTrigger = 0,
+        readout_time: DefaultArgType.ReadoutTime = 0,
+        burst_at_each_point: DefaultArgType.BurstAtEachPoint = 1,
         **kwargs,
     ):
         """

--- a/bec_server/bec_server/scan_server/scans/round_roi_scan.py
+++ b/bec_server/bec_server/scan_server/scans/round_roi_scan.py
@@ -21,7 +21,7 @@ from typing import Annotated
 import numpy as np
 
 from bec_lib.device import DeviceBase
-from bec_lib.scan_args import ScanArgument, Units
+from bec_lib.scan_args import DefaultArgType, ScanArgument
 from bec_server.scan_server.scans import position_generators
 from bec_server.scan_server.scans.scan_base import ScanBase, ScanType
 from bec_server.scan_server.scans.scan_modifier import scan_hook
@@ -77,31 +77,19 @@ class RoundROIScan(ScanBase):
             int, ScanArgument(display_name="Number of Points in First Shell", ge=1)
         ],
         *,
-        relative: bool,
-        exp_time: Annotated[
-            float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
-        ] = 0,
-        frames_per_trigger: Annotated[
-            int, ScanArgument(display_name="Frames per Trigger", ge=1)
-        ] = 1,
-        settling_time: Annotated[
-            float, ScanArgument(display_name="Settling Time", units=Units.s, ge=0)
-        ] = 0,
-        settling_time_after_trigger: Annotated[
-            float, ScanArgument(display_name="Settling Time After Trigger", units=Units.s, ge=0)
-        ] = 0,
-        readout_time: Annotated[
-            float, ScanArgument(display_name="Readout Time", units=Units.s, ge=0)
-        ] = 0,
+        relative: DefaultArgType.Relative,
+        exp_time: DefaultArgType.ExposureTime = 0,
+        frames_per_trigger: DefaultArgType.FramesPerTrigger = 1,
+        settling_time: DefaultArgType.SettlingTime = 0,
+        settling_time_after_trigger: DefaultArgType.SettlingTimeAfterTrigger = 0,
+        readout_time: DefaultArgType.ReadoutTime = 0,
         center_1: Annotated[
             float, ScanArgument(display_name="Center Motor 1", reference_units="motor_1")
         ] = 0,
         center_2: Annotated[
             float, ScanArgument(display_name="Center Motor 2", reference_units="motor_2")
         ] = 0,
-        burst_at_each_point: Annotated[
-            int, ScanArgument(display_name="Burst at Each Point", ge=1)
-        ] = 1,
+        burst_at_each_point: DefaultArgType.BurstAtEachPoint = 1,
         **kwargs,
     ):
         """

--- a/bec_server/bec_server/scan_server/scans/round_scan.py
+++ b/bec_server/bec_server/scan_server/scans/round_scan.py
@@ -21,7 +21,7 @@ from typing import Annotated
 import numpy as np
 
 from bec_lib.device import DeviceBase
-from bec_lib.scan_args import ScanArgument, Units
+from bec_lib.scan_args import DefaultArgType, ScanArgument
 from bec_server.scan_server.scans import position_generators
 from bec_server.scan_server.scans.scan_base import ScanBase, ScanType
 from bec_server.scan_server.scans.scan_modifier import scan_hook
@@ -75,31 +75,19 @@ class RoundScan(ScanBase):
             int, ScanArgument(display_name="Positions in First Ring", ge=1)
         ],
         *,
-        relative: bool,
-        exp_time: Annotated[
-            float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
-        ] = 0,
-        frames_per_trigger: Annotated[
-            int, ScanArgument(display_name="Frames per Trigger", ge=1)
-        ] = 1,
-        settling_time: Annotated[
-            float, ScanArgument(display_name="Settling Time", units=Units.s, ge=0)
-        ] = 0,
-        settling_time_after_trigger: Annotated[
-            float, ScanArgument(display_name="Settling Time After Trigger", units=Units.s, ge=0)
-        ] = 0,
-        readout_time: Annotated[
-            float, ScanArgument(display_name="Readout Time", units=Units.s, ge=0)
-        ] = 0,
+        relative: DefaultArgType.Relative,
+        exp_time: DefaultArgType.ExposureTime = 0,
+        frames_per_trigger: DefaultArgType.FramesPerTrigger = 1,
+        settling_time: DefaultArgType.SettlingTime = 0,
+        settling_time_after_trigger: DefaultArgType.SettlingTimeAfterTrigger = 0,
+        readout_time: DefaultArgType.ReadoutTime = 0,
         center_1: Annotated[
             float, ScanArgument(display_name="Center Motor 1", reference_units="motor_1")
         ] = 0,
         center_2: Annotated[
             float, ScanArgument(display_name="Center Motor 2", reference_units="motor_2")
         ] = 0,
-        burst_at_each_point: Annotated[
-            int, ScanArgument(display_name="Burst at Each Point", ge=1)
-        ] = 1,
+        burst_at_each_point: DefaultArgType.BurstAtEachPoint = 1,
         **kwargs,
     ):
         """
@@ -115,11 +103,11 @@ class RoundScan(ScanBase):
             pos_in_first_ring (int): number of positions in the first ring
             relative (bool): If True, the motors will be moved relative to their
                 current position.
-            exp_time (Annotated[float, Units.s]): exposure time in seconds. Default is 0.
-            frames_per_trigger (Annotated[int]): number of frames acquired per trigger. Default is 1.
-            settling_time (Annotated[float, Units.s]): settling time in seconds. Default is 0.
-            settling_time_after_trigger (Annotated[float, Units.s]): settling time after trigger in seconds. Default is 0.
-            readout_time (Annotated[float, Units.s]): readout time in seconds. Default is 0.
+            exp_time (float): exposure time in seconds. Default is 0.
+            frames_per_trigger (int): number of frames acquired per trigger. Default is 1.
+            settling_time (float): settling time in seconds. Default is 0.
+            settling_time_after_trigger (float): settling time after trigger in seconds. Default is 0.
+            readout_time (float): readout time in seconds. Default is 0.
             center_1 (float): center position for motor_1. Default is 0.
             center_2 (float): center position for motor_2. Default is 0.
             burst_at_each_point (int): number of exposures at each point. Default is 1.

--- a/bec_server/bec_server/scan_server/scans/time_scan.py
+++ b/bec_server/bec_server/scan_server/scans/time_scan.py
@@ -20,7 +20,7 @@ from typing import Annotated
 
 import numpy as np
 
-from bec_lib.scan_args import ScanArgument, Units
+from bec_lib.scan_args import DefaultArgType, ScanArgument, Units
 from bec_server.scan_server.scans.scan_base import ScanBase, ScanType
 from bec_server.scan_server.scans.scan_modifier import scan_hook
 
@@ -44,12 +44,8 @@ class TimeScan(ScanBase):
         self,
         points: int,
         interval: Annotated[float, ScanArgument(display_name="Interval", units=Units.s, ge=0)],
-        exp_time: Annotated[
-            float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
-        ] = 0,
-        settling_time: Annotated[
-            float, ScanArgument(display_name="Settling Time", units=Units.s, ge=0)
-        ] = 0,
+        exp_time: DefaultArgType.ExposureTime = 0,
+        settling_time: DefaultArgType.SettlingTime = 0,
         **kwargs,
     ):
         """

--- a/bec_server/bec_server/scan_server/scans/updated_move.py
+++ b/bec_server/bec_server/scan_server/scans/updated_move.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from bec_lib.device import DeviceBase
 from bec_lib.logger import bec_logger
+from bec_lib.scan_args import DefaultArgType
 from bec_server.scan_server.scans.scan_base import ScanBase, bundle_args
 from bec_server.scan_server.scans.scan_modifier import scan_hook
 
@@ -45,7 +46,7 @@ class UpdatedMoveScan(ScanBase):
     # We set is_scan to False to separate this class from the other scans in the user interface
     is_scan = False
 
-    def __init__(self, *args, relative: bool, **kwargs):
+    def __init__(self, *args, relative: DefaultArgType.Relative, **kwargs):
         """
         Simple move command that moves one or more motors to the specified positions.
         The umv command is the blocking version of the mv command.


### PR DESCRIPTION
## Description

A small refactoring to use type aliases in scan definitions. This not only makes the definition more compact and removes the need to turn off the formatter, it also makes the standard type definitions more consistent. 

## Type of Change

- Standard scan arguments are now defined in bec_lib.scan_args
- Internal scans reuse them whenever possible

## How to test

- Run unit tests

## Potential side effects

It may remove clarity on what the type hint actually provides. However, I would argue that the long type definition we had before is even more detrimental. 

