### PR TITLE
perf: simplify bec client mock and remove unused test devices

### DIFF
--- a/bec_lib/bec_lib/tests/fixtures.py
+++ b/bec_lib/bec_lib/tests/fixtures.py
@@ -10,7 +10,7 @@ import pytest
 import yaml
 
 from bec_lib.service_config import ServiceConfig
-from bec_lib.tests.utils import ClientMock, ConnectorMock, DMClientMock
+from bec_lib.tests.utils import ClientMock, ConnectorMock, DMClientMock, FancyClientMock
 
 
 @pytest.fixture
@@ -77,9 +77,8 @@ def dm_with_devices(session_from_test_config, device_manager):
     yield device_manager
 
 
-@pytest.fixture()
-def bec_client_mock(dm_with_devices):
-    client = ClientMock(
+def create_bec_client_mock(mock_class, dm_with_devices):
+    client = mock_class(
         ServiceConfig(redis={"host": "host", "port": 123}, scibec={"host": "host", "port": 123}),
         ConnectorMock,
         wait_for_server=False,
@@ -96,3 +95,13 @@ def bec_client_mock(dm_with_devices):
         client.shutdown()
         client._reset_singleton()
         device_manager.devices.flush()
+
+
+@pytest.fixture()
+def bec_client_mock(dm_with_devices):
+    yield from create_bec_client_mock(ClientMock, dm_with_devices)
+
+
+@pytest.fixture()
+def fancy_bec_client_mock(dm_with_devices):
+    yield from create_bec_client_mock(FancyClientMock, dm_with_devices)

--- a/bec_lib/bec_lib/tests/fixtures.py
+++ b/bec_lib/bec_lib/tests/fixtures.py
@@ -10,7 +10,7 @@ import pytest
 import yaml
 
 from bec_lib.service_config import ServiceConfig
-from bec_lib.tests.utils import ClientMock, ConnectorMock, DMClientMock, FancyClientMock
+from bec_lib.tests.utils import ClientMock, ConnectorMock, DMClientMock
 
 
 @pytest.fixture
@@ -19,9 +19,9 @@ def threads_check():
     yield
     threads_after = set(th for th in threading.enumerate() if th is not threading.main_thread())
     additional_threads = threads_after - threads_at_start
-    assert len(additional_threads) == 0, (
-        f"Test creates {len(additional_threads)} threads that are not cleaned: {additional_threads}"
-    )
+    assert (
+        len(additional_threads) == 0
+    ), f"Test creates {len(additional_threads)} threads that are not cleaned: {additional_threads}"
 
 
 @pytest.fixture(scope="session")
@@ -101,8 +101,3 @@ def create_bec_client_mock(mock_class, dm_with_devices):
 @pytest.fixture()
 def bec_client_mock(dm_with_devices):
     yield from create_bec_client_mock(ClientMock, dm_with_devices)
-
-
-@pytest.fixture()
-def fancy_bec_client_mock(dm_with_devices):
-    yield from create_bec_client_mock(FancyClientMock, dm_with_devices)

--- a/bec_lib/bec_lib/tests/fixtures.py
+++ b/bec_lib/bec_lib/tests/fixtures.py
@@ -19,9 +19,9 @@ def threads_check():
     yield
     threads_after = set(th for th in threading.enumerate() if th is not threading.main_thread())
     additional_threads = threads_after - threads_at_start
-    assert (
-        len(additional_threads) == 0
-    ), f"Test creates {len(additional_threads)} threads that are not cleaned: {additional_threads}"
+    assert len(additional_threads) == 0, (
+        f"Test creates {len(additional_threads)} threads that are not cleaned: {additional_threads}"
+    )
 
 
 @pytest.fixture(scope="session")
@@ -72,9 +72,10 @@ def device_manager(device_manager_class):
 
 @pytest.fixture
 def dm_with_devices(session_from_test_config, device_manager):
-    device_manager._session = copy.deepcopy(session_from_test_config)
-    device_manager._load_session()
-    yield device_manager
+    with mock.patch("bec_lib.devicemanager.logger"):
+        device_manager._session = copy.deepcopy(session_from_test_config)
+        device_manager._load_session()
+    return device_manager
 
 
 def create_bec_client_mock(mock_class, dm_with_devices):

--- a/bec_lib/bec_lib/tests/test_config.yaml
+++ b/bec_lib/bec_lib/tests/test_config.yaml
@@ -3,305 +3,209 @@
 ############################################################
 
 eiger:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimCamera
-  deviceConfig:
-    device_access: true
-  deviceTags:
-    - detector
-  enabled: true
-  readOnly: false
-  softwareTrigger: true
+    readoutPriority: monitored
+    deviceClass: ophyd_devices.SimCamera
+    deviceConfig:
+        device_access: true
+    deviceTags:
+        - detector
+    enabled: true
+    readOnly: false
+    softwareTrigger: true
 
 ############## Cameras and detectors end here ##############
 
 dyn_signals:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.sim.sim.SynDynamicComponents
-  deviceConfig:
-  enabled: true
-  readOnly: false
+    readoutPriority: baseline
+    deviceClass: ophyd_devices.sim.sim.SynDynamicComponents
+    deviceConfig:
+    enabled: true
+    readOnly: false
 
 pseudo_signal1:
-  deviceClass: ophyd_devices.ComputedSignal
-  deviceConfig:
-    compute_method: "def compute_signals(signal1, signal2):\n    return signal1.get()*signal2.get()\n"
-    input_signals:
-      - "bpm4i"
-      - "bpm5i"
-  enabled: true
-  readOnly: false
-  readoutPriority: baseline
+    deviceClass: ophyd_devices.ComputedSignal
+    deviceConfig:
+        compute_method: "def compute_signals(signal1, signal2):
+
+            \    return signal1.get()*signal2.get()\n"
+        input_signals:
+            - "bpm4i"
+            - "bpm5i"
+    enabled: true
+    readOnly: false
+    readoutPriority: baseline
 
 failure_device:
-  deviceClass: ophyd_devices.sim.SimPositionerWithCommFailure
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  enabled: true
-  readOnly: false
-  readoutPriority: baseline
+    deviceClass: ophyd_devices.sim.SimPositionerWithCommFailure
+    deviceConfig:
+        delay: 1
+        update_frequency: 400
+    enabled: true
+    readOnly: false
+    readoutPriority: baseline
 
 bec_signals_device:
-  deviceClass: ophyd_devices.sim.sim_test_devices.SimCameraWithPSIComponents
-  deviceConfig:
-  enabled: true
-  readOnly: false
-  readoutPriority: baseline
+    deviceClass: ophyd_devices.sim.sim_test_devices.SimCameraWithPSIComponents
+    deviceConfig:
+    enabled: true
+    readOnly: false
+    readoutPriority: baseline
 
 ############################################################
 ####################### User motors ########################
 ############################################################
 
 eyefoc:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    limits:
-      - -50
-      - 50
-    tolerance: 0.01
-    update_frequency: 400
-  deviceTags:
-    - user motors
-  enabled: true
-  readOnly: false
+    readoutPriority: baseline
+    deviceClass: ophyd_devices.SimPositioner
+    deviceConfig:
+        delay: 1
+        limits:
+            - -50
+            - 50
+        tolerance: 0.01
+        update_frequency: 400
+    deviceTags:
+        - user motors
+    enabled: true
+    readOnly: false
 eyex:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    limits:
-      - -50
-      - 50
-    tolerance: 0.01
-    update_frequency: 400
-  deviceTags:
-    - user motors
-  enabled: true
-  readOnly: false
+    readoutPriority: baseline
+    deviceClass: ophyd_devices.SimPositioner
+    deviceConfig:
+        delay: 1
+        limits:
+            - -50
+            - 50
+        tolerance: 0.01
+        update_frequency: 400
+    deviceTags:
+        - user motors
+    enabled: true
+    readOnly: false
 eyey:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    limits:
-      - -50
-      - 50
-    tolerance: 0.01
-    update_frequency: 400
-  deviceTags:
-    - user motors
-  enabled: true
-  readOnly: false
+    readoutPriority: baseline
+    deviceClass: ophyd_devices.SimPositioner
+    deviceConfig:
+        delay: 1
+        limits:
+            - -50
+            - 50
+        tolerance: 0.01
+        update_frequency: 400
+    deviceTags:
+        - user motors
+    enabled: true
+    readOnly: false
 flyer_sim:
-  readoutPriority: on_request
-  deviceClass: ophyd_devices.SynFlyer
-  deviceConfig:
-    delay: 1
-    device_access: true
-    update_frequency: 400
-  deviceTags:
-    - flyer
-  enabled: true
-  readOnly: false
+    readoutPriority: on_request
+    deviceClass: ophyd_devices.SynFlyer
+    deviceConfig:
+        delay: 1
+        device_access: true
+        update_frequency: 400
+    deviceTags:
+        - flyer
+    enabled: true
+    readOnly: false
 hrox:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    limits:
-      - -50
-      - 50
-    tolerance: 0.01
-    update_frequency: 400
-  deviceTags:
-    - user motors
-  enabled: true
-  readOnly: false
+    readoutPriority: baseline
+    deviceClass: ophyd_devices.SimPositioner
+    deviceConfig:
+        delay: 1
+        limits:
+            - -50
+            - 50
+        tolerance: 0.01
+        update_frequency: 400
+    deviceTags:
+        - user motors
+    enabled: true
+    readOnly: false
 hroy:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    limits:
-      - -50
-      - 50
-    tolerance: 0.01
-    update_frequency: 400
-  deviceTags:
-    - user motors
-  enabled: true
-  readOnly: false
+    readoutPriority: baseline
+    deviceClass: ophyd_devices.SimPositioner
+    deviceConfig:
+        delay: 1
+        limits:
+            - -50
+            - 50
+        tolerance: 0.01
+        update_frequency: 400
+    deviceTags:
+        - user motors
+    enabled: true
+    readOnly: false
 hroz:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    limits:
-      - -50
-      - 50
-    tolerance: 0.01
-    update_frequency: 400
-  deviceTags:
-    - user motors
-  enabled: true
-  readOnly: false
-hx:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    limits:
-      - -50
-      - 50
-    tolerance: 0.01
-    update_frequency: 400
-  deviceTags:
-    - user motors
-  enabled: true
-  readOnly: false
-hy:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    limits:
-      - -50
-      - 50
-    tolerance: 0.01
-    update_frequency: 400
-  deviceTags:
-    - user motors
-  enabled: true
-  readOnly: false
-hz:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    limits:
-      - -50
-      - 50
-    tolerance: 0.01
-    update_frequency: 400
-  deviceTags:
-    - user motors
-  enabled: true
-  readOnly: false
-mbsx:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    limits:
-      - -50
-      - 50
-    tolerance: 0.01
-    update_frequency: 400
-  deviceTags:
-    - user motors
-  enabled: true
-  readOnly: false
-mbsy:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    limits:
-      - -50
-      - 50
-    tolerance: 0.01
-    update_frequency: 400
-  deviceTags:
-    - user motors
-  enabled: true
-  readOnly: false
-pinx:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    limits:
-      - -50
-      - 50
-    tolerance: 0.01
-    update_frequency: 400
-  deviceTags:
-    - user motors
-  enabled: true
-  readOnly: false
-piny:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    limits:
-      - -50
-      - 50
-    tolerance: 0.01
-    update_frequency: 400
-  deviceTags:
-    - user motors
-  enabled: true
-  readOnly: false
+    readoutPriority: baseline
+    deviceClass: ophyd_devices.SimPositioner
+    deviceConfig:
+        delay: 1
+        limits:
+            - -50
+            - 50
+        tolerance: 0.01
+        update_frequency: 400
+    deviceTags:
+        - user motors
+    enabled: true
+    readOnly: false
 pinz:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    limits:
-      - -50
-      - 50
-    tolerance: 0.01
-    update_frequency: 400
-  deviceTags:
-    - user motors
-  enabled: true
-  readOnly: false
+    readoutPriority: baseline
+    deviceClass: ophyd_devices.SimPositioner
+    deviceConfig:
+        delay: 1
+        limits:
+            - -50
+            - 50
+        tolerance: 0.01
+        update_frequency: 400
+    deviceTags:
+        - user motors
+    enabled: true
+    readOnly: false
 samx:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    limits:
-      - -50
-      - 50
-    tolerance: 0.01
-    update_frequency: 400
-  deviceTags:
-    - user motors
-  enabled: true
-  readOnly: false
+    readoutPriority: baseline
+    deviceClass: ophyd_devices.SimPositioner
+    deviceConfig:
+        delay: 1
+        limits:
+            - -50
+            - 50
+        tolerance: 0.01
+        update_frequency: 400
+    deviceTags:
+        - user motors
+    enabled: true
+    readOnly: false
 samy:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    limits:
-      - -50
-      - 50
-    tolerance: 0.01
-    update_frequency: 400
-  deviceTags:
-    - user motors
-  enabled: true
-  readOnly: false
+    readoutPriority: baseline
+    deviceClass: ophyd_devices.SimPositioner
+    deviceConfig:
+        delay: 1
+        limits:
+            - -50
+            - 50
+        tolerance: 0.01
+        update_frequency: 400
+    deviceTags:
+        - user motors
+    enabled: true
+    readOnly: false
 samz:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    limits:
-      - -50
-      - 50
-    tolerance: 0.01
-    update_frequency: 400
-  deviceTags:
-    - user motors
-  enabled: true
-  readOnly: false
+    readoutPriority: baseline
+    deviceClass: ophyd_devices.SimPositioner
+    deviceConfig:
+        delay: 1
+        limits:
+            - -50
+            - 50
+        tolerance: 0.01
+        update_frequency: 400
+    deviceTags:
+        - user motors
+    enabled: true
+    readOnly: false
 
 ################### User motors end here ###################
 
@@ -310,1831 +214,116 @@ samz:
 ############################################################
 
 bpm3a:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
+    readoutPriority: monitored
+    deviceClass: ophyd_devices.SimMonitor
+    deviceConfig:
+    deviceTags:
+        - beamline
+    enabled: true
+    readOnly: false
 bpm3b:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
+    readoutPriority: monitored
+    deviceClass: ophyd_devices.SimMonitor
+    deviceConfig:
+    deviceTags:
+        - beamline
+    enabled: true
+    readOnly: false
 bpm3c:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
+    readoutPriority: monitored
+    deviceClass: ophyd_devices.SimMonitor
+    deviceConfig:
+    deviceTags:
+        - beamline
+    enabled: true
+    readOnly: false
 bpm3d:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
+    readoutPriority: monitored
+    deviceClass: ophyd_devices.SimMonitor
+    deviceConfig:
+    deviceTags:
+        - beamline
+    enabled: true
+    readOnly: false
 bpm3i:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm3x:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm3y:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm3z:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm4a:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm4b:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm4c:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm4d:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
+    readoutPriority: monitored
+    deviceClass: ophyd_devices.SimMonitor
+    deviceConfig:
+    deviceTags:
+        - beamline
+    enabled: true
+    readOnly: false
 bpm4i:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm4s:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm4x:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm4xf:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm4xm:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm4y:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm4yf:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm4ym:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm4z:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm5a:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm5b:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm5c:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm5d:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
+    readoutPriority: monitored
+    deviceClass: ophyd_devices.SimMonitor
+    deviceConfig:
+    deviceTags:
+        - beamline
+    enabled: true
+    readOnly: false
 bpm5i:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm5x:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm5y:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm5z:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm6a:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm6b:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm6c:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm6d:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
+    readoutPriority: monitored
+    deviceClass: ophyd_devices.SimMonitor
+    deviceConfig:
+    deviceTags:
+        - beamline
+    enabled: true
+    readOnly: false
 bpm6i:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm6x:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm6y:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm6z:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-curr:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-diode:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ebpmdx:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ebpmdy:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ebpmux:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ebpmuy:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ftp:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
+    readoutPriority: monitored
+    deviceClass: ophyd_devices.SimMonitor
+    deviceConfig:
+    deviceTags:
+        - beamline
+    enabled: true
+    readOnly: false
 temp:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
+    readoutPriority: monitored
+    deviceClass: ophyd_devices.SimMonitor
+    deviceConfig:
+    deviceTags:
+        - beamline
+    enabled: true
+    readOnly: false
 transd:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimMonitor
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
+    readoutPriority: monitored
+    deviceClass: ophyd_devices.SimMonitor
+    deviceConfig:
+    deviceTags:
+        - beamline
+    enabled: true
+    readOnly: false
 
 monitor_async:
-  readoutPriority: async
-  deviceClass: ophyd_devices.sim.sim_monitor.SimMonitorAsync
-  deviceConfig:
-    sim_init:
-      model: GaussianModel
-      params:
-        amplitude: 500
-        center: 0
-        sigma: 1
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-  softwareTrigger: true
+    readoutPriority: async
+    deviceClass: ophyd_devices.sim.sim_monitor.SimMonitorAsync
+    deviceConfig:
+        sim_init:
+            model: GaussianModel
+            params:
+                amplitude: 500
+                center: 0
+                sigma: 1
+    deviceTags:
+        - beamline
+    enabled: true
+    readOnly: false
+    softwareTrigger: true
 
 ################ Beamline monitors end here ################
-
-############################################################
-##################### Beamline motors ######################
-############################################################
-
-aptrx:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-aptry:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bim2x:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bim2y:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bm1trx:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bm1try:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bm2trx:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bm2try:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bm3trx:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bm3try:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bm4trx:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bm4try:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bm5trx:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bm5try:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bm6trx:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bm6try:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm4r:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bpm5r:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bs1x:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bs1y:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bs2x:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-bs2y:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-burstn:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-burstr:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ddg1a:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ddg1b:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ddg1c:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ddg1d:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ddg1e:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ddg1f:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ddg1g:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ddg1h:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-dettrx:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-di2trx:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-di2try:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-dtpush:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-dtth:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-dttrx:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-dttry:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-dttrz:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ebcsx:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ebcsy:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ebfi1:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ebfi2:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ebfi3:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ebfi4:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ebfzpx:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ebfzpy:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ebtrx:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ebtry:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ebtrz:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-fi1try:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-fi2try:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-fi3try:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-fsh1x:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-fsh2x:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-ftrans:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-fttrx1:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-fttrx2:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-fttry1:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-fttry2:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-fttrz:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-idgap:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-mibd:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-mibd1:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-mibd2:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-miroll:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-mith:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-mitrx:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-mitry:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-mitry1:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-mitry2:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-mitry3:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-mobd:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-mobdai:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-mobdbo:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-mobdco:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-mobddi:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-mokev:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-mopush1:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-mopush2:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-moroll1:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-moroll2:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-moth1:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-moth1e:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-moth2:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-moth2e:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-motrx2:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-motry:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-motry2:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-motrz1:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-motrz1e:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-moyaw2:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl0ch:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl0trxi:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl0trxo:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl0wh:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl1ch:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl1cv:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl1trxi:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl1trxo:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl1tryb:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl1tryt:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl1wh:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl1wv:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl2ch:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl2cv:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl2trxi:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl2trxo:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl2tryb:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl2tryt:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl2wh:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl2wv:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl3ch:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl3cv:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl3trxi:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl3trxo:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl3tryb:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl3tryt:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl3wh:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl3wv:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl4ch:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl4cv:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl4trxi:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl4trxo:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl4tryb:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl4tryt:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl4wh:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl4wv:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl5ch:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl5cv:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl5trxi:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl5trxo:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl5tryb:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl5tryt:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl5wh:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sl5wv:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-strox:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-stroy:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-stroz:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sttrx:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-sttry:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    update_frequency: 400
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
-
-################# Beamline motors end here #################
 
 ############################################################
 #################### Read-only signals #####################
 ############################################################
 
 ring_current_sim:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.ReadOnlySignal
-  deviceConfig:
-  deviceTags:
-    - beamline
-  enabled: true
-  readOnly: false
+    readoutPriority: monitored
+    deviceClass: ophyd_devices.ReadOnlySignal
+    deviceConfig:
+    deviceTags:
+        - beamline
+    enabled: true
+    readOnly: false
 ################ Read-only signals end here ################
 
 ############################################################
@@ -2142,114 +331,114 @@ ring_current_sim:
 ############################################################
 
 motor1_disabled:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    labels: motor1_disabled
-    limits:
-      - -50
-      - 50
-    name: motor1_disabled
-    tolerance: 0.01
-    update_frequency: 400
-  deviceTags:
-    - user motors
-  enabled: false
-  readOnly: false
+    readoutPriority: monitored
+    deviceClass: ophyd_devices.SimPositioner
+    deviceConfig:
+        delay: 1
+        labels: motor1_disabled
+        limits:
+            - -50
+            - 50
+        name: motor1_disabled
+        tolerance: 0.01
+        update_frequency: 400
+    deviceTags:
+        - user motors
+    enabled: false
+    readOnly: false
 motor1_disabled_set:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    labels: motor1_disabled_set
-    limits:
-      - -50
-      - 50
-    name: motor1_disabled_set
-    tolerance: 0.01
-    update_frequency: 400
-  deviceTags:
-    - user motors
-  enabled: true
-  readOnly: true
+    readoutPriority: baseline
+    deviceClass: ophyd_devices.SimPositioner
+    deviceConfig:
+        delay: 1
+        labels: motor1_disabled_set
+        limits:
+            - -50
+            - 50
+        name: motor1_disabled_set
+        tolerance: 0.01
+        update_frequency: 400
+    deviceTags:
+        - user motors
+    enabled: true
+    readOnly: true
 motor2_disabled:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    labels: motor2_disabled
-    limits:
-      - -50
-      - 50
-    name: motor2_disabled
-    tolerance: 0.01
-    update_frequency: 400
-  deviceTags:
-    - user motors
-  enabled: false
-  readOnly: false
+    readoutPriority: baseline
+    deviceClass: ophyd_devices.SimPositioner
+    deviceConfig:
+        delay: 1
+        labels: motor2_disabled
+        limits:
+            - -50
+            - 50
+        name: motor2_disabled
+        tolerance: 0.01
+        update_frequency: 400
+    deviceTags:
+        - user motors
+    enabled: false
+    readOnly: false
 motor2_disabled_set:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.SimPositioner
-  deviceConfig:
-    delay: 1
-    labels: motor2_disabled_set
-    limits:
-      - -50
-      - 50
-    name: motor2_disabled_set
-    tolerance: 0.01
-    update_frequency: 400
-  deviceTags:
-    - user motors
-  enabled: true
-  readOnly: true
+    readoutPriority: baseline
+    deviceClass: ophyd_devices.SimPositioner
+    deviceConfig:
+        delay: 1
+        labels: motor2_disabled_set
+        limits:
+            - -50
+            - 50
+        name: motor2_disabled_set
+        tolerance: 0.01
+        update_frequency: 400
+    deviceTags:
+        - user motors
+    enabled: true
+    readOnly: true
 ######### DeviceProxy and SimCamera for delayed init tests ##########
 proxy_cam_test:
-  readoutPriority: monitored
-  deviceClass: ophyd_devices.SimCamera
-  deviceConfig:
-    device_access: true
-  deviceTags:
-    - detector
-  enabled: true
-  readOnly: false
-  softwareTrigger: false
+    readoutPriority: monitored
+    deviceClass: ophyd_devices.SimCamera
+    deviceConfig:
+        device_access: true
+    deviceTags:
+        - detector
+    enabled: true
+    readOnly: false
+    softwareTrigger: false
 sim_proxy_test:
-  readoutPriority: on_request
-  deviceClass: ophyd_devices.SlitProxy
-  deviceConfig:
-    proxy_cam_test:
-      signal_name: image
-      center_offset: [0, 0] # [x,y]
-      covariance: [[1000, 500], [200, 1000]] # [[x,x],[y,y]]
-      pixel_size: 0.01
-      ref_motors: [samx, samy]
-      slit_width: [1, 1]
-      motor_dir: [0, 1] # x:0 , y:1, z:2 coordinates
-  enabled: true
-  readOnly: false
+    readoutPriority: on_request
+    deviceClass: ophyd_devices.SlitProxy
+    deviceConfig:
+        proxy_cam_test:
+            signal_name: image
+            center_offset: [0, 0] # [x,y]
+            covariance: [[1000, 500], [200, 1000]] # [[x,x],[y,y]]
+            pixel_size: 0.01
+            ref_motors: [samx, samy]
+            slit_width: [1, 1]
+            motor_dir: [0, 1] # x:0 , y:1, z:2 coordinates
+    enabled: true
+    readOnly: false
 rt_controller:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.sim.SimPositionerWithController
-  deviceConfig:
-    delay: 1
-    limits:
-      - -50
-      - 50
-    tolerance: 0.01
-    update_frequency: 400
-  deviceTags:
-    - user motors
-    - test device
-  enabled: true
-  readOnly: false
+    readoutPriority: baseline
+    deviceClass: ophyd_devices.sim.SimPositionerWithController
+    deviceConfig:
+        delay: 1
+        limits:
+            - -50
+            - 50
+        tolerance: 0.01
+        update_frequency: 400
+    deviceTags:
+        - user motors
+        - test device
+    enabled: true
+    readOnly: false
 device_with_not_resolving_status:
-  readoutPriority: baseline
-  deviceClass: ophyd_devices.sim.sim_test_devices.SimDeviceWithStatusStageUnstage
-  deviceConfig:
-  deviceTags:
-    - test device
-  enabled: false
-  readOnly: false
+    readoutPriority: baseline
+    deviceClass: ophyd_devices.sim.sim_test_devices.SimDeviceWithStatusStageUnstage
+    deviceConfig:
+    deviceTags:
+        - test device
+    enabled: false
+    readOnly: false

--- a/bec_lib/bec_lib/tests/utils.py
+++ b/bec_lib/bec_lib/tests/utils.py
@@ -294,6 +294,140 @@ def positioner_info_mock_with_user_access(device_name):
     return info
 
 
+# fmt: off
+DYN_SIGNALS_MSG = messages.DeviceInfoMessage(
+    device="dyn_signals",
+    info={
+        "device_info": {
+            "device_dotted_name": "dyn_signals",
+            "device_attr_name": "dyn_signals",
+            "device_base_class": "device",
+            "device_class": "SimDevice",
+            "signals": {},
+            "hints": {"fields": []},
+            "describe": {
+                "dyn_signals_messages_message1": {"source": "SIM:dyn_signals_messages_message1", "dtype": "integer", "shape": [], "precision": 3},
+                "dyn_signals_messages_message2": {"source": "SIM:dyn_signals_messages_message2", "dtype": "integer", "shape": [], "precision": 3},
+                "dyn_signals_messages_message3": {"source": "SIM:dyn_signals_messages_message3", "dtype": "integer", "shape": [], "precision": 3},
+                "dyn_signals_messages_message4": {"source": "SIM:dyn_signals_messages_message4", "dtype": "integer", "shape": [], "precision": 3},
+                "dyn_signals_messages_message5": {"source": "SIM:dyn_signals_messages_message5", "dtype": "integer", "shape": [], "precision": 3},
+            },
+            "describe_configuration": {},
+            "sub_devices": [
+                {
+                    "device_name": "dyn_signals_messages",
+                    "device_info": {
+                        "device_attr_name": "messages",
+                        "device_dotted_name": "messages",
+                        "device_base_class": "device",
+                        "device_class": "SimDevice",
+                        "signals": {
+                            "message1": {
+                                "component_name": "message1",
+                                "obj_name": "dyn_signals_messages_message1",
+                                "kind_int": 1,
+                                "kind_str": "normal",
+                                "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
+                            },
+                            "message2": {
+                                "component_name": "message2",
+                                "obj_name": "dyn_signals_messages_message2",
+                                "kind_int": 1,
+                                "kind_str": "normal",
+                                "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
+                            },
+                            "message3": {
+                                "component_name": "message3",
+                                "obj_name": "dyn_signals_messages_message3",
+                                "kind_int": 1,
+                                "kind_str": "normal",
+                                "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
+                            },
+                            "message4": {
+                                "component_name": "message4",
+                                "obj_name": "dyn_signals_messages_message4",
+                                "kind_int": 1,
+                                "kind_str": "normal",
+                                "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
+                            },
+                            "message5": {
+                                "component_name": "message5",
+                                "obj_name": "dyn_signals_messages_message5",
+                                "kind_int": 1,
+                                "kind_str": "normal",
+                                "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
+                            },
+                        },
+                        "hints": {"fields": []},
+                        "describe": {
+                            "dyn_signals_messages_message1": {"source": "SIM:dyn_signals_messages_message1", "dtype": "integer", "shape": [], "precision": 3},
+                            "dyn_signals_messages_message2": {"source": "SIM:dyn_signals_messages_message2", "dtype": "integer", "shape": [], "precision": 3},
+                            "dyn_signals_messages_message3": {"source": "SIM:dyn_signals_messages_message3", "dtype": "integer", "shape": [], "precision": 3},
+                            "dyn_signals_messages_message4": {"source": "SIM:dyn_signals_messages_message4", "dtype": "integer", "shape": [], "precision": 3},
+                            "dyn_signals_messages_message5": {"source": "SIM:dyn_signals_messages_message5", "dtype": "integer", "shape": [], "precision": 3},
+                        },
+                        "describe_configuration": {},
+                        "sub_devices": [],
+                        "custom_user_access": {},
+                    },
+                }
+            ],
+            "custom_user_access": {},
+        }
+    },
+)
+EIGER_MSG = messages.DeviceInfoMessage(
+        device="eiger",
+        info={
+            "device_info": {
+                "device_dotted_name": "eiger",
+                "device_attr_name": "eiger",
+                "device_base_class": "device",
+                "device_class": "SimCamera",
+                "signals": {
+                    "preview": {
+                        "component_name": "preview",
+                        "signal_class": "PreviewSignal",
+                        "obj_name": "eiger_preview",
+                        "kind_int": 5,
+                        "kind_str": "hinted",
+                        "doc": "",
+                        "describe": {
+                            "source": "BECMessageSignal:eiger_preview",
+                            "dtype": "DevicePreviewMessage",
+                            "shape": [],
+                            "signal_info": {
+                                "data_type": "raw",
+                                "saved": False,
+                                "ndim": 2,
+                                "scope": "scan",
+                                "role": "preview",
+                                "enabled": True,
+                                "rpc_access": False,
+                                "signals": [["preview", 5]],
+                                "signal_metadata": {"num_rotation_90": 0, "transpose": False},
+                            },
+                        },
+                        "metadata": {
+                            "connected": True,
+                            "read_access": True,
+                            "write_access": True,
+                            "timestamp": 1749046715.160324,
+                            "status": None,
+                            "severity": None,
+                            "precision": None,
+                        },
+                    }
+                },
+                "hints": {"fields": []},
+                "describe": {},
+                "describe_configuration": {},
+                "sub_devices": [],
+                "custom_user_access": {},
+            }
+        },
+    )
+# fmt: on
 def get_device_info_mock(device_name, device_class) -> messages.DeviceInfoMessage:
     if device_name == "rt_controller":
         return messages.DeviceInfoMessage(
@@ -302,140 +436,9 @@ def get_device_info_mock(device_name, device_class) -> messages.DeviceInfoMessag
     elif device_name == "samx":
         return messages.DeviceInfoMessage(device="samx", info=positioner_info_mock(device_name))
     elif device_name == "dyn_signals":
-        # fmt: off
-        return messages.DeviceInfoMessage(
-            device="dyn_signals",
-            info={
-                "device_info": {
-                    "device_dotted_name": "dyn_signals",
-                    "device_attr_name": "dyn_signals",
-                    "device_base_class": "device",
-                    "device_class": "SimDevice",
-                    "signals": {},
-                    "hints": {"fields": []},
-                    "describe": {
-                        "dyn_signals_messages_message1": {"source": "SIM:dyn_signals_messages_message1", "dtype": "integer", "shape": [], "precision": 3},
-                        "dyn_signals_messages_message2": {"source": "SIM:dyn_signals_messages_message2", "dtype": "integer", "shape": [], "precision": 3},
-                        "dyn_signals_messages_message3": {"source": "SIM:dyn_signals_messages_message3", "dtype": "integer", "shape": [], "precision": 3},
-                        "dyn_signals_messages_message4": {"source": "SIM:dyn_signals_messages_message4", "dtype": "integer", "shape": [], "precision": 3},
-                        "dyn_signals_messages_message5": {"source": "SIM:dyn_signals_messages_message5", "dtype": "integer", "shape": [], "precision": 3},
-                    },
-                    "describe_configuration": {},
-                    "sub_devices": [
-                        {
-                            "device_name": "dyn_signals_messages",
-                            "device_info": {
-                                "device_attr_name": "messages",
-                                "device_dotted_name": "messages",
-                                "device_base_class": "device",
-                                "device_class": "SimDevice",
-                                "signals": {
-                                    "message1": {
-                                        "component_name": "message1",
-                                        "obj_name": "dyn_signals_messages_message1",
-                                        "kind_int": 1,
-                                        "kind_str": "normal",
-                                        "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
-                                    },
-                                    "message2": {
-                                        "component_name": "message2",
-                                        "obj_name": "dyn_signals_messages_message2",
-                                        "kind_int": 1,
-                                        "kind_str": "normal",
-                                        "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
-                                    },
-                                    "message3": {
-                                        "component_name": "message3",
-                                        "obj_name": "dyn_signals_messages_message3",
-                                        "kind_int": 1,
-                                        "kind_str": "normal",
-                                        "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
-                                    },
-                                    "message4": {
-                                        "component_name": "message4",
-                                        "obj_name": "dyn_signals_messages_message4",
-                                        "kind_int": 1,
-                                        "kind_str": "normal",
-                                        "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
-                                    },
-                                    "message5": {
-                                        "component_name": "message5",
-                                        "obj_name": "dyn_signals_messages_message5",
-                                        "kind_int": 1,
-                                        "kind_str": "normal",
-                                        "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
-                                    },
-                                },
-                                "hints": {"fields": []},
-                                "describe": {
-                                    "dyn_signals_messages_message1": {"source": "SIM:dyn_signals_messages_message1", "dtype": "integer", "shape": [], "precision": 3},
-                                    "dyn_signals_messages_message2": {"source": "SIM:dyn_signals_messages_message2", "dtype": "integer", "shape": [], "precision": 3},
-                                    "dyn_signals_messages_message3": {"source": "SIM:dyn_signals_messages_message3", "dtype": "integer", "shape": [], "precision": 3},
-                                    "dyn_signals_messages_message4": {"source": "SIM:dyn_signals_messages_message4", "dtype": "integer", "shape": [], "precision": 3},
-                                    "dyn_signals_messages_message5": {"source": "SIM:dyn_signals_messages_message5", "dtype": "integer", "shape": [], "precision": 3},
-                                },
-                                "describe_configuration": {},
-                                "sub_devices": [],
-                                "custom_user_access": {},
-                            },
-                        }
-                    ],
-                    "custom_user_access": {},
-                }
-            },
-        )
+        return DYN_SIGNALS_MSG
     elif device_name == "eiger":
-        return messages.DeviceInfoMessage(
-            device="eiger",
-            info={
-                "device_info": {
-                    "device_dotted_name": "eiger",
-                    "device_attr_name": "eiger",
-                    "device_base_class": "device",
-                    "device_class": "SimCamera",
-                    "signals": {
-                        "preview": {
-                            "component_name": "preview",
-                            "signal_class": "PreviewSignal",
-                            "obj_name": "eiger_preview",
-                            "kind_int": 5,
-                            "kind_str": "hinted",
-                            "doc": "",
-                            "describe": {
-                                "source": "BECMessageSignal:eiger_preview",
-                                "dtype": "DevicePreviewMessage",
-                                "shape": [],
-                                "signal_info": {
-                                    "data_type": "raw",
-                                    "saved": False,
-                                    "ndim": 2,
-                                    "scope": "scan",
-                                    "role": "preview",
-                                    "enabled": True,
-                                    "rpc_access": False,
-                                    "signals": [["preview", 5]],
-                                    "signal_metadata": {"num_rotation_90": 0, "transpose": False},
-                                },
-                            },
-                            "metadata": {
-                                "connected": True,
-                                "read_access": True,
-                                "write_access": True,
-                                "timestamp": 1749046715.160324,
-                                "status": None,
-                                "severity": None,
-                                "precision": None,
-                            },
-                        }
-                    },
-                    "hints": {"fields": []},
-                    "describe": {},
-                    "describe_configuration": {},
-                    "sub_devices": [],
-                    "custom_user_access": {},
-                }
-            },
-        )
+        return EIGER_MSG
     device_base_class = "positioner" if device_class == "SimPositioner" else "signal"
     if device_base_class == "positioner":
         signals = positioner_info_mock(device_name)["device_info"]["signals"]

--- a/bec_lib/bec_lib/tests/utils.py
+++ b/bec_lib/bec_lib/tests/utils.py
@@ -106,8 +106,24 @@ class ScansMock(Scans):
         pass
 
 
-class FancyClientMock(BECClient):
-    started = False
+class ClientMock(BECClient):
+    started = True
+
+    def __init__(
+        self,
+        config: ServiceConfig | None = None,
+        connector_cls: type[RedisConnector] | None = None,
+        wait_for_server: bool = False,
+        forced: bool = False,
+    ):
+        super().__init__(config, connector_cls, wait_for_server, forced)
+        self.connector = MagicMock()
+        self.alarm_handler = MagicMock()
+        self.macros = MagicMock()
+        self.metadata = {}
+        self._load_scans()
+        self._hostname = "host_name.domain"
+        self.queue = ScanManager(ConnectorMock(""))
 
     def _start_metrics_emitter(self):
         pass
@@ -127,25 +143,6 @@ class FancyClientMock(BECClient):
             close_scan_def=self.scans.close_scan_def,
             close_scan_group=self.scans.close_scan_group,
         )
-
-
-class ClientMock(FancyClientMock):
-    started = True
-
-    def __init__(
-        self,
-        config: ServiceConfig | None = None,
-        connector_cls: type[RedisConnector] | None = None,
-        wait_for_server: bool = False,
-        forced: bool = False,
-    ):
-        super().__init__(config, connector_cls, wait_for_server, forced)
-        self.connector = MagicMock()
-        self.alarm_handler = MagicMock()
-        self.metadata = {}
-        self._load_scans()
-        self._hostname = "host_name.domain"
-        self.queue = ScanManager(ConnectorMock(""))
 
     def get_global_var(self, name: str):
         return name

--- a/bec_lib/bec_lib/tests/utils.py
+++ b/bec_lib/bec_lib/tests/utils.py
@@ -6,6 +6,7 @@ import os
 import time
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Literal
+from unittest.mock import MagicMock
 
 import bec_lib
 from bec_lib import messages
@@ -15,6 +16,7 @@ from bec_lib.devicemanager import DeviceManagerBase
 from bec_lib.endpoints import EndpointInfo, MessageEndpoints
 from bec_lib.logger import bec_logger
 from bec_lib.redis_connector import RedisConnector
+from bec_lib.scan_manager import ScanManager
 from bec_lib.scans import Scans
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -103,7 +105,15 @@ class ScansMock(Scans):
         pass
 
 
-class ClientMock(BECClient):
+class FancyClientMock(BECClient):
+    started = False
+
+    def _start_metrics_emitter(self):
+        pass
+
+    def _start_update_service_info(self):
+        pass
+
     def _load_scans(self):
         self.scans = ScansMock(self)
         builtins.__dict__["scans"] = self.scans
@@ -117,13 +127,29 @@ class ClientMock(BECClient):
             close_scan_group=self.scans.close_scan_group,
         )
 
-    # def _start_services(self):
-    #     pass
 
-    def _start_metrics_emitter(self):
-        pass
+class ClientMock(FancyClientMock):
+    started = True
 
-    def _start_update_service_info(self):
+    def __init__(
+        self,
+        config: ServiceConfig | None = None,
+        connector_cls: type[RedisConnector] | None = None,
+        wait_for_server: bool = False,
+        forced: bool = False,
+    ):
+        super().__init__(config, connector_cls, wait_for_server, forced)
+        self.connector = MagicMock()
+        self.alarm_handler = MagicMock()
+        self.metadata = {}
+        self._load_scans()
+        self._hostname = "host_name.domain"
+        self.queue = ScanManager(ConnectorMock(""))
+
+    def get_global_var(self, name: str):
+        return name
+
+    def _start_services(self):
         pass
 
 
@@ -703,7 +729,6 @@ class DMClientMock(DeviceManagerBase):
 
 
 class PipelineMock:  # pragma: no cover
-
     def __init__(self, connector) -> None:
         self._pipe_buffer = []
         self._connector = connector

--- a/bec_lib/bec_lib/tests/utils.py
+++ b/bec_lib/bec_lib/tests/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import builtins
 import copy
 import os
+import threading
 import time
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Literal
@@ -153,9 +154,9 @@ class ClientMock(FancyClientMock):
         pass
 
 
-def get_device_info_mock(device_name, device_class) -> messages.DeviceInfoMessage:
-
-    positioner_info = {
+def positioner_info_mock(device_name):
+    # fmt: off
+    return {
         "device_info": {
             "device_base_class": "positioner",
             "device_class": "SimPositioner",
@@ -166,21 +167,8 @@ def get_device_info_mock(device_name, device_class) -> messages.DeviceInfoMessag
                     "kind_int": 5,
                     "kind_str": "hinted",
                     "doc": "readback doc string",
-                    "describe": {
-                        "source": f"SIM:{device_name}",
-                        "dtype": "integer",
-                        "shape": [],
-                        "precision": 3,
-                    },
-                    "metadata": {
-                        "connected": True,
-                        "read_access": True,
-                        "write_access": False,
-                        "timestamp": 0,
-                        "status": None,
-                        "severity": None,
-                        "precision": None,
-                    },
+                    "describe": {"source": f"SIM:{device_name}", "dtype": "integer", "shape": [], "precision": 3},
+                    "metadata": {"connected": True, "read_access": True, "write_access": False, "timestamp": 0, "status": None, "severity": None, "precision": None},
                 },
                 "setpoint": {
                     "component_name": "setpoint",
@@ -188,21 +176,8 @@ def get_device_info_mock(device_name, device_class) -> messages.DeviceInfoMessag
                     "kind_int": 1,
                     "kind_str": "normal",
                     "doc": "setpoint doc string",
-                    "describe": {
-                        "source": f"SIM:{device_name}_setpoint",
-                        "dtype": "integer",
-                        "shape": [],
-                        "precision": 3,
-                    },
-                    "metadata": {
-                        "connected": True,
-                        "read_access": True,
-                        "write_access": True,
-                        "timestamp": 0,
-                        "status": None,
-                        "severity": None,
-                        "precision": None,
-                    },
+                    "describe": {"source": f"SIM:{device_name}_setpoint", "dtype": "integer", "shape": [], "precision": 3},
+                    "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
                 },
                 "motor_is_moving": {
                     "component_name": "motor_is_moving",
@@ -210,21 +185,8 @@ def get_device_info_mock(device_name, device_class) -> messages.DeviceInfoMessag
                     "kind_int": 1,
                     "kind_str": "normal",
                     "doc": "motor_is_moving doc string",
-                    "describe": {
-                        "source": f"SIM:{device_name}_motor_is_moving",
-                        "dtype": "integer",
-                        "shape": [],
-                        "precision": 3,
-                    },
-                    "metadata": {
-                        "connected": True,
-                        "read_access": True,
-                        "write_access": True,
-                        "timestamp": 0,
-                        "status": None,
-                        "severity": None,
-                        "precision": None,
-                    },
+                    "describe": {"source": f"SIM:{device_name}_motor_is_moving", "dtype": "integer", "shape": [], "precision": 3},
+                    "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
                 },
                 "velocity": {
                     "component_name": "velocity",
@@ -232,21 +194,8 @@ def get_device_info_mock(device_name, device_class) -> messages.DeviceInfoMessag
                     "kind_int": 2,
                     "kind_str": "config",
                     "doc": "velocity doc string",
-                    "describe": {
-                        "source": f"SIM:{device_name}_velocity",
-                        "dtype": "integer",
-                        "shape": [],
-                        "precision": 3,
-                    },
-                    "metadata": {
-                        "connected": True,
-                        "read_access": True,
-                        "write_access": True,
-                        "timestamp": 0,
-                        "status": None,
-                        "severity": None,
-                        "precision": None,
-                    },
+                    "describe": {"source": f"SIM:{device_name}_velocity", "dtype": "integer", "shape": [], "precision": 3},
+                    "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
                 },
                 "acceleration": {
                     "component_name": "acceleration",
@@ -254,21 +203,8 @@ def get_device_info_mock(device_name, device_class) -> messages.DeviceInfoMessag
                     "kind_int": 2,
                     "kind_str": "config",
                     "doc": "acceleration doc string",
-                    "describe": {
-                        "source": f"SIM:{device_name}_acceleration",
-                        "dtype": "integer",
-                        "shape": [],
-                        "precision": 3,
-                    },
-                    "metadata": {
-                        "connected": True,
-                        "read_access": True,
-                        "write_access": True,
-                        "timestamp": 0,
-                        "status": None,
-                        "severity": None,
-                        "precision": None,
-                    },
+                    "describe": {"source": f"SIM:{device_name}_acceleration", "dtype": "integer", "shape": [], "precision": 3},
+                    "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
                 },
                 "high_limit_travel": {
                     "component_name": "high_limit_travel",
@@ -276,21 +212,8 @@ def get_device_info_mock(device_name, device_class) -> messages.DeviceInfoMessag
                     "kind_int": 2,
                     "kind_str": "config",
                     "doc": "",
-                    "describe": {
-                        "source": f"SIM:{device_name}_high_limit_travel",
-                        "dtype": "integer",
-                        "shape": [],
-                        "precision": 3,
-                    },
-                    "metadata": {
-                        "connected": True,
-                        "read_access": True,
-                        "write_access": True,
-                        "timestamp": 0,
-                        "status": None,
-                        "severity": None,
-                        "precision": None,
-                    },
+                    "describe": {"source": f"SIM:{device_name}_high_limit_travel", "dtype": "integer", "shape": [], "precision": 3},
+                    "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
                 },
                 "low_limit_travel": {
                     "component_name": "low_limit_travel",
@@ -298,21 +221,8 @@ def get_device_info_mock(device_name, device_class) -> messages.DeviceInfoMessag
                     "kind_int": 2,
                     "kind_str": "config",
                     "doc": "",
-                    "describe": {
-                        "source": f"SIM:{device_name}_low_limit_travel",
-                        "dtype": "integer",
-                        "shape": [],
-                        "precision": 3,
-                    },
-                    "metadata": {
-                        "connected": True,
-                        "read_access": True,
-                        "write_access": True,
-                        "timestamp": 0,
-                        "status": None,
-                        "severity": None,
-                        "precision": None,
-                    },
+                    "describe": {"source": f"SIM:{device_name}_low_limit_travel", "dtype": "integer", "shape": [], "precision": 3},
+                    "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
                 },
                 "unused": {
                     "component_name": "unused",
@@ -320,62 +230,31 @@ def get_device_info_mock(device_name, device_class) -> messages.DeviceInfoMessag
                     "kind_int": 0,
                     "kind_str": "omitted",
                     "doc": "",
-                    "describe": {
-                        "source": f"SIM:{device_name}_unused",
-                        "dtype": "integer",
-                        "shape": [],
-                        "precision": 3,
-                    },
-                    "metadata": {
-                        "connected": True,
-                        "read_access": True,
-                        "write_access": True,
-                        "timestamp": 0,
-                        "status": None,
-                        "severity": None,
-                        "precision": None,
-                    },
+                    "describe": {"source": f"SIM:{device_name}_unused", "dtype": "integer", "shape": [], "precision": 3},
+                    "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
                 },
             },
             "hints": {"fields": [device_name]},
             "describe": {
-                device_name: {
-                    "source": f"SIM:{device_name}",
-                    "dtype": "integer",
-                    "shape": [],
-                    "precision": 3,
-                },
-                f"{device_name}_setpoint": {
-                    "source": f"SIM:{device_name}_setpoint",
-                    "dtype": "integer",
-                    "shape": [],
-                    "precision": 3,
-                },
-                f"{device_name}_motor_is_moving": {
-                    "source": f"SIM:{device_name}_motor_is_moving",
-                    "dtype": "integer",
-                    "shape": [],
-                    "precision": 3,
-                },
+                device_name: {"source": f"SIM:{device_name}", "dtype": "integer", "shape": [], "precision": 3},
+                f"{device_name}_setpoint": {"source": f"SIM:{device_name}_setpoint", "dtype": "integer", "shape": [], "precision": 3},
+                f"{device_name}_motor_is_moving": {"source": f"SIM:{device_name}_motor_is_moving", "dtype": "integer", "shape": [], "precision": 3},
             },
             "describe_configuration": {
-                f"{device_name}_velocity": {
-                    "source": f"SIM:{device_name}_velocity",
-                    "dtype": "integer",
-                    "shape": [],
-                },
-                f"{device_name}_acceleration": {
-                    "source": f"SIM:{device_name}_acceleration",
-                    "dtype": "integer",
-                    "shape": [],
-                },
+                f"{device_name}_velocity": {"source": f"SIM:{device_name}_velocity", "dtype": "integer", "shape": []},
+                f"{device_name}_acceleration": {"source": f"SIM:{device_name}_acceleration", "dtype": "integer", "shape": []},
             },
             "sub_devices": [],
             "custom_user_access": {},
         }
     }
-    positioner_info_with_user_access = copy.deepcopy(positioner_info)
-    positioner_info_with_user_access["device_info"]["custom_user_access"].update(
+    # fmt: on
+
+
+def positioner_info_mock_with_user_access(device_name):
+    info = positioner_info_mock(device_name)
+    # fmt: off
+    info["device_info"]["custom_user_access"].update(
         {
             "dummy_controller": {
                 "device_class": "DummyController",
@@ -384,62 +263,20 @@ def get_device_info_mock(device_name, device_class) -> messages.DeviceInfoMessag
                         "type": "func",
                         "doc": None,
                         "signature": [
-                            {
-                                "name": "arg1",
-                                "kind": "POSITIONAL_OR_KEYWORD",
-                                "default": "_empty",
-                                "annotation": "float",
-                            },
-                            {
-                                "name": "arg2",
-                                "kind": "POSITIONAL_OR_KEYWORD",
-                                "default": "_empty",
-                                "annotation": "int",
-                            },
+                            {"name": "arg1", "kind": "POSITIONAL_OR_KEYWORD", "default": "_empty", "annotation": "float"},
+                            {"name": "arg2", "kind": "POSITIONAL_OR_KEYWORD", "default": "_empty", "annotation": "int"},
                         ],
                     },
-                    "_func_with_args": {
-                        "type": "func",
-                        "doc": None,
-                        "signature": [
-                            {
-                                "name": "args",
-                                "kind": "VAR_POSITIONAL",
-                                "default": "_empty",
-                                "annotation": "_empty",
-                            }
-                        ],
-                    },
+                    "_func_with_args": {"type": "func", "doc": None, "signature": [{"name": "args", "kind": "VAR_POSITIONAL", "default": "_empty", "annotation": "_empty"}]},
                     "_func_with_args_and_kwargs": {
                         "type": "func",
                         "doc": None,
                         "signature": [
-                            {
-                                "name": "args",
-                                "kind": "VAR_POSITIONAL",
-                                "default": "_empty",
-                                "annotation": "_empty",
-                            },
-                            {
-                                "name": "kwargs",
-                                "kind": "VAR_KEYWORD",
-                                "default": "_empty",
-                                "annotation": "_empty",
-                            },
+                            {"name": "args", "kind": "VAR_POSITIONAL", "default": "_empty", "annotation": "_empty"},
+                            {"name": "kwargs", "kind": "VAR_KEYWORD", "default": "_empty", "annotation": "_empty"},
                         ],
                     },
-                    "_func_with_kwargs": {
-                        "type": "func",
-                        "doc": None,
-                        "signature": [
-                            {
-                                "name": "kwargs",
-                                "kind": "VAR_KEYWORD",
-                                "default": "_empty",
-                                "annotation": "_empty",
-                            }
-                        ],
-                    },
+                    "_func_with_kwargs": {"type": "func", "doc": None, "signature": [{"name": "kwargs", "kind": "VAR_KEYWORD", "default": "_empty", "annotation": "_empty"}]},
                     "_func_without_args_kwargs": {"type": "func", "doc": None, "signature": []},
                     "controller_show_all": {
                         "type": "func",
@@ -453,12 +290,20 @@ def get_device_info_mock(device_name, device_class) -> messages.DeviceInfoMessag
             }
         }
     )
-    device_info = {
-        "rt_controller": messages.DeviceInfoMessage(
-            device="rt_controller", info=positioner_info_with_user_access
-        ),
-        "samx": messages.DeviceInfoMessage(device="samx", info=positioner_info),
-        "dyn_signals": messages.DeviceInfoMessage(
+    # fmt: on
+    return info
+
+
+def get_device_info_mock(device_name, device_class) -> messages.DeviceInfoMessage:
+    if device_name == "rt_controller":
+        return messages.DeviceInfoMessage(
+            device="rt_controller", info=positioner_info_mock_with_user_access(device_name)
+        )
+    elif device_name == "samx":
+        return messages.DeviceInfoMessage(device="samx", info=positioner_info_mock(device_name))
+    elif device_name == "dyn_signals":
+        # fmt: off
+        return messages.DeviceInfoMessage(
             device="dyn_signals",
             info={
                 "device_info": {
@@ -469,36 +314,11 @@ def get_device_info_mock(device_name, device_class) -> messages.DeviceInfoMessag
                     "signals": {},
                     "hints": {"fields": []},
                     "describe": {
-                        "dyn_signals_messages_message1": {
-                            "source": "SIM:dyn_signals_messages_message1",
-                            "dtype": "integer",
-                            "shape": [],
-                            "precision": 3,
-                        },
-                        "dyn_signals_messages_message2": {
-                            "source": "SIM:dyn_signals_messages_message2",
-                            "dtype": "integer",
-                            "shape": [],
-                            "precision": 3,
-                        },
-                        "dyn_signals_messages_message3": {
-                            "source": "SIM:dyn_signals_messages_message3",
-                            "dtype": "integer",
-                            "shape": [],
-                            "precision": 3,
-                        },
-                        "dyn_signals_messages_message4": {
-                            "source": "SIM:dyn_signals_messages_message4",
-                            "dtype": "integer",
-                            "shape": [],
-                            "precision": 3,
-                        },
-                        "dyn_signals_messages_message5": {
-                            "source": "SIM:dyn_signals_messages_message5",
-                            "dtype": "integer",
-                            "shape": [],
-                            "precision": 3,
-                        },
+                        "dyn_signals_messages_message1": {"source": "SIM:dyn_signals_messages_message1", "dtype": "integer", "shape": [], "precision": 3},
+                        "dyn_signals_messages_message2": {"source": "SIM:dyn_signals_messages_message2", "dtype": "integer", "shape": [], "precision": 3},
+                        "dyn_signals_messages_message3": {"source": "SIM:dyn_signals_messages_message3", "dtype": "integer", "shape": [], "precision": 3},
+                        "dyn_signals_messages_message4": {"source": "SIM:dyn_signals_messages_message4", "dtype": "integer", "shape": [], "precision": 3},
+                        "dyn_signals_messages_message5": {"source": "SIM:dyn_signals_messages_message5", "dtype": "integer", "shape": [], "precision": 3},
                     },
                     "describe_configuration": {},
                     "sub_devices": [
@@ -515,109 +335,44 @@ def get_device_info_mock(device_name, device_class) -> messages.DeviceInfoMessag
                                         "obj_name": "dyn_signals_messages_message1",
                                         "kind_int": 1,
                                         "kind_str": "normal",
-                                        "metadata": {
-                                            "connected": True,
-                                            "read_access": True,
-                                            "write_access": True,
-                                            "timestamp": 0,
-                                            "status": None,
-                                            "severity": None,
-                                            "precision": None,
-                                        },
+                                        "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
                                     },
                                     "message2": {
                                         "component_name": "message2",
                                         "obj_name": "dyn_signals_messages_message2",
                                         "kind_int": 1,
                                         "kind_str": "normal",
-                                        "metadata": {
-                                            "connected": True,
-                                            "read_access": True,
-                                            "write_access": True,
-                                            "timestamp": 0,
-                                            "status": None,
-                                            "severity": None,
-                                            "precision": None,
-                                        },
+                                        "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
                                     },
                                     "message3": {
                                         "component_name": "message3",
                                         "obj_name": "dyn_signals_messages_message3",
                                         "kind_int": 1,
                                         "kind_str": "normal",
-                                        "metadata": {
-                                            "connected": True,
-                                            "read_access": True,
-                                            "write_access": True,
-                                            "timestamp": 0,
-                                            "status": None,
-                                            "severity": None,
-                                            "precision": None,
-                                        },
+                                        "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
                                     },
                                     "message4": {
                                         "component_name": "message4",
                                         "obj_name": "dyn_signals_messages_message4",
                                         "kind_int": 1,
                                         "kind_str": "normal",
-                                        "metadata": {
-                                            "connected": True,
-                                            "read_access": True,
-                                            "write_access": True,
-                                            "timestamp": 0,
-                                            "status": None,
-                                            "severity": None,
-                                            "precision": None,
-                                        },
+                                        "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
                                     },
                                     "message5": {
                                         "component_name": "message5",
                                         "obj_name": "dyn_signals_messages_message5",
                                         "kind_int": 1,
                                         "kind_str": "normal",
-                                        "metadata": {
-                                            "connected": True,
-                                            "read_access": True,
-                                            "write_access": True,
-                                            "timestamp": 0,
-                                            "status": None,
-                                            "severity": None,
-                                            "precision": None,
-                                        },
+                                        "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
                                     },
                                 },
                                 "hints": {"fields": []},
                                 "describe": {
-                                    "dyn_signals_messages_message1": {
-                                        "source": "SIM:dyn_signals_messages_message1",
-                                        "dtype": "integer",
-                                        "shape": [],
-                                        "precision": 3,
-                                    },
-                                    "dyn_signals_messages_message2": {
-                                        "source": "SIM:dyn_signals_messages_message2",
-                                        "dtype": "integer",
-                                        "shape": [],
-                                        "precision": 3,
-                                    },
-                                    "dyn_signals_messages_message3": {
-                                        "source": "SIM:dyn_signals_messages_message3",
-                                        "dtype": "integer",
-                                        "shape": [],
-                                        "precision": 3,
-                                    },
-                                    "dyn_signals_messages_message4": {
-                                        "source": "SIM:dyn_signals_messages_message4",
-                                        "dtype": "integer",
-                                        "shape": [],
-                                        "precision": 3,
-                                    },
-                                    "dyn_signals_messages_message5": {
-                                        "source": "SIM:dyn_signals_messages_message5",
-                                        "dtype": "integer",
-                                        "shape": [],
-                                        "precision": 3,
-                                    },
+                                    "dyn_signals_messages_message1": {"source": "SIM:dyn_signals_messages_message1", "dtype": "integer", "shape": [], "precision": 3},
+                                    "dyn_signals_messages_message2": {"source": "SIM:dyn_signals_messages_message2", "dtype": "integer", "shape": [], "precision": 3},
+                                    "dyn_signals_messages_message3": {"source": "SIM:dyn_signals_messages_message3", "dtype": "integer", "shape": [], "precision": 3},
+                                    "dyn_signals_messages_message4": {"source": "SIM:dyn_signals_messages_message4", "dtype": "integer", "shape": [], "precision": 3},
+                                    "dyn_signals_messages_message5": {"source": "SIM:dyn_signals_messages_message5", "dtype": "integer", "shape": [], "precision": 3},
                                 },
                                 "describe_configuration": {},
                                 "sub_devices": [],
@@ -628,8 +383,9 @@ def get_device_info_mock(device_name, device_class) -> messages.DeviceInfoMessag
                     "custom_user_access": {},
                 }
             },
-        ),
-        "eiger": messages.DeviceInfoMessage(
+        )
+    elif device_name == "eiger":
+        return messages.DeviceInfoMessage(
             device="eiger",
             info={
                 "device_info": {
@@ -679,14 +435,10 @@ def get_device_info_mock(device_name, device_class) -> messages.DeviceInfoMessag
                     "custom_user_access": {},
                 }
             },
-        ),
-    }
-    if device_name in device_info:
-        return device_info[device_name]
-
+        )
     device_base_class = "positioner" if device_class == "SimPositioner" else "signal"
     if device_base_class == "positioner":
-        signals = positioner_info["device_info"]["signals"]
+        signals = positioner_info_mock(device_name)["device_info"]["signals"]
     elif device_base_class == "signal":
         signals = {
             device_name: {
@@ -714,7 +466,7 @@ def get_device_info_mock(device_name, device_class) -> messages.DeviceInfoMessag
         },
         "custom_user_access": {},
     }
-
+    # fmt: on
     return messages.DeviceInfoMessage(device=device_name, info=dev_info, metadata={})
 
 

--- a/bec_lib/tests/test_client.py
+++ b/bec_lib/tests/test_client.py
@@ -3,7 +3,7 @@
 import pytest
 
 from bec_lib.client import SystemConfig
-from bec_lib.tests.fixtures import bec_client_mock
+from bec_lib.tests.fixtures import fancy_bec_client_mock
 
 
 def test_system_config():
@@ -23,9 +23,9 @@ def test_system_config():
         config = SystemConfig(file_directory="ä")
 
 
-def test_show_all_commands(bec_client_mock, capsys):
+def test_show_all_commands(fancy_bec_client_mock, capsys):
     """Test the show_all_commands method."""
-    client = bec_client_mock
+    client = fancy_bec_client_mock
     client.show_all_commands()
     captured = capsys.readouterr()
     assert "User macros" in captured.out

--- a/bec_lib/tests/test_client.py
+++ b/bec_lib/tests/test_client.py
@@ -3,7 +3,7 @@
 import pytest
 
 from bec_lib.client import SystemConfig
-from bec_lib.tests.fixtures import fancy_bec_client_mock
+from bec_lib.tests.fixtures import bec_client_mock
 
 
 def test_system_config():
@@ -23,9 +23,9 @@ def test_system_config():
         config = SystemConfig(file_directory="ä")
 
 
-def test_show_all_commands(fancy_bec_client_mock, capsys):
+def test_show_all_commands(bec_client_mock, capsys):
     """Test the show_all_commands method."""
-    client = fancy_bec_client_mock
+    client = bec_client_mock
     client.show_all_commands()
     captured = capsys.readouterr()
     assert "User macros" in captured.out

--- a/bec_lib/tests/test_scan_context.py
+++ b/bec_lib/tests/test_scan_context.py
@@ -1,9 +1,9 @@
+import builtins
 from typing import Annotated
 from unittest import mock
 
 import pytest
 
-from bec_lib.device import DeviceBase
 from bec_lib.scan_args import ScanArgument
 from bec_lib.scans import (
     DatasetIdOnHold,
@@ -23,25 +23,28 @@ from bec_lib.signature_serializer import serialize_dtype
 # pylint: disable=protected-access
 
 
-def test_filewriter_cm(fancy_bec_client_mock):
-    client = fancy_bec_client_mock
-    client.scans._file_writer = None
-    client.system_config.file_directory = None
-    client.system_config.file_suffix = None
-    with FileWriter(file_suffix="testsuffix", file_directory="testdirectory"):
-        assert client.system_config.file_directory == "testdirectory"
-        assert client.system_config.file_suffix == "testsuffix"
-    assert client.system_config.file_directory is None
-    assert client.system_config.file_suffix is None
+def test_filewriter_cm(bec_client_mock):
+    client = bec_client_mock
+    with mock.patch.dict(builtins.__dict__, {"bec": client}):
+        client.scans._file_writer = None
+        client.system_config.file_directory = None
+        client.system_config.file_suffix = None
+        with FileWriter(file_suffix="testsuffix", file_directory="testdirectory"):
+            assert client.system_config.file_directory == "testdirectory"
+            assert client.system_config.file_suffix == "testsuffix"
+        assert client.system_config.file_directory is None
+        assert client.system_config.file_suffix is None
 
 
-def test_metadata_handler(fancy_bec_client_mock):
-    client = fancy_bec_client_mock
-    client.metadata = {"descr": "test", "uid": "12345"}
-    with Metadata({"descr": "alignment", "pol": 1}):
-        assert client.metadata == {"descr": "alignment", "uid": "12345", "pol": 1}
+def test_metadata_handler(bec_client_mock):
+    client = bec_client_mock
 
-    assert client.metadata == {"descr": "test", "uid": "12345"}
+    with mock.patch.dict(builtins.__dict__, {"bec": client}):
+        client.metadata = {"descr": "test", "uid": "12345"}
+        with Metadata({"descr": "alignment", "pol": 1}):
+            assert client.metadata == {"descr": "alignment", "uid": "12345", "pol": 1}
+
+        assert client.metadata == {"descr": "test", "uid": "12345"}
 
 
 def test_hide_report_cm(bec_client_mock):
@@ -193,40 +196,42 @@ def test_strip_scan_signature_annotations_for_ipython_signature():
     ]
 
 
-def test_interactive_scan_cm(fancy_bec_client_mock):
-    client = fancy_bec_client_mock
-    client.scans._open_interactive_scan = mock.MagicMock()
-    client.scans._close_interactive_scan = mock.MagicMock()
-    client.scans._interactive_trigger = mock.MagicMock()
-    client.scans._interactive_read_monitored = mock.MagicMock()
+def test_interactive_scan_cm(bec_client_mock):
+    client = bec_client_mock
+    with mock.patch.dict(builtins.__dict__, {"bec": client}):
+        client.scans._open_interactive_scan = mock.MagicMock()
+        client.scans._close_interactive_scan = mock.MagicMock()
+        client.scans._interactive_trigger = mock.MagicMock()
+        client.scans._interactive_read_monitored = mock.MagicMock()
 
-    with client.scans.interactive_scan("samx") as scan:
-        scan.trigger()
-        scan.read_monitored_devices()
-
-    client.scans._open_interactive_scan.assert_called_once()
-    client.scans._close_interactive_scan.assert_called_once()
-    client.scans._interactive_trigger.assert_called_once()
-    client.scans._interactive_read_monitored.assert_called_once()
-
-
-def test_interactive_scan_cm_raise_calls_close(fancy_bec_client_mock):
-    client = fancy_bec_client_mock
-    client.scans._open_interactive_scan = mock.MagicMock()
-    client.scans._close_interactive_scan = mock.MagicMock()
-    client.scans._interactive_trigger = mock.MagicMock()
-    client.scans._interactive_read_monitored = mock.MagicMock()
-
-    with pytest.raises(AttributeError):
         with client.scans.interactive_scan("samx") as scan:
             scan.trigger()
             scan.read_monitored_devices()
-            raise AttributeError()
 
-    client.scans._open_interactive_scan.assert_called_once()
-    client.scans._close_interactive_scan.assert_called_once()
-    client.scans._interactive_trigger.assert_called_once()
-    client.scans._interactive_read_monitored.assert_called_once()
+        client.scans._open_interactive_scan.assert_called_once()
+        client.scans._close_interactive_scan.assert_called_once()
+        client.scans._interactive_trigger.assert_called_once()
+        client.scans._interactive_read_monitored.assert_called_once()
+
+
+def test_interactive_scan_cm_raise_calls_close(bec_client_mock):
+    client = bec_client_mock
+    with mock.patch.dict(builtins.__dict__, {"bec": client}):
+        client.scans._open_interactive_scan = mock.MagicMock()
+        client.scans._close_interactive_scan = mock.MagicMock()
+        client.scans._interactive_trigger = mock.MagicMock()
+        client.scans._interactive_read_monitored = mock.MagicMock()
+
+        with pytest.raises(AttributeError):
+            with client.scans.interactive_scan("samx") as scan:
+                scan.trigger()
+                scan.read_monitored_devices()
+                raise AttributeError()
+
+        client.scans._open_interactive_scan.assert_called_once()
+        client.scans._close_interactive_scan.assert_called_once()
+        client.scans._interactive_trigger.assert_called_once()
+        client.scans._interactive_read_monitored.assert_called_once()
 
 
 def test_interactive_scan_cm_raises_scan_motors(bec_client_mock):

--- a/bec_lib/tests/test_scan_context.py
+++ b/bec_lib/tests/test_scan_context.py
@@ -23,8 +23,8 @@ from bec_lib.signature_serializer import serialize_dtype
 # pylint: disable=protected-access
 
 
-def test_filewriter_cm(bec_client_mock):
-    client = bec_client_mock
+def test_filewriter_cm(fancy_bec_client_mock):
+    client = fancy_bec_client_mock
     client.scans._file_writer = None
     client.system_config.file_directory = None
     client.system_config.file_suffix = None
@@ -35,8 +35,8 @@ def test_filewriter_cm(bec_client_mock):
     assert client.system_config.file_suffix is None
 
 
-def test_metadata_handler(bec_client_mock):
-    client = bec_client_mock
+def test_metadata_handler(fancy_bec_client_mock):
+    client = fancy_bec_client_mock
     client.metadata = {"descr": "test", "uid": "12345"}
     with Metadata({"descr": "alignment", "pol": 1}):
         assert client.metadata == {"descr": "alignment", "uid": "12345", "pol": 1}
@@ -193,8 +193,8 @@ def test_strip_scan_signature_annotations_for_ipython_signature():
     ]
 
 
-def test_interactive_scan_cm(bec_client_mock):
-    client = bec_client_mock
+def test_interactive_scan_cm(fancy_bec_client_mock):
+    client = fancy_bec_client_mock
     client.scans._open_interactive_scan = mock.MagicMock()
     client.scans._close_interactive_scan = mock.MagicMock()
     client.scans._interactive_trigger = mock.MagicMock()
@@ -210,8 +210,8 @@ def test_interactive_scan_cm(bec_client_mock):
     client.scans._interactive_read_monitored.assert_called_once()
 
 
-def test_interactive_scan_cm_raise_calls_close(bec_client_mock):
-    client = bec_client_mock
+def test_interactive_scan_cm_raise_calls_close(fancy_bec_client_mock):
+    client = fancy_bec_client_mock
     client.scans._open_interactive_scan = mock.MagicMock()
     client.scans._close_interactive_scan = mock.MagicMock()
     client.scans._interactive_trigger = mock.MagicMock()


### PR DESCRIPTION
Changes the existing `ClientMock` which initialises a bunch of stuff to `FancyClientMock`, and introduces a simpler `ClientMock` which doesn't, which can be used in most cases. Removes many unused devices from the test config.