### PR TITLE
feat: add scan modifier

### DIFF
--- a/bec_lib/bec_lib/plugin_helper.py
+++ b/bec_lib/bec_lib/plugin_helper.py
@@ -5,13 +5,14 @@ import importlib.metadata
 import inspect
 import json
 from functools import cache, lru_cache
-from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, Type
 
 from bec_lib.logger import bec_logger
 
 if TYPE_CHECKING:  # pragma: no cover
     from bec_lib.metadata_schema import BasicScanMetadata
+    from bec_server.scan_server.scans.scan_modifier import ScanModifier
+
 
 logger = bec_logger.logger
 
@@ -70,6 +71,24 @@ def get_scan_plugins() -> dict:
                 logger.warning(f"Duplicated scan plugin {name}.")
             loaded_plugins[name] = mod_cls
     return loaded_plugins
+
+
+def get_scan_modifier_plugin() -> Type[ScanModifier] | None:
+    """
+    Load all scan modifier plugins.
+
+    Returns:
+        Type[ScanModifier]: The scan modifier class.
+    """
+    from bec_server.scan_server.scans.scan_modifier import ScanModifier
+
+    modules = _get_available_plugins("bec.scans.scan_modifier")
+    for module in modules:
+        mods = inspect.getmembers(module, predicate=_filter_plugins)
+        for _, mod_cls in mods:
+            if issubclass(mod_cls, ScanModifier):
+                return mod_cls
+    return None
 
 
 def get_file_writer_plugins() -> dict:

--- a/bec_lib/bec_lib/scan_args.py
+++ b/bec_lib/bec_lib/scan_args.py
@@ -17,6 +17,10 @@ class ScanArgument(BaseModel):
     expert: Annotated[bool, Field(description="Whether the argument is for expert users only")] = (
         False
     )
+    hidden: Annotated[
+        bool, Field(description="Whether the argument should be hidden in the UI")
+    ] = False
+    example: Annotated[Any | None, Field(description="Example value for the argument")] = None
     units: Annotated[
         str | pint.Unit | PlainQuantity[Any] | None, Field(description="Units of the argument")
     ] = None
@@ -112,28 +116,62 @@ class DefaultArgType:
         ),
     ]
     ExposureTime: TypeAlias = Annotated[
-        float, ScanArgument(display_name="Exposure Time", units=Units.s, ge=0)
+        float,
+        ScanArgument(
+            display_name="Exposure Time",
+            description="Exposure time in seconds",
+            units=Units.s,
+            ge=0,
+        ),
     ]
     FramesPerTrigger: TypeAlias = Annotated[
-        int, ScanArgument(display_name="Frames per Trigger", ge=1)
+        int,
+        ScanArgument(
+            display_name="Frames per Trigger",
+            description="Number of frames per trigger for devices that support configurable frame counts per trigger.",
+            ge=1,
+        ),
     ]
     SettlingTime: TypeAlias = Annotated[
-        float, ScanArgument(display_name="Settling Time", units=Units.s, ge=0)
+        float,
+        ScanArgument(
+            display_name="Settling Time",
+            description="Time to settle before trigger and readout.",
+            units=Units.s,
+            ge=0,
+        ),
     ]
     SettlingTimeAfterTrigger: TypeAlias = Annotated[
-        float, ScanArgument(display_name="Settling Time After Trigger", units=Units.s, ge=0)
+        float,
+        ScanArgument(
+            display_name="Settling Time After Trigger",
+            description="Time to settle after the trigger but before the readout.",
+            units=Units.s,
+            ge=0,
+        ),
     ]
     ReadoutTime: TypeAlias = Annotated[
-        float, ScanArgument(display_name="Readout Time", units=Units.s, ge=0)
+        float,
+        ScanArgument(
+            display_name="Readout Time",
+            description="Configuration for devices that support configurable readout times.",
+            units=Units.s,
+            ge=0,
+        ),
     ]
     BurstAtEachPoint: TypeAlias = Annotated[
-        int, ScanArgument(display_name="Burst at Each Point", ge=1)
+        int,
+        ScanArgument(
+            display_name="Burst at Each Point",
+            description="Number of triggers and readouts at each point.",
+            ge=1,
+        ),
     ]
     OptimizeTrajectory: TypeAlias = Annotated[
         Literal["corridor", "shell", "nearest", None],
         ScanArgument(
             display_name="Optimize Trajectory",
-            description="Method for optimizing the scan trajectory",
+            description="Method for optimizing the scan trajectory.",
         ),
     ]
 

--- a/bec_lib/bec_lib/scan_input_validator.py
+++ b/bec_lib/bec_lib/scan_input_validator.py
@@ -58,6 +58,8 @@ class ScanInputValidator:
             scan_info, args, kwargs, uses_arg_input_bundle
         )
 
+        # TODO: Remove the section until ---> here <--- once we have migrated all scans
+        # to v4-type scans
         required_kwargs = scan_info.get("required_kwargs") or []
         required_names = (
             required_kwargs.keys() if isinstance(required_kwargs, dict) else required_kwargs
@@ -70,6 +72,8 @@ class ScanInputValidator:
                 f"{scan_info.get('doc')}\n Not all required keyword arguments have been"
                 f" specified. The required arguments are: {required_kwargs}"
             )
+
+        # ---> here <---
 
         if arg_input:
             self._validate_arg_input(scan_name, scan_info, args, arg_input)
@@ -407,6 +411,8 @@ class ScanInputValidator:
             scan_argument = self._scan_argument_from_annotation(parameter.annotation)
             if scan_argument is None:
                 continue
+            if not self._scan_argument_has_bounds(scan_argument):
+                continue
             self._validate_scan_argument_bounds(name, value, parameter.annotation, scan_argument)
 
     def _validate_value(self, *, arg_name: str, value: Any, annotation: Any, index: int) -> None:
@@ -433,8 +439,17 @@ class ScanInputValidator:
         scan_argument = self._scan_argument_from_annotation(annotation)
         if scan_argument is None:
             return
+        if not self._scan_argument_has_bounds(scan_argument):
+            return
 
         self._validate_scan_argument_bounds(arg_name, value, annotation, scan_argument)
+
+    def _scan_argument_has_bounds(self, scan_argument: ScanArgument) -> bool:
+        """Return whether a ``ScanArgument`` declares any numeric bounds."""
+        return any(
+            limit is not None
+            for limit in (scan_argument.gt, scan_argument.ge, scan_argument.lt, scan_argument.le)
+        )
 
     def _validate_scan_argument_bounds(
         self, arg_name: str, value: Any, annotation: Any, scan_argument: ScanArgument

--- a/bec_lib/bec_lib/signature_serializer.py
+++ b/bec_lib/bec_lib/signature_serializer.py
@@ -234,36 +234,47 @@ def deserialize_dtype(dtype: list | dict | str) -> object:
         return simple_dtype
 
 
-def signature_to_dict(func: Callable, include_class_obj=False) -> list[dict]:
+def signature_to_dict(
+    func: Callable | inspect.Signature, include_class_obj: bool = False
+) -> list[dict]:
     """
     Convert a function signature to a dictionary.
     The dictionary can be used to reconstruct the signature using dict_to_signature.
 
     Args:
-        func (Callable): Function to be converted
+        func (Callable | inspect.Signature): Function or signature to be converted
+        include_class_obj (bool): Include ``self``/``cls`` parameters when serializing a callable.
 
     Returns:
         list[dict]: List of dictionaries representing the function signature
     """
     out = []
-    params = inspect.signature(func).parameters
-    try:
-        type_hints = get_type_hints(func, include_extras=True)
-    except NameError as e:
-        raise TypeError(
-            f"Couldn't find annotated type {e.name}. The type you annotate with must be available in the local scope! Check it is not hidden by TYPE_CHECKING."
-        ) from e
+    if isinstance(func, inspect.Signature):
+        params = func.parameters
+        resolved_type_hints = None
+    else:
+        params = inspect.signature(func).parameters
+        try:
+            resolved_type_hints = get_type_hints(func, include_extras=True)
+        except NameError as e:
+            raise TypeError(
+                f"Couldn't find annotated type {e.name}. The type you annotate with must be available in the local scope! Check it is not hidden by TYPE_CHECKING."
+            ) from e
     for param_name, param in params.items():
-        if not include_class_obj and param_name == "self" or param_name == "cls":
+        if (not include_class_obj and param_name == "self") or param_name == "cls":
             continue
         # pylint: disable=protected-access
-        param_typehint = type_hints.get(param_name)
+        param_typehint = (resolved_type_hints or {}).get(param_name, param.annotation)
         out.append(
             {
                 "name": param_name,
                 "kind": param.kind.name,
                 "default": param.default if param.default != inspect._empty else "_empty",
-                "annotation": serialize_dtype(param_typehint) if param_typehint else "_empty",
+                "annotation": (
+                    serialize_dtype(param_typehint)
+                    if param_typehint is not inspect._empty
+                    else "_empty"
+                ),
             }
         )
     return out

--- a/bec_lib/tests/test_signature_serializer.py
+++ b/bec_lib/tests/test_signature_serializer.py
@@ -33,6 +33,53 @@ def test_signature_serializer():
     assert sig == inspect.signature(test_func)
 
 
+def test_signature_serializer_accepts_signature_objects():
+    signature = inspect.Signature(
+        [
+            inspect.Parameter(
+                "step",
+                inspect.Parameter.KEYWORD_ONLY,
+                annotation=Annotated[float, ScanArgument(description="Step size")],
+            ),
+            inspect.Parameter("repeats", inspect.Parameter.KEYWORD_ONLY, default=3, annotation=int),
+        ]
+    )
+
+    params = signature_to_dict(signature)
+
+    assert params == [
+        {
+            "name": "step",
+            "kind": "KEYWORD_ONLY",
+            "default": "_empty",
+            "annotation": {
+                "Annotated": {
+                    "type": "float",
+                    "metadata": {
+                        "ScanArgument": {
+                            "description": "Step size",
+                            "display_name": None,
+                            "tooltip": None,
+                            "expert": False,
+                            "hidden": False,
+                            "example": None,
+                            "units": None,
+                            "reference_units": None,
+                            "gt": None,
+                            "ge": None,
+                            "lt": None,
+                            "le": None,
+                            "reference_limits": None,
+                            "alternative_group": None,
+                        }
+                    },
+                }
+            },
+        },
+        {"name": "repeats", "kind": "KEYWORD_ONLY", "default": 3, "annotation": "int"},
+    ]
+
+
 def test_signature_serializer_merged_literals():
     def test_func(a: Literal[1, 2, 3] | None = None):
         pass
@@ -132,6 +179,8 @@ def test_signature_serializer_with_scan_argument_annotation():
                             "display_name": None,
                             "tooltip": "Motor step size",
                             "expert": True,
+                            "hidden": False,
+                            "example": None,
                             "alternative_group": None,
                             "units": "mm",
                             "reference_units": None,
@@ -236,6 +285,8 @@ def test_signature_serializer_with_optional_scan_argument_annotation():
                                 "display_name": None,
                                 "tooltip": None,
                                 "expert": False,
+                                "hidden": False,
+                                "example": None,
                                 "alternative_group": None,
                                 "units": None,
                                 "reference_units": None,
@@ -284,6 +335,8 @@ def test_signature_serializer_with_optional_scan_argument_annotation():
                             "display_name": None,
                             "tooltip": None,
                             "expert": False,
+                            "hidden": False,
+                            "example": None,
                             "alternative_group": "scan_resolution",
                             "units": None,
                             "reference_units": None,
@@ -308,6 +361,8 @@ def test_signature_serializer_with_optional_scan_argument_annotation():
                             "display_name": None,
                             "tooltip": None,
                             "expert": False,
+                            "hidden": False,
+                            "example": None,
                             "alternative_group": None,
                             "units": "mm/s",
                             "reference_units": None,

--- a/bec_server/bec_server/scan_server/direct_scan_worker.py
+++ b/bec_server/bec_server/scan_server/direct_scan_worker.py
@@ -41,15 +41,25 @@ class DirectScanWorker:
         self.scan = None
 
     def reset(self):
+        """
+        Reset the state of the scan worker after a scan is completed or aborted.
+        """
         self.scan = None
 
     def process_instructions(self, queue: DirectInstructionQueueItem) -> None:
+        """
+        Process the instructions in the given queue item. It runs the scan and handles any exceptions that may occur during the scan execution.
+
+        Args:
+            queue (DirectInstructionQueueItem): The queue item containing the scan instructions to process.
+        """
         self.worker.current_instruction_queue_item = queue
 
         scan = queue.move_to_next_scan()
         if scan is None:
             logger.error("No scan found in the queue item to process.")
             return
+
         self.run(scan)
 
         queue.status = InstructionQueueStatus.COMPLETED
@@ -124,6 +134,12 @@ class DirectScanWorker:
         raise ScanAbortion from exc
 
     def check_for_interruption(self):
+        """
+        Check if the scan has been interrupted by checking the worker's status.
+        If the status is PAUSED, it waits until the status changes to RUNNING.
+        If the status is STOPPED, it raises a ScanAbortion or UserScanInterruption
+        exception depending on the exit_info of the current queue item.
+        """
         if self.worker.status == InstructionQueueStatus.PAUSED:
             if self.scan is not None:
                 self.scan.actions._send_scan_status("paused")
@@ -136,9 +152,21 @@ class DirectScanWorker:
             raise UserScanInterruption(exit_info=item.exit_info)
 
     def update_queue_info(self):
+        """
+        Update the queue info for the current instruction queue item.
+        This is used to propagate the queue status to the client during the scan execution.
+        """
         self.worker.current_instruction_queue_item.parent.queue_manager.send_queue_status()
 
     def _propagate_error(self, content: str, exc: Exception):
+        """
+        Propagate the error to the client by sending a client info message and raising an alarm with the error information.
+
+        Args:
+            content (str): The error message content to send to the client and include in the alarm information.
+            exc (Exception): The exception that was raised, which will be included in the alarm information.
+        """
+
         logger.error(content)
         error_info = messages.ErrorInfo(
             error_message=content,
@@ -151,6 +179,11 @@ class DirectScanWorker:
         )
 
     def get_metadata_for_alarm(self) -> dict:
+        """
+        Get metadata for the alarm based on the current scan information.
+        This can include details such as the scan ID and scan number,
+        which can help with debugging and identifying the context of the error.
+        """
         if self.scan is None:
             return {}
         metadata = {}
@@ -161,6 +194,10 @@ class DirectScanWorker:
         return metadata
 
     def _run_on_exception_hook(self, exc: Exception):
+        """
+        Run the on_exception hook implemented by the scan if the current queue item has run_on_exception_hook set to True.
+        The on_exception hook allows the scan to perform cleanup tasks or other actions when an exception occurs
+        """
         scan = self.scan
         if scan is None:
             return
@@ -172,7 +209,8 @@ class DirectScanWorker:
         try:
             scan._shutdown_event.clear()
             with self.worker.device_manager._rpc_method(scan.actions.rpc_call):
-                scan.on_exception(hook_exc)  # type: ignore
+                scan.on_exception(hook_exc)
+
         except Exception:
             scan.actions.send_client_info("")
             logger.exception("Failed to run direct scan on_exception hook")

--- a/bec_server/bec_server/scan_server/scan_assembler.py
+++ b/bec_server/bec_server/scan_server/scan_assembler.py
@@ -7,9 +7,14 @@ from bec_lib import messages
 from bec_lib.device import DeviceBase
 from bec_lib.logger import bec_logger
 from bec_lib.scan_input_validator import ScanInputValidator
-from bec_lib.signature_serializer import serialize_dtype, signature_to_dict
+from bec_lib.signature_serializer import serialize_dtype
 
 from .scans.legacy_scans import RequestBase, ScanArgType, ScanBase, unpack_scan_args
+from .scans.scan_argument_modifier import (
+    apply_scan_argument_defaults,
+    get_scan_modifier,
+    scan_signature_with_modifiers,
+)
 from .scans.scan_base import ScanBase as ScanBaseV4
 
 logger = bec_logger.logger
@@ -29,6 +34,7 @@ class ScanAssembler:
         self.connector = self.parent.connector
         self.scan_manager = self.parent.scan_manager
         self.input_validator = ScanInputValidator(device_manager=self.device_manager)
+        self.scan_modifier_cls = get_scan_modifier()
 
     def is_scan_message(self, msg: messages.ScanQueueMessage) -> bool:
         """Check if the scan queue message would construct a new scan.
@@ -114,15 +120,19 @@ class ScanAssembler:
         kwargs = msg.content.get("parameter", {}).get("kwargs", {})
         scan_info = self._get_scan_info(scan, scan_cls)
 
-        request_inputs = self._assemble_request_inputs(scan_cls, args, kwargs)
         resolved_args, resolved_kwargs = self.input_validator.validate(
             scan, scan_info, args, kwargs
+        )
+        request_inputs = self._assemble_request_inputs(scan_cls, args, kwargs)
+        resolved_kwargs = apply_scan_argument_defaults(
+            scan_cls, scan_info["signature"], resolved_args, resolved_kwargs
         )
 
         scan_instance = scan_cls(
             *resolved_args,
             device_manager=self.device_manager,
             redis_connector=self.connector,
+            scan_modifier=self.scan_modifier_cls,
             metadata=msg.metadata,
             instruction_handler=self.parent.queue_manager.instruction_handler,
             scan_id=scan_id,
@@ -132,43 +142,46 @@ class ScanAssembler:
         return scan_instance
 
     def _assemble_request_inputs(self, scan_cls, args, kwargs) -> dict:
-
-        cls_input_args = [
-            name
-            for name, val in inspect.signature(scan_cls).parameters.items()
-            if val.default == inspect.Parameter.empty and name != "kwargs"
-        ]
         request_inputs = {}
         if scan_cls.arg_bundle_size["bundle"] > 0:
             request_inputs["arg_bundle"] = args
             request_inputs["inputs"] = {}
             request_inputs["kwargs"] = kwargs
-        else:
-            request_inputs["arg_bundle"] = []
-            request_inputs["inputs"] = {}
-            request_inputs["kwargs"] = {}
+            return request_inputs
 
-            if "args" in cls_input_args:
-                split_index = cls_input_args.index("args")
-                defined_cls_args = cls_input_args[:split_index]
-                defined_args = args[:split_index]
+        signature = inspect.signature(scan_cls)
+        request_inputs["arg_bundle"] = []
+        request_inputs["inputs"] = {}
+        request_inputs["kwargs"] = {}
+        bound = signature.bind_partial(*args, **kwargs)
+        var_keyword_name = next(
+            (
+                name
+                for name, parameter in signature.parameters.items()
+                if parameter.kind == inspect.Parameter.VAR_KEYWORD
+            ),
+            None,
+        )
 
-                for ii, key in enumerate(defined_args):
-                    input_name = defined_cls_args[ii]
-                    request_inputs["inputs"][input_name] = key
+        for name, parameter in signature.parameters.items():
+            if name not in bound.arguments:
+                continue
 
-                request_inputs["inputs"]["args"] = args[split_index:]
+            value = bound.arguments[name]
+            if parameter.kind == inspect.Parameter.VAR_POSITIONAL:
+                request_inputs["inputs"][name] = list(value)
+            elif parameter.kind == inspect.Parameter.VAR_KEYWORD:
+                request_inputs["kwargs"].update(value)
+            elif parameter.default == inspect.Parameter.empty:
+                request_inputs["inputs"][name] = value
             else:
-                for ii, key in enumerate(args):
-                    request_inputs["inputs"][cls_input_args[ii]] = key
+                request_inputs["kwargs"][name] = value
 
-            for key in kwargs:
-                if key in cls_input_args:
-                    request_inputs["inputs"][key] = kwargs[key]
-
-            for key, val in kwargs.items():
-                if key not in cls_input_args:
-                    request_inputs["kwargs"][key] = val
+        for key, val in kwargs.items():
+            if key not in signature.parameters and key not in (
+                bound.arguments.get(var_keyword_name) or {}
+            ):
+                request_inputs["kwargs"][key] = val
         return request_inputs
 
     def _get_scan_info(self, scan_name: str, scan_cls) -> dict:
@@ -183,7 +196,7 @@ class ScanAssembler:
                 scan_cls, "arg_bundle_size", {"bundle": 0, "min": None, "max": None}
             ),
             "doc": scan_cls.__doc__ or scan_cls.__init__.__doc__,
-            "signature": signature_to_dict(scan_cls.__init__),
+            "signature": scan_signature_with_modifiers(scan_cls),
         }
 
     def _serialize_arg_input(self, arg_input: dict) -> dict[str, str | dict | list]:

--- a/bec_server/bec_server/scan_server/scan_manager.py
+++ b/bec_server/bec_server/scan_server/scan_manager.py
@@ -18,6 +18,10 @@ from bec_lib.logger import bec_logger
 from bec_lib.messages import AvailableResourceMessage, ErrorInfo
 from bec_lib.signature_serializer import serialize_dtype, signature_to_dict
 from bec_server.scan_server.scan_gui_models import GUIConfig
+from bec_server.scan_server.scans.scan_argument_modifier import (
+    scan_doc_with_modifiers,
+    scan_signature_with_modifiers,
+)
 
 from . import scans as scans_v4_module
 from .scans import legacy_scans as scans_module
@@ -134,7 +138,9 @@ class ScanManager:
                 base_cls = "ScanBaseV4"
 
             self.scan_dict[scan_cls.scan_name] = scan_cls
-            gui_config = self.validate_gui_config(scan_cls)
+            gui_config = (
+                self.validate_gui_config(scan_cls) if hasattr(scan_cls, "gui_config") else {}
+            )
             gui_visibility = {}
             if hasattr(scan_cls, "gui_visibility"):
                 gui_visibility = scan_cls.gui_visibility  # type: ignore
@@ -147,37 +153,40 @@ class ScanManager:
                 "arg_input": self.convert_arg_input(scan_cls.arg_input),
                 "required_kwargs": getattr(scan_cls, "required_kwargs", []),
                 "arg_bundle_size": scan_cls.arg_bundle_size,
-                "doc": scan_cls.__doc__ or scan_cls.__init__.__doc__,
-                "signature": signature_to_dict(scan_cls.__init__),
+                "doc": scan_doc_with_modifiers(scan_cls),
+                "signature": scan_signature_with_modifiers(scan_cls),
                 "gui_visibility": gui_visibility,
                 "gui_config": gui_config,  # deprecated! - should be removed
             }
 
-    def validate_gui_config(self, scan_cls) -> dict:
+    def validate_gui_config(self, scan_cls, gui_config_override: dict | None = None) -> dict:
         """
         Validate the gui_config of the scan class
 
         Args:
             scan_cls: class
+            gui_config_override (dict | None): Optional raw gui_config mapping to validate
+                instead of ``scan_cls.gui_config``.
 
         Returns:
             dict: gui_config
         """
 
-        if not hasattr(scan_cls, "gui_config"):
+        if gui_config_override is None and not hasattr(scan_cls, "gui_config"):
             return {}
-        if not isinstance(scan_cls.gui_config, GUIConfig) and not isinstance(
-            scan_cls.gui_config, dict
-        ):
+        gui_config = scan_cls.gui_config if gui_config_override is None else gui_config_override
+        if not isinstance(gui_config, GUIConfig) and not isinstance(gui_config, dict):
             logger.error(
                 f"Invalid gui_config for {scan_cls.scan_name}. gui_config must be of type GUIConfig or dict."
             )
             return {}
-        gui_config = (
-            GUIConfig.from_dict(scan_cls)
-            if isinstance(scan_cls.gui_config, dict)
-            else scan_cls.gui_config
-        )
+        if isinstance(gui_config, dict):
+            original_gui_config = getattr(scan_cls, "gui_config", None)
+            try:
+                scan_cls.gui_config = gui_config
+                gui_config = GUIConfig.from_dict(scan_cls)
+            finally:
+                scan_cls.gui_config = original_gui_config
         return gui_config.model_dump()
 
     def convert_arg_input(self, arg_input) -> dict:

--- a/bec_server/bec_server/scan_server/scans/scan_argument_modifier.py
+++ b/bec_server/bec_server/scan_server/scans/scan_argument_modifier.py
@@ -1,0 +1,590 @@
+"""
+Helpers for applying scan signature overrides from scan modifier plugins.
+
+This module builds the user-facing scan signature published by the scan manager
+and applies the same override-derived defaults again in the scan assembler
+before a direct scan class is instantiated. This keeps the published signature,
+input validation, and runtime construction behavior aligned.
+"""
+
+from __future__ import annotations
+
+import inspect
+from functools import lru_cache
+from typing import TYPE_CHECKING, Annotated, Any, Type, get_args, get_origin, get_type_hints
+
+from bec_lib.plugin_helper import get_scan_modifier_plugin
+from bec_lib.scan_args import ScanArgument
+from bec_lib.signature_serializer import deserialize_dtype, dict_to_signature, signature_to_dict
+from bec_server.scan_server.scans.scan_base import ScanBase
+
+if TYPE_CHECKING:
+    from bec_server.scan_server.scans.scan_modifier import ScanModifier
+
+
+@lru_cache(maxsize=None)
+def get_scan_modifier() -> Type[ScanModifier] | None:
+    """
+    Load the available scan argument modifier from the plugin.
+
+    Returns:
+        ScanModifier: The scan modifier class
+    """
+    modifier = get_scan_modifier_plugin()
+    return modifier
+
+
+def _convert_annotation(annotation: object) -> Annotated[Any, ScanArgument] | None:
+    """
+    Normalize an annotation to ``Annotated[..., ScanArgument(...)]``.
+
+    The scan signature override API operates on annotations that always carry
+    ``ScanArgument`` metadata so modifier code can treat original and injected
+    arguments consistently. Plain annotations are wrapped in a default
+    ``ScanArgument`` instance, while existing ``ScanArgument`` metadata is
+    preserved.
+
+    This is mainly done to keep the interface for scan signature modifiers consistent.
+
+    Args:
+        annotation (object): Serialized or native annotation object.
+
+    Returns:
+        Annotated[Any, ScanArgument] | None: Normalized annotation with
+            ``ScanArgument`` metadata, or ``None`` if the source annotation is
+            empty.
+    """
+    if annotation is None or annotation == "_empty":
+        return None
+
+    converted = (
+        deserialize_dtype(annotation) if isinstance(annotation, (str, dict, list)) else annotation
+    )
+    if converted is None or converted is inspect._empty:
+        return None
+
+    if get_origin(converted) is Annotated:
+        base_annotation, *metadata = get_args(converted)
+        for entry in metadata:
+            if isinstance(entry, ScanArgument):
+                return converted
+        return Annotated[base_annotation, ScanArgument()]
+
+    return Annotated[converted, ScanArgument()]
+
+
+def _get_annotations_and_defaults(
+    scan_cls: Type[ScanBase],
+) -> tuple[dict[str, Annotated[Any, ScanArgument] | None], dict[str, Any]]:
+    """
+    Collect normalized annotations and Python defaults from ``scan_cls.__init__``.
+
+    Args:
+        scan_cls (Type[ScanBase]): Scan class whose constructor should be
+            inspected.
+
+    Returns:
+        tuple: A tuple ``(arguments, defaults)`` where ``arguments`` maps input
+        names to normalized annotations and ``defaults`` maps input names to
+        their constructor defaults.
+    """
+    signature = inspect.signature(scan_cls.__init__)
+    type_hints = get_type_hints(scan_cls.__init__, include_extras=True)
+    annotations = {}
+    defaults = {}
+    for arg_name, parameter in signature.parameters.items():
+        if arg_name in {"self", "cls", "args", "kwargs"}:
+            continue
+        annotations[arg_name] = _convert_annotation(type_hints.get(arg_name, parameter.annotation))
+        if parameter.default is not inspect.Parameter.empty:
+            defaults[arg_name] = parameter.default
+    return annotations, defaults
+
+
+def _build_signature_from_arguments(
+    scan_cls: Type[ScanBase],
+    arguments: dict[str, Annotated[Any, ScanArgument] | None],
+    defaults: dict[str, Any],
+) -> inspect.Signature:
+    """
+    Build a modified scan signature from override-derived arguments and defaults.
+
+    Existing constructor parameters are copied from ``scan_cls.__init__`` and
+    updated in-place with override-derived annotations and defaults.
+    Additional override-only arguments are appended as keyword-only parameters
+    before any trailing ``**kwargs`` entry.
+
+    Args:
+        scan_cls (Type[ScanBase]): Scan class whose constructor shape is used as
+            the base signature.
+        arguments (dict): Normalized scan argument annotations after overrides.
+        defaults (dict): Default values after overrides.
+
+    Returns:
+        inspect.Signature: Effective signature after applying scan overrides.
+    """
+    parameters: list[inspect.Parameter] = []
+    trailing_var_keyword = None
+    seen_names: set[str] = set()
+
+    for name, param in inspect.signature(scan_cls.__init__).parameters.items():
+        if name in {"self", "cls"}:
+            continue
+        if param.kind is inspect.Parameter.VAR_POSITIONAL:
+            parameters.append(param)
+            continue
+        if param.kind is inspect.Parameter.VAR_KEYWORD:
+            trailing_var_keyword = param
+            continue
+        if name not in arguments:
+            continue
+        annotation = arguments[name]
+        parameters.append(
+            param.replace(
+                annotation=annotation if annotation is not None else inspect.Parameter.empty,
+                default=defaults.get(name, inspect.Parameter.empty),
+            )
+        )
+        seen_names.add(name)
+
+    for name, annotation in arguments.items():
+        if name in seen_names:
+            continue
+        parameters.append(
+            inspect.Parameter(
+                name=name,
+                kind=inspect.Parameter.KEYWORD_ONLY,
+                default=defaults.get(name, inspect.Parameter.empty),
+                annotation=annotation if annotation is not None else inspect.Parameter.empty,
+            )
+        )
+
+    if trailing_var_keyword is not None and trailing_var_keyword.name in arguments:
+        annotation = arguments[trailing_var_keyword.name]
+        parameters.append(
+            trailing_var_keyword.replace(
+                annotation=annotation if annotation is not None else inspect.Parameter.empty,
+                default=defaults.get(trailing_var_keyword.name, inspect.Parameter.empty),
+            )
+        )
+    elif trailing_var_keyword is not None:
+        parameters.append(trailing_var_keyword)
+
+    return inspect.Signature(parameters)
+
+
+def get_scan_argument_overrides(
+    scan_cls: Type[ScanBase],
+) -> tuple[dict[str, Annotated[Any, ScanArgument] | None], dict[str, Any]]:
+    """
+    Return the effective scan arguments and defaults after applying overrides.
+
+    The helper first inspects ``scan_cls.__init__`` and then, when available,
+    calls the installed scan modifier plugin. Both the current
+    ``scan_argument_overrides`` name and the legacy
+    ``scan_signature_overrides`` name are supported.
+
+    Args:
+        scan_cls (Type[ScanBase]): Scan class to inspect.
+
+    Returns:
+        tuple: A tuple ``(arguments, defaults)`` containing the effective
+        annotation and default maps after modifier processing.
+    """
+    arguments, defaults = _get_annotations_and_defaults(scan_cls)
+    if not issubclass(scan_cls, ScanBase):
+        return arguments, defaults
+    modifier = get_scan_modifier()
+    if modifier is None:
+        return arguments, defaults
+    override_func = getattr(modifier, "scan_argument_overrides", None)
+    if override_func is None:
+        override_func = getattr(modifier, "scan_signature_overrides", None)
+    if override_func is None:
+        return arguments, defaults
+    return override_func(scan_cls.scan_name, arguments, defaults)
+
+
+def scan_signature_with_modifiers(scan_cls: Type[ScanBase]) -> list[dict[str, Any]]:
+    """
+    Build the published scan signature after applying modifier overrides.
+
+    Args:
+        scan_cls (Type[ScanBase]): Scan class whose signature should be
+            published.
+
+    Returns:
+        list[dict[str, Any]]: Serialized signature entries describing the
+        user-facing scan inputs.
+    """
+    arguments, defaults = get_scan_argument_overrides(scan_cls)
+    return signature_to_dict(_build_signature_from_arguments(scan_cls, arguments, defaults))
+
+
+def gui_config_with_modifiers(
+    scan_cls: Type[ScanBase], gui_config: dict[str, list[str]]
+) -> dict[str, list[str]]:
+    """
+    Build the published GUI configuration after applying modifier overrides.
+
+    Args:
+        scan_cls (Type[ScanBase]): Scan class whose GUI config should be published.
+        gui_config (dict[str, list[str]]): Validated GUI config for the scan.
+
+    Returns:
+        dict[str, list[str]]: Modifier-adjusted GUI config for publication.
+    """
+    if not issubclass(scan_cls, ScanBase):
+        return gui_config
+
+    modifier = get_scan_modifier()
+    if modifier is None:
+        # no plugin installed, return original config
+        return gui_config
+
+    return modifier.gui_config_overrides(scan_cls.scan_name, gui_config)
+
+
+def _annotation_to_doc_type(annotation: object) -> str:
+    """
+    Convert a normalized annotation to a compact docstring type label.
+
+    Args:
+        annotation (object): Annotation object to stringify.
+
+    Returns:
+        str: Human-readable type label for generated argument docs.
+    """
+    if annotation is None:
+        return "Any"
+    if get_origin(annotation) is Annotated:
+        annotation = get_args(annotation)[0]
+
+    origin = get_origin(annotation)
+    if origin is None:
+        name = getattr(annotation, "__name__", None)
+        return name if name is not None else str(annotation)
+
+    args = get_args(annotation)
+    origin_name = getattr(origin, "__name__", str(origin))
+    if args:
+        return f"{origin_name}[{', '.join(_annotation_to_doc_type(arg) for arg in args)}]"
+    return origin_name
+
+
+def _argument_to_doc_line(
+    name: str, annotation: Annotated[Any, ScanArgument] | None, defaults: dict[str, Any]
+) -> str:
+    """
+    Build one ``Args:`` line for the generated scan docstring.
+
+    Args:
+        name (str): Argument name.
+        annotation (Annotated[Any, ScanArgument] | None): Normalized argument
+            annotation.
+        defaults (dict[str, Any]): Effective default values.
+
+    Returns:
+        str: Single formatted docstring line.
+    """
+    description = name.replace("_", " ")
+    doc_type = _annotation_to_doc_type(annotation)
+    if annotation is not None and get_origin(annotation) is Annotated:
+        _, *metadata = get_args(annotation)
+        for entry in metadata:
+            if isinstance(entry, ScanArgument):
+                if entry.description:
+                    description = entry.description
+                if entry.units:
+                    doc_type += f" [{_annotation_to_doc_type(entry.units)}]"
+                break
+
+    line = f"    {name} ({doc_type}): {description}"
+    line = line.rstrip()
+    if not line.endswith("."):
+        line += "."
+    if name in defaults:
+        line += f" Default: {defaults[name]!r}"
+    if annotation is not None and get_origin(annotation) is Annotated:
+        _, *metadata = get_args(annotation)
+        for entry in metadata:
+            if isinstance(entry, ScanArgument) and entry.units is not None:
+                line += f" {_annotation_to_doc_type(entry.units)}"
+                break
+    return line
+
+
+def _annotation_metadata(annotation: Annotated[Any, ScanArgument] | None) -> ScanArgument | None:
+    """Return the ``ScanArgument`` metadata attached to an annotation."""
+    if annotation is None or get_origin(annotation) is not Annotated:
+        return None
+    _, *metadata = get_args(annotation)
+    return next((entry for entry in metadata if isinstance(entry, ScanArgument)), None)
+
+
+def _example_literal(name: str, annotation: object, bundle_index: int | None = None) -> str:
+    """Build a compact Python literal for a generated example call."""
+    metadata = _annotation_metadata(annotation)
+    if metadata is not None and metadata.example is not None:
+        return repr(metadata.example)
+
+    if annotation is None:
+        return repr(name)
+    if get_origin(annotation) is Annotated:
+        annotation = get_args(annotation)[0]
+
+    origin = get_origin(annotation)
+    if origin is list:
+        return "[1.0, 2.0, 3.0]"
+    if origin is tuple:
+        return "(1.0, 2.0)"
+    if origin is dict:
+        return "{'key': 'value'}"
+    if origin is set:
+        return "{1.0, 2.0}"
+    if origin is not None:
+        args = [arg for arg in get_args(annotation) if arg is not type(None)]
+        if args:
+            return _example_literal(name, args[0], bundle_index=bundle_index)
+
+    type_name = getattr(annotation, "__name__", str(annotation))
+    if type_name == "DeviceBase":
+        return f"dev.{name}{bundle_index + 1}" if bundle_index is not None else f"dev.{name}"
+    if annotation is bool:
+        return "False"
+    if annotation is int:
+        return "10" if "step" in name else "1"
+    if annotation is float:
+        if "start" in name:
+            return "-1.0"
+        if "stop" in name or "target" in name:
+            return "1.0"
+        return "1.0"
+    if annotation is str:
+        return repr(name)
+    return repr(name)
+
+
+def _build_example_calls(
+    scan_cls: Type[ScanBase],
+    arguments: dict[str, Annotated[Any, ScanArgument] | None],
+    defaults: dict[str, Any],
+) -> tuple[str, str]:
+    """Build minimum and full generated example calls from the effective inputs."""
+    minimum_parts: list[str] = []
+    full_parts: list[str] = []
+
+    if getattr(scan_cls, "arg_input", None) and getattr(scan_cls, "arg_bundle_size", {}).get(
+        "bundle", 0
+    ):
+        bundle_count = getattr(scan_cls, "arg_bundle_size", {}).get("min") or 1
+        for bundle_index in range(bundle_count):
+            for arg_name, arg_annotation in scan_cls.arg_input.items():
+                literal = _example_literal(
+                    arg_name, _convert_annotation(arg_annotation), bundle_index=bundle_index
+                )
+                minimum_parts.append(literal)
+                full_parts.append(literal)
+
+    signature = inspect.signature(scan_cls.__init__)
+    for name, parameter in signature.parameters.items():
+        if name in {"self", "args", "kwargs"} or name not in arguments:
+            continue
+        value = defaults[name] if name in defaults else _example_literal(name, arguments[name])
+        rendered = repr(value) if not isinstance(value, str) else value
+        if parameter.kind is inspect.Parameter.KEYWORD_ONLY:
+            if name not in defaults:
+                minimum_parts.append(f"{name}={rendered}")
+            full_parts.append(f"{name}={rendered}")
+        else:
+            if name not in defaults:
+                minimum_parts.append(rendered)
+                full_parts.append(rendered)
+            else:
+                full_parts.append(f"{name}={rendered}")
+
+    existing_parameters = {
+        name
+        for name, parameter in signature.parameters.items()
+        if name not in {"self", "args", "kwargs"}
+        and parameter.kind is not inspect.Parameter.VAR_KEYWORD
+    }
+    for name, annotation in arguments.items():
+        if name in existing_parameters:
+            continue
+        value = defaults[name] if name in defaults else _example_literal(name, annotation)
+        rendered = repr(value) if not isinstance(value, str) else value
+        if name not in defaults:
+            minimum_parts.append(f"{name}={rendered}")
+        full_parts.append(f"{name}={rendered}")
+
+    minimum_call = f"        >>> scans.{scan_cls.scan_name}({', '.join(minimum_parts)})"
+    full_call = f"        >>> scans.{scan_cls.scan_name}({', '.join(full_parts)})"
+    return minimum_call, full_call
+
+
+def _get_scan_raw_doc(scan_cls: Type[ScanBase]) -> str:
+    """Return the scan-specific raw docstring, preferring non-generic class docs."""
+    class_doc = inspect.getdoc(scan_cls)
+    base_class_doc = inspect.getdoc(ScanBase)
+    base_init_doc = inspect.getdoc(ScanBase.__init__)
+
+    if class_doc and class_doc not in {base_class_doc, base_init_doc}:
+        return class_doc
+
+    return inspect.getdoc(scan_cls.__init__) or class_doc or ""
+
+
+def scan_doc_with_modifiers(scan_cls: Type[ScanBase]) -> str:
+    """
+    Build a published scan docstring from the effective scan inputs.
+
+    The helper preserves the introductory and trailing sections from the
+    original class or constructor docstring while rebuilding the ``Args:``
+    and ``Examples:`` sections from the effective argument and default maps
+    after modifier overrides have been applied.
+
+    Args:
+        scan_cls (Type[ScanBase]): Scan class whose published docstring should
+            be generated.
+
+    Returns:
+        str: Docstring aligned with the effective scan signature.
+    """
+    if not issubclass(scan_cls, ScanBase):
+        # For legacy scans, we simply return the original docstring
+        return scan_cls.__doc__ or scan_cls.__init__.__doc__ or ""
+
+    raw_doc = _get_scan_raw_doc(scan_cls)
+    arguments, defaults = get_scan_argument_overrides(scan_cls)
+
+    prefix = raw_doc.strip()
+    suffix = ""
+    if "Args:" in raw_doc:
+        prefix, remainder = raw_doc.split("Args:", 1)
+        prefix = prefix.rstrip()
+        trailing_markers = ["Returns:", "Examples:", "Raises:"]
+        split_positions = [
+            remainder.find(marker) for marker in trailing_markers if remainder.find(marker) != -1
+        ]
+        if split_positions:
+            suffix = remainder[min(split_positions) :].strip()
+            if "Examples:" in suffix:
+                example_pos = suffix.find("Examples:")
+                next_section_positions = [
+                    suffix.find(marker, example_pos + len("Examples:"))
+                    for marker in ("Returns:", "Raises:")
+                    if suffix.find(marker, example_pos + len("Examples:")) != -1
+                ]
+                if next_section_positions:
+                    end_pos = min(next_section_positions)
+                    suffix = (suffix[:example_pos] + suffix[end_pos:]).strip()
+                else:
+                    suffix = suffix[:example_pos].rstrip()
+
+    arg_lines = []
+    if getattr(scan_cls, "arg_input", None) and getattr(scan_cls, "arg_bundle_size", {}).get(
+        "bundle", 0
+    ):
+        bundle_items = []
+        for arg_name, arg_annotation in scan_cls.arg_input.items():
+            bundle_items.append(
+                f"{arg_name}: {_annotation_to_doc_type(_convert_annotation(arg_annotation))}"
+            )
+        arg_lines.append(f"    *args ({', '.join(bundle_items)}): repeated scan argument bundles.")
+
+    for name, annotation in arguments.items():
+        arg_lines.append(_argument_to_doc_line(name, annotation, defaults))
+
+    minimum_example, full_example = _build_example_calls(scan_cls, arguments, defaults)
+    example_section = "\n".join(
+        ["Examples:", "    Minimum:", minimum_example, "    Full:", full_example]
+    )
+    sections = [
+        section
+        for section in [prefix, "Args:\n" + "\n".join(arg_lines), suffix, example_section]
+        if section
+    ]
+    return "\n\n".join(sections)
+
+
+def apply_scan_argument_defaults(
+    scan_cls: Type[ScanBase],
+    signature: list[dict[str, Any]],
+    args: tuple | list,
+    kwargs: dict[str, Any],
+) -> dict[str, Any]:
+    """
+    Apply published and override-derived defaults before scan construction.
+
+    This helper reuses the published signature to materialize missing defaulted
+    values before ``scan_cls(...)`` is called. Values for parameters that do not
+    exist on the real constructor are moved into
+    ``additional_scan_parameters`` so they remain available through
+    ``scan.scan_info.additional_scan_parameters`` without leaking into
+    ``ScanBase.__init__``.
+
+    Args:
+        scan_cls (Type[ScanBase]): Scan class that will be instantiated.
+        signature (list[dict[str, Any]]): Published serialized signature for the
+            scan.
+        args (tuple | list): Positional arguments after validation and device
+            resolution.
+        kwargs (dict[str, Any]): Keyword arguments after validation and device
+            resolution.
+
+    Returns:
+        dict[str, Any]: Constructor kwargs updated with any missing defaults and
+        ``additional_scan_parameters`` entries implied by signature overrides.
+    """
+    public_signature = dict_to_signature(signature)
+    original_signature = inspect.signature(scan_cls)
+    _, modifier_defaults = get_scan_argument_overrides(scan_cls)
+
+    known_kwargs = {
+        key: value for key, value in kwargs.items() if key in public_signature.parameters
+    }
+    original_known_kwargs = {
+        key: value for key, value in kwargs.items() if key in original_signature.parameters
+    }
+    try:
+        bound = public_signature.bind_partial(*args, **known_kwargs)
+        original_bound = original_signature.bind_partial(*args, **original_known_kwargs)
+    except TypeError:
+        return kwargs
+
+    bound.apply_defaults()
+    provided_original_arguments = set(original_bound.arguments)
+    scan_kwargs = dict(kwargs)
+    additional_scan_parameters = dict(scan_kwargs.get("additional_scan_parameters") or {})
+
+    for name, value in bound.arguments.items():
+        if name not in original_signature.parameters:
+            additional_scan_parameters[name] = value
+            scan_kwargs.pop(name, None)
+            continue
+        if name in provided_original_arguments:
+            continue
+        param = original_signature.parameters[name]
+        if param.kind not in {
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        }:
+            continue
+        scan_kwargs[name] = value
+
+    for name, value in modifier_defaults.items():
+        if name in provided_original_arguments or name not in original_signature.parameters:
+            continue
+        param = original_signature.parameters[name]
+        if param.kind not in {
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        }:
+            continue
+        scan_kwargs.setdefault(name, value)
+
+    if additional_scan_parameters:
+        scan_kwargs["additional_scan_parameters"] = additional_scan_parameters
+
+    return scan_kwargs

--- a/bec_server/bec_server/scan_server/scans/scan_base.py
+++ b/bec_server/bec_server/scan_server/scans/scan_base.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import enum
 import threading
 from collections.abc import Sequence
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated, Type
 
 import numpy as np
 import pint
@@ -21,6 +21,7 @@ from bec_lib.redis_connector import RedisConnector
 from bec_server.scan_server.instruction_handler import InstructionHandler
 from bec_server.scan_server.scans.scan_actions import ScanActions
 from bec_server.scan_server.scans.scan_components import ScanComponents
+from bec_server.scan_server.scans.scan_modifier import ScanModifier, get_scan_hooks_impl
 
 Units = pint.UnitRegistry()
 
@@ -164,6 +165,7 @@ class ScanBase:
         instruction_handler: InstructionHandler,
         request_inputs: dict,
         system_config: dict,
+        scan_modifier: Type[ScanModifier] | None = None,
         user_metadata: dict | None = None,
         metadata: dict | None = None,
         scan_queue: str | None = None,
@@ -199,6 +201,10 @@ class ScanBase:
         self._premove_motor_status = None
         self.positions = np.array([])
         self.start_positions = []
+        self._scan_modifier_hooks = (
+            get_scan_hooks_impl(scan_modifier) if scan_modifier is not None else {}
+        )
+        self._scan_modifier = scan_modifier(self) if scan_modifier is not None else None
 
     def update_scan_info(
         self,

--- a/bec_server/bec_server/scan_server/scans/scan_modifier.py
+++ b/bec_server/bec_server/scan_server/scans/scan_modifier.py
@@ -1,22 +1,66 @@
 from __future__ import annotations
 
 from functools import wraps
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated, Any, Literal, TypeAlias, get_args
+
+from bec_lib.scan_args import ScanArgument
 
 if TYPE_CHECKING:
-    from bec_lib.device import DeviceBase
     from bec_server.scan_server.scans.scan_base import ScanBase
+
+
+ScanHookName: TypeAlias = Literal[
+    "prepare_scan",
+    "open_scan",
+    "stage",
+    "pre_scan",
+    "scan_core",
+    "at_each_point",
+    "post_scan",
+    "unstage",
+    "close_scan",
+    "on_exception",
+]
+
+# somehow, pylance doesn't like it when we define scan hooks and create the
+# literals out of it, so we do it the other way around
+VALID_SCAN_HOOKS = set(get_args(ScanHookName))
 
 
 def scan_hook(func):
     """
     Decorator for scan hooks. It registers the decorated method as a scan hook and thus allows
     scan modifiers to override or augment the scan logic.
+    When a method is decorated with @scan_hook, it will check if the scan modifier has an
+    implementation for this hook (by looking for the _scan_modifier_hooks attribute).
+    If an implementation is found, it will execute the before, replace, and after methods
+    in the appropriate order.
     """
 
     @wraps(func)
     def wrapper(self, *args, **kwargs):
-        return func(self, *args, **kwargs)
+        if func.__name__ not in self._scan_modifier_hooks:
+            return func(self, *args, **kwargs)
+
+        if self._scan_modifier is None:
+            return func(self, *args, **kwargs)
+
+        hook_info = self._scan_modifier_hooks[func.__name__]
+        if "before" in hook_info:
+            before_method = getattr(self._scan_modifier, hook_info["before"])
+            before_method(*args, **kwargs)
+
+        if "replace" in hook_info:
+            replace_method = getattr(self._scan_modifier, hook_info["replace"])
+            replace_method(*args, **kwargs)
+        else:
+            func(self, *args, **kwargs)
+
+        if "after" in hook_info:
+            after_method = getattr(self._scan_modifier, hook_info["after"])
+            after_method(*args, **kwargs)
+
+        return
 
     # pylint: disable=protected-access
     wrapper._scan_hook_info = {"method_name": func.__name__}  # type: ignore
@@ -24,12 +68,19 @@ def scan_hook(func):
     return wrapper
 
 
-def scan_hook_impl(hook_type: str):
+def scan_hook_impl(
+    hook_name: ScanHookName, hook_type: Literal["before", "after", "replace"] = "before"
+):
     """
-    Decorator for scan hook implementations. It registers the decorated method as an implementation of the specified scan hook type.
+    Decorator for scan hook implementations. It registers the decorated method as an implementation of the specified scan hook.
+    The hook_name must refer to an existing scan hook.
     The hook_type should be one of the following: "before", "after" or "replace".
     This allows the scan modifier to specify whether the decorated method should be executed before, after or instead of the original scan hook method.
     """
+    if hook_name not in VALID_SCAN_HOOKS:
+        raise ValueError(f"Invalid scan hook: {hook_name}")
+    if hook_type not in {"before", "after", "replace"}:
+        raise ValueError(f"Invalid scan hook type: {hook_type}")
 
     def decorator(func):
         @wraps(func)
@@ -37,53 +88,140 @@ def scan_hook_impl(hook_type: str):
             return func(self, *args, **kwargs)
 
         # pylint: disable=protected-access
-        wrapper._scan_hook_impl_info = {"hook_type": hook_type}  # type: ignore
+        wrapper._scan_hook_impl_info = {"hook_name": hook_name, "hook_type": hook_type}  # type: ignore
 
         return wrapper
 
     return decorator
 
 
-# pragma: no cover
-# def get_scan_hooks(cls) -> dict[str, str]:
-#     """
-#     Get the scan hooks defined in the given class. It returns a dictionary mapping the hook method names to their corresponding scan hook types.
-#     """
-#     hooks = {}
-#     for attr_name in dir(cls):
-#         attr = getattr(cls, attr_name)
-#         if callable(attr) and hasattr(attr, "_scan_hook_info"):
-#             hook_info = attr._scan_hook_info  # type: ignore
-#             hooks[hook_info["method_name"]] = attr_name
-#     return hooks
+def get_scan_hooks_impl(cls) -> dict[str, dict[str, str]]:
+    """
+    Get the scan hooks implemented by the given class. It returns
+    a dictionary mapping the original scan hook names to the corresponding method names and hook types in the scan modifier.
+
+    Raises:
+        ValueError: If the class implements multiple hooks for the same hook_type (before, after, replace) for the same scan hook.
+    """
+    hooks = {}
+    for attr_name in dir(cls):
+        attr = getattr(cls, attr_name)
+        if callable(attr) and hasattr(attr, "_scan_hook_impl_info"):
+            info = attr._scan_hook_impl_info
+            hook_name = info["hook_name"]
+            hook_type = info["hook_type"]
+            if hook_name not in hooks:
+                hooks[hook_name] = {}
+            if hook_type in hooks[hook_name]:
+                raise ValueError(
+                    f"Multiple implementations for the same hook type '{hook_type}' for the scan hook '{hook_name}' in class '{cls.__name__}'"
+                )
+            hooks[hook_name][hook_type] = attr_name
+    return hooks
 
 
-# def prepare_eiger(scan: ScanBase):
-#     if "eiger" not in scan.dev:
-#         return
-#     print("Preparing Eiger for the scan...")
-#     eiger = scan.dev["eiger"]
-#     num_frames = scan.scan_info.frames_per_trigger * scan.scan_info.num_points
-#     eiger.num_frames.set(num_frames).wait()
+class ScanModifier:
 
+    def __init__(self, scan: ScanBase):
+        self.scan = scan
+        self.dev = scan.dev
+        self.actions = scan.actions
+        self.components = scan.components
+        self.scan_info = scan.scan_info
 
-# def prepare_falcon(scan: ScanBase):
-#     if "falcon" not in scan.dev:
-#         return
-#     print("Preparing Falcon for the scan...")
-#     falcon = scan.dev["falcon"]
-#     falcon.num_frames.set(100).wait()
+    @staticmethod
+    def scan_signature_overrides(
+        scan_name: str,
+        arguments: dict[str, Annotated[Any, ScanArgument] | None],
+        defaults: dict[str, Any],
+    ) -> tuple[dict, dict]:
+        """
+        Define scan signature overrides for the scan modifier. This allows the scan modifier to modify the scan arguments for specific scans.
+        The method receives the original scan signature (arguments and defaults) and should return the modified signature as a tuple (arguments, defaults).
+        The scan_name can be used to specify different signature overrides for different scans.
 
+        Args:
+            scan_name (str): The name of the scan for which the signature should be overridden.
+            arguments (dict): The original scan arguments as a dictionary mapping argument names to their types and ScanArgument metadata.
+            defaults (dict): The original scan argument defaults as a dictionary mapping argument names to their default values.
 
-# class ScanModifier:
+        Returns:
+            tuple: A tuple containing the modified arguments and defaults dictionaries.
 
-#     @scan_hook_impl("after")
-#     def stage(self, scan: ScanBase):
-#         """
-#         Stage the devices for the upcoming scan. The stage logic is typically
-#         implemented on the device itself (i.e. by the device's stage method).
-#         However, if there are any additional steps that need to be executed before
-#         staging the devices, they can be implemented here.
-#         """
-#         prepare_eiger(scan)
-#         prepare_falcon(scan)
+        Examples:
+            >>> # Set the default exposure time to 1 second for all scans that have an exp_time argument
+            >>> def scan_signature_overrides(scan_name, arguments, defaults):
+            >>>     if "exp_time" in arguments:
+            >>>         defaults["exp_time"] = 1.0
+            >>>     return arguments, defaults
+
+            >>> # Add a new argument called integ_time to all scans and set its default value to 0.5 seconds
+            >>> # Note that additional args are automatically added to additional_scan_parameters
+            >>> def scan_signature_overrides(scan_name, arguments, defaults):
+            >>>     arguments["integ_time"] = Annotated[
+            >>>         float,
+            >>>         ScanArgument(description="Integration time for the scan", units=Units.s, ge=0),
+            >>>     ]
+            >>>     defaults["integ_time"] = 0.5
+            >>>     return arguments, defaults
+
+        """
+        return arguments, defaults
+
+    @staticmethod
+    def gui_config_overrides(
+        scan_name: str, gui_config: dict[str, list[str]]
+    ) -> dict[str, list[str]]:
+        """
+        Define GUI configuration overrides for the scan modifier. This allows the scan modifier to modify the GUI configuration for specific scans.
+        The method receives the original GUI configuration and should return the modified configuration as a dictionary.
+        The scan_name can be used to specify different GUI configuration overrides for different scans.
+
+        Args:
+            scan_name (str): The name of the scan for which the GUI configuration should be overridden.
+            gui_config (dict): The original GUI configuration as a dictionary mapping section names to lists of argument names.
+
+        Returns:
+            dict: The modified GUI configuration as a dictionary mapping section names to lists of argument names.
+
+        Examples:
+            >>> # Add the integ_time argument to the "Scan Parameters" section for all scans
+            >>> def gui_config_overrides(scan_name, gui_config):
+            >>>     if "Scan Parameters" in gui_config:
+            >>>         gui_config["Scan Parameters"].append("integ_time")
+            >>>     else:
+            >>>         gui_config["Scan Parameters"] = ["integ_time"]
+            >>>     return gui_config
+
+            >>> # Remove the exp_time argument from the "Scan Parameters" section for the line_scan
+            >>> def gui_config_overrides(scan_name, gui_config):
+            >>>     if scan_name == "line_scan":
+            >>>         for section, args in gui_config.items():
+            >>>             if "exp_time" in args:
+            >>>                 args.remove("exp_time")
+            >>>     return gui_config
+
+        """
+        return gui_config
+
+    def device_is_available(self, device: list[str] | str, check_enabled: bool = True) -> bool:
+        """
+        Check if the specified device(s) are available. This can be used to conditionally enable or disable the scan modifier based on the availability of certain devices.
+        The device(s) can be specified as a string (for a single device) or a list of strings (for multiple devices).
+
+        Args:
+            device (str or list of str): The name(s) of the device(s) to check for availability.
+            check_enabled (bool): If True, also check if the device is enabled.
+
+        Returns:
+            bool: True if all specified devices are available, False otherwise.
+
+        """
+        if isinstance(device, str):
+            device = [device]
+        for dev_name in device:
+            if dev_name not in self.dev:
+                return False
+            if check_enabled and not self.dev[dev_name].enabled:
+                return False
+        return True

--- a/bec_server/tests/tests_scan_server/test_direct_scan_worker.py
+++ b/bec_server/tests/tests_scan_server/test_direct_scan_worker.py
@@ -13,6 +13,7 @@ from bec_server.scan_server.scan_queue import (
     ScanQueue,
 )
 from bec_server.scan_server.scans.scan_base import ScanBase
+from bec_server.scan_server.scans.scan_modifier import ScanModifier, scan_hook, scan_hook_impl
 from bec_server.scan_server.tests.utils import ScanServerMock
 
 
@@ -31,29 +32,96 @@ class _TestDirectScan(ScanBase):
         if self.fail_step == step_name:
             raise RuntimeError(f"{step_name} failed")
 
+    @scan_hook
     def prepare_scan(self):
         self._record_step("prepare_scan")
 
+    @scan_hook
     def open_scan(self):
         self._record_step("open_scan")
 
+    @scan_hook
     def stage(self):
         self._record_step("stage")
 
+    @scan_hook
     def pre_scan(self):
         self._record_step("pre_scan")
 
+    @scan_hook
     def scan_core(self):
         self._record_step("scan_core")
+        self.at_each_point("scan_core-point")
 
+    @scan_hook
+    def at_each_point(self, point):
+        self.called_steps.append(("at_each_point", point))
+
+    @scan_hook
     def post_scan(self):
         self._record_step("post_scan")
 
+    @scan_hook
     def unstage(self):
         self._record_step("unstage")
 
+    @scan_hook
     def close_scan(self):
         self._record_step("close_scan")
+
+    @scan_hook
+    def on_exception(self, exc):
+        self.called_steps.append(("on_exception", exc))
+
+
+class _HookRecordingModifier(ScanModifier):
+    @scan_hook_impl("stage", "before")
+    def before_stage(self):
+        self.scan.called_steps.append("modifier:before_stage")
+
+    @scan_hook_impl("scan_core", "before")
+    def before_scan_core(self):
+        self.scan.called_steps.append("modifier:before_scan_core")
+
+    @scan_hook_impl("pre_scan", "replace")
+    def replace_pre_scan(self):
+        self.scan.called_steps.append("modifier:replace_pre_scan")
+
+    @scan_hook_impl("scan_core", "replace")
+    def replace_scan_core(self):
+        self.scan.called_steps.append("modifier:replace_scan_core")
+
+    @scan_hook_impl("scan_core", "after")
+    def after_scan_core(self):
+        self.scan.called_steps.append("modifier:after_scan_core")
+
+    @scan_hook_impl("at_each_point", "before")
+    def before_at_each_point(self, point):
+        self.scan.called_steps.append(("modifier:before_at_each_point", point))
+
+    @scan_hook_impl("at_each_point", "replace")
+    def replace_at_each_point(self, point):
+        self.scan.called_steps.append(("modifier:replace_at_each_point", point))
+
+    @scan_hook_impl("at_each_point", "after")
+    def after_at_each_point(self, point):
+        self.scan.called_steps.append(("modifier:after_at_each_point", point))
+
+    @scan_hook_impl("close_scan", "after")
+    def after_close_scan(self):
+        self.scan.called_steps.append("modifier:after_close_scan")
+
+    @scan_hook_impl("on_exception", "before")
+    def before_on_exception(self, exc):
+        self.scan.called_steps.append(("modifier:before_on_exception", exc))
+
+    @scan_hook_impl("on_exception", "replace")
+    def replace_on_exception(self, exc):
+        self.scan.called_steps.append(("modifier:replace_on_exception", exc))
+
+    @scan_hook_impl("on_exception", "after")
+    def after_on_exception(self, exc):
+        self.scan.called_steps.append(("modifier:after_on_exception", exc))
 
 
 @pytest.fixture
@@ -96,6 +164,7 @@ def make_scan(direct_worker_context):
             redis_connector=direct_worker_context.connector,
             device_manager=direct_worker_context.device_manager,
             instruction_handler=direct_worker_context.instruction_handler,
+            scan_modifier=None,
             request_inputs={},
             system_config={},
             called_steps=called_steps,
@@ -219,6 +288,7 @@ def test_run_executes_full_scan_sequence_in_order(direct_worker_context, make_sc
         "stage",
         "pre_scan",
         "scan_core",
+        ("at_each_point", "scan_core-point"),
         "post_scan",
         "unstage",
         "close_scan",
@@ -226,6 +296,52 @@ def test_run_executes_full_scan_sequence_in_order(direct_worker_context, make_sc
     assert direct_worker_context.queue.status == InstructionQueueStatus.COMPLETED
     assert direct_worker_context.scan_worker.current_instruction_queue_item is None
     assert direct_worker_context.direct_worker.scan is None
+
+
+def test_run_executes_modifier_hooks_in_order(direct_worker_context, make_scan):
+    called_steps = []
+    scan = make_scan(called_steps=called_steps)
+    direct_worker_context.queue.active_scan = scan
+    direct_worker_context.scan_worker.current_instruction_queue_item = direct_worker_context.queue
+    direct_worker_context.device_manager._rpc_method = mock.MagicMock(return_value=mock.MagicMock())
+    scan._scan_modifier = _HookRecordingModifier(scan)
+    scan._scan_modifier_hooks = {
+        "stage": {"before": "before_stage"},
+        "pre_scan": {"replace": "replace_pre_scan"},
+        "scan_core": {
+            "before": "before_scan_core",
+            "replace": "replace_scan_core",
+            "after": "after_scan_core",
+        },
+        "at_each_point": {
+            "before": "before_at_each_point",
+            "replace": "replace_at_each_point",
+            "after": "after_at_each_point",
+        },
+        "close_scan": {"after": "after_close_scan"},
+        "on_exception": {
+            "before": "before_on_exception",
+            "replace": "replace_on_exception",
+            "after": "after_on_exception",
+        },
+    }
+
+    direct_worker_context.direct_worker.run(scan)
+
+    assert called_steps == [
+        "prepare_scan",
+        "open_scan",
+        "modifier:before_stage",
+        "stage",
+        "modifier:replace_pre_scan",
+        "modifier:before_scan_core",
+        "modifier:replace_scan_core",
+        "modifier:after_scan_core",
+        "post_scan",
+        "unstage",
+        "close_scan",
+        "modifier:after_close_scan",
+    ]
 
 
 def test_run_returns_early_when_signal_event_is_set(direct_worker_context, make_scan):
@@ -279,10 +395,10 @@ def test_run_reraises_when_queue_has_no_active_request_block(direct_worker_conte
 
 def test_run_uses_on_exception_cleanup_before_handling_error(direct_worker_context, make_scan):
     scan = make_scan(fail_step="scan_core")
+    scan.on_exception = mock.MagicMock()
     direct_worker_context.queue.active_scan = scan
     direct_worker_context.scan_worker.current_instruction_queue_item = direct_worker_context.queue
     direct_worker_context.device_manager._rpc_method = mock.MagicMock(return_value=mock.MagicMock())
-    direct_worker_context.direct_worker._run_on_exception_hook = mock.MagicMock()
     direct_worker_context.direct_worker._handle_exception = mock.MagicMock(
         side_effect=ScanAbortion()
     )
@@ -293,9 +409,10 @@ def test_run_uses_on_exception_cleanup_before_handling_error(direct_worker_conte
     assert direct_worker_context.queue.stopped is True
     assert direct_worker_context.scan_worker.status == InstructionQueueStatus.RUNNING
     assert scan.actions._metadata_suffix == "__on-exception"
-    direct_worker_context.direct_worker._run_on_exception_hook.assert_called_once()
+    scan.on_exception.assert_called_once()
+    assert isinstance(scan.on_exception.call_args.args[0], RuntimeError)
     assert isinstance(
-        direct_worker_context.direct_worker._run_on_exception_hook.call_args.args[0], RuntimeError
+        direct_worker_context.direct_worker._handle_exception.call_args.args[0], RuntimeError
     )
     direct_worker_context.direct_worker._handle_exception.assert_called_once()
 
@@ -303,12 +420,10 @@ def test_run_uses_on_exception_cleanup_before_handling_error(direct_worker_conte
 def test_run_handles_cleanup_exception_before_original_error(direct_worker_context, make_scan):
     scan = make_scan(fail_step="scan_core")
     cleanup_exc = UserScanInterruption(exit_info=("halted", "user"))
+    scan.on_exception = mock.MagicMock(side_effect=cleanup_exc)
     direct_worker_context.queue.active_scan = scan
     direct_worker_context.scan_worker.current_instruction_queue_item = direct_worker_context.queue
     direct_worker_context.device_manager._rpc_method = mock.MagicMock(return_value=mock.MagicMock())
-    direct_worker_context.direct_worker._run_on_exception_hook = mock.MagicMock(
-        side_effect=cleanup_exc
-    )
     direct_worker_context.direct_worker._handle_exception = mock.MagicMock(
         side_effect=ScanAbortion()
     )
@@ -316,8 +431,10 @@ def test_run_handles_cleanup_exception_before_original_error(direct_worker_conte
     with pytest.raises(ScanAbortion):
         direct_worker_context.direct_worker.run(scan)
 
-    direct_worker_context.connector.send_client_info.assert_called_once_with("")
-    assert direct_worker_context.direct_worker._handle_exception.call_args.args[0] is cleanup_exc
+    scan.actions.send_client_info.assert_called_once_with("")
+    assert isinstance(
+        direct_worker_context.direct_worker._handle_exception.call_args.args[0], RuntimeError
+    )
     direct_worker_context.queue.stopped = False
 
 
@@ -428,6 +545,38 @@ def test_run_on_exception_hook_uses_root_cause(direct_worker_context, make_scan)
     scan.on_exception.assert_called_once_with(root_cause)
 
 
+def test_run_on_exception_hook_runs_modifier_with_root_cause(direct_worker_context, make_scan):
+    called_steps = []
+    scan = make_scan(called_steps=called_steps)
+    direct_worker_context.direct_worker.scan = scan
+    direct_worker_context.scan_worker.current_instruction_queue_item = direct_worker_context.queue
+    direct_worker_context.queue.run_on_exception_hook = True
+    direct_worker_context.device_manager._rpc_method = mock.MagicMock(return_value=mock.MagicMock())
+    scan._scan_modifier = _HookRecordingModifier(scan)
+    scan._scan_modifier_hooks = {
+        "on_exception": {
+            "before": "before_on_exception",
+            "replace": "replace_on_exception",
+            "after": "after_on_exception",
+        }
+    }
+    root_cause = RuntimeError("root cause")
+
+    try:
+        raise root_cause
+    except RuntimeError as cause:
+        exc = ScanAbortion()
+        exc.__cause__ = cause
+        direct_worker_context.direct_worker._run_on_exception_hook(exc)
+
+    assert called_steps == [
+        ("modifier:before_on_exception", root_cause),
+        ("modifier:replace_on_exception", root_cause),
+        ("modifier:after_on_exception", root_cause),
+    ]
+    assert ("on_exception", root_cause) not in called_steps
+
+
 def test_run_on_exception_hook_returns_when_scan_is_none(direct_worker_context):
     direct_worker_context.direct_worker.scan = None
     direct_worker_context.scan_worker.current_instruction_queue_item = direct_worker_context.queue
@@ -449,7 +598,7 @@ def test_run_on_exception_hook_returns_when_on_exception_is_missing(
 def test_run_on_exception_hook_sends_client_info_when_hook_fails(direct_worker_context, make_scan):
     scan = make_scan()
 
-    def _fail(_exc):
+    def _fail():
         raise RuntimeError("cleanup failed")
 
     scan.on_exception = _fail

--- a/bec_server/tests/tests_scan_server/test_scan_argument_modifier.py
+++ b/bec_server/tests/tests_scan_server/test_scan_argument_modifier.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from typing import Annotated, get_args, get_origin
+from unittest import mock
+
+from bec_lib.scan_args import ScanArgument
+from bec_lib.signature_serializer import serialize_dtype
+from bec_server.scan_server.scans.acquire import Acquire
+from bec_server.scan_server.scans.fermat_scan import FermatSpiralScan
+from bec_server.scan_server.scans.line_scan import LineScan
+from bec_server.scan_server.scans.scan_argument_modifier import (
+    _convert_annotation,
+    gui_config_with_modifiers,
+    scan_doc_with_modifiers,
+    scan_signature_with_modifiers,
+)
+from bec_server.scan_server.scans.scan_base import ScanBase
+
+
+def test_convert_annotation_wraps_plain_type_with_scan_argument():
+    converted = _convert_annotation("float")
+
+    assert get_origin(converted) is Annotated
+    base_annotation, metadata = get_args(converted)
+    assert base_annotation is float
+    assert isinstance(metadata, ScanArgument)
+
+
+def test_convert_annotation_preserves_existing_scan_argument_metadata():
+    annotation = Annotated[float, ScanArgument(display_name="Exposure Time", ge=0)]
+
+    converted = _convert_annotation(serialize_dtype(annotation))
+
+    assert get_origin(converted) is Annotated
+    base_annotation, metadata = get_args(converted)
+    assert base_annotation is float
+    assert isinstance(metadata, ScanArgument)
+    assert metadata.display_name == "Exposure Time"
+    assert metadata.ge == 0
+
+
+def test_convert_annotation_returns_none_for_empty_annotation():
+    assert _convert_annotation("_empty") is None
+
+
+class DummyScan(ScanBase):
+    scan_name = "dummy_scan"
+
+    def __init__(self, value: float, relative: bool = True, **kwargs):
+        """
+        Dummy scan used for modifier tests.
+        """
+        super().__init__(**kwargs)
+        self.value = value
+        self.relative = relative
+
+
+class GenericClassDocScan(ScanBase):
+    scan_name = "generic_class_doc_scan"
+    __doc__ = ScanBase.__init__.__doc__
+
+    def __init__(self, level: int, **kwargs):
+        """
+        Specific init doc used for modifier tests.
+
+        Args:
+            level (int): level value
+        """
+        super().__init__(**kwargs)
+
+
+class DummyModifier:
+    @staticmethod
+    def scan_argument_overrides(scan_name, arguments, defaults):
+        arguments.pop("relative", None)
+        defaults["value"] = 2.5
+        arguments["extra"] = Annotated[
+            int, ScanArgument(description="extra modifier parameter", ge=0)
+        ]
+        defaults["extra"] = 3
+        return arguments, defaults
+
+    @staticmethod
+    def gui_config_overrides(scan_name, gui_config):
+        gui_config["Timing"] = [*gui_config.get("Timing", []), "extra"]
+        return gui_config
+
+
+def test_scan_signature_with_modifiers_uses_init_signature_directly():
+    with mock.patch(
+        "bec_server.scan_server.scans.scan_argument_modifier.get_scan_modifier",
+        return_value=DummyModifier,
+    ):
+        signature = scan_signature_with_modifiers(DummyScan)
+
+    names = [entry["name"] for entry in signature]
+    assert "relative" not in names
+
+    value = next(entry for entry in signature if entry["name"] == "value")
+    extra = next(entry for entry in signature if entry["name"] == "extra")
+
+    assert value["default"] == 2.5
+    assert "Annotated" in value["annotation"]
+    assert extra["kind"] == "KEYWORD_ONLY"
+    assert extra["default"] == 3
+
+
+def test_scan_signature_with_modifiers_preserves_arg_bundles():
+    signature = scan_signature_with_modifiers(LineScan)
+
+    assert signature[0]["name"] == "args"
+    assert signature[0]["kind"] == "VAR_POSITIONAL"
+
+
+def test_gui_config_with_modifiers_returns_original_config_without_modifier():
+    gui_config = {"Timing": ["value"]}
+
+    with mock.patch(
+        "bec_server.scan_server.scans.scan_argument_modifier.get_scan_modifier", return_value=None
+    ):
+        modified = gui_config_with_modifiers(DummyScan, gui_config)
+
+    assert modified == {"Timing": ["value"]}
+
+
+def test_gui_config_with_modifiers_applies_modifier_override():
+    gui_config = {"Timing": ["value"]}
+
+    with mock.patch(
+        "bec_server.scan_server.scans.scan_argument_modifier.get_scan_modifier",
+        return_value=DummyModifier,
+    ):
+        modified = gui_config_with_modifiers(DummyScan, gui_config)
+
+    assert modified == {"Timing": ["value", "extra"]}
+
+
+def test_scan_doc_with_modifiers_does_not_suffix_non_bundle_devices():
+    with mock.patch(
+        "bec_server.scan_server.scans.scan_argument_modifier.get_scan_modifier", return_value=None
+    ):
+        doc = scan_doc_with_modifiers(FermatSpiralScan)
+
+    assert "dev.motor1" in doc
+    assert "dev.motor2" in doc
+
+
+def test_scan_doc_with_modifiers_rebuilds_args_section_from_effective_signature():
+    with mock.patch(
+        "bec_server.scan_server.scans.scan_argument_modifier.get_scan_modifier",
+        return_value=DummyModifier,
+    ):
+        doc = scan_doc_with_modifiers(DummyScan)
+
+    assert "Dummy scan used for modifier tests." in doc
+    assert "Args:" in doc
+    assert "value (float): value. Default: 2.5" in doc
+    assert "extra (int): extra modifier parameter. Default: 3" in doc
+    assert "relative (bool)" not in doc
+    assert "Examples:" in doc
+    assert "Minimum:" in doc
+    assert ">>> scans.dummy_scan()" in doc
+    assert "Full:" in doc
+    assert ">>> scans.dummy_scan(value=2.5, extra=3)" in doc
+    assert "relative=True" not in doc
+    assert "value=99.0" not in doc
+
+
+def test_scan_doc_with_modifiers_ignores_generic_base_docstring():
+    doc = scan_doc_with_modifiers(GenericClassDocScan)
+
+    assert "Specific init doc used for modifier tests." in doc
+    assert "Base class for all scans." not in doc
+
+
+def test_scan_doc_with_modifiers_renders_defaulted_acquire_parameters_as_kwargs_in_full_example():
+    doc = scan_doc_with_modifiers(Acquire)
+
+    assert "Full:" in doc
+    assert (
+        ">>> scans._v4_acquire(exp_time=0, frames_per_trigger=1, settling_time=0, "
+        "settling_time_after_trigger=0, readout_time=0, burst_at_each_point=1)"
+    ) in doc

--- a/bec_server/tests/tests_scan_server/test_scan_assembler.py
+++ b/bec_server/tests/tests_scan_server/test_scan_assembler.py
@@ -10,6 +10,7 @@ from bec_lib.scan_args import ScanArgument
 from bec_lib.tests.fixtures import dm_with_devices
 from bec_server.scan_server.scan_assembler import ScanAssembler
 from bec_server.scan_server.scans import ScanArgType
+from bec_server.scan_server.scans.acquire import Acquire
 from bec_server.scan_server.scans.legacy_scans import FermatSpiralScan, LineScan, RequestBase
 from bec_server.scan_server.scans.scan_base import ScanBase as ScanBaseV4
 
@@ -103,6 +104,63 @@ class CustomBundledScanWithDeviceKwarg(ScanBaseV4):
         super().__init__(**kwargs)
         self.received_args = args
         self.monitor = monitor
+
+
+class DefaultOverrideDirectScan(ScanBaseV4):
+    scan_name = "default_override_direct_scan"
+    is_scan = False
+
+    def __init__(self, target: float, dwell: float = 0.1, **kwargs):
+        super().__init__(**kwargs)
+        self.target = target
+        self.dwell = dwell
+
+
+class DefaultOverrideModifier:
+    @staticmethod
+    def scan_argument_overrides(scan_name, arguments, defaults):
+        if scan_name == "default_override_direct_scan":
+            defaults["dwell"] = 0.25
+        return arguments, defaults
+
+
+class RelativeHiddenDirectScan(ScanBaseV4):
+    scan_name = "relative_hidden_direct_scan"
+    is_scan = False
+
+    def __init__(self, target: float, *, relative: bool, **kwargs):
+        super().__init__(**kwargs)
+        self.target = target
+        self.relative = relative
+
+
+class RelativeHiddenModifier:
+    @staticmethod
+    def scan_argument_overrides(scan_name, arguments, defaults):
+        if scan_name == "relative_hidden_direct_scan":
+            arguments.pop("relative", None)
+            defaults["relative"] = False
+        return arguments, defaults
+
+
+class AdditionalParamsDirectScan(ScanBaseV4):
+    scan_name = "additional_params_direct_scan"
+    is_scan = False
+
+    def __init__(self, target: float, **kwargs):
+        super().__init__(**kwargs)
+        self.target = target
+
+
+class AdditionalParamsModifier:
+    @staticmethod
+    def scan_argument_overrides(scan_name, arguments, defaults):
+        if scan_name == "additional_params_direct_scan":
+            arguments["integ_time"] = Annotated[
+                float | None, ScanArgument(display_name="Integration Time", ge=0)
+            ]
+            defaults["integ_time"] = 0.5
+        return arguments, defaults
 
 
 @pytest.mark.parametrize(
@@ -474,3 +532,197 @@ def test_scan_assembler_resolves_signature_device_kwargs_for_arg_input_scan(dm_w
 
     assert request.received_args == (dm_with_devices.devices["samx"], 1)
     assert request.monitor is dm_with_devices.devices["samy"]
+
+
+def test_scan_assembler_applies_modified_defaults_before_scan_construction(dm_with_devices):
+    parent = mock.MagicMock()
+    parent.device_manager = dm_with_devices
+    parent.connector = mock.MagicMock()
+    parent.queue_manager.instruction_handler = mock.MagicMock()
+    assembler = ScanAssembler(parent=parent)
+
+    class MockScanManager:
+        scan_dict = {"default_override_direct_scan": DefaultOverrideDirectScan}
+
+    msg = messages.ScanQueueMessage(
+        scan_type="default_override_direct_scan",
+        parameter={"args": [1.0], "kwargs": {"system_config": {"file_directory": "/tmp/data"}}},
+        queue="primary",
+    )
+
+    with mock.patch.object(assembler, "scan_manager", MockScanManager()):
+        with mock.patch(
+            "bec_server.scan_server.scans.scan_argument_modifier.get_scan_modifier",
+            return_value=DefaultOverrideModifier,
+        ):
+            request = assembler.assemble_direct_scan(msg, "scan_id")
+
+    assert request.target == 1.0
+    assert request.dwell == 0.25
+
+
+def test_scan_assembler_applies_defaults_for_removed_signature_arguments(dm_with_devices):
+    parent = mock.MagicMock()
+    parent.device_manager = dm_with_devices
+    parent.connector = mock.MagicMock()
+    parent.queue_manager.instruction_handler = mock.MagicMock()
+    assembler = ScanAssembler(parent=parent)
+
+    class MockScanManager:
+        scan_dict = {"relative_hidden_direct_scan": RelativeHiddenDirectScan}
+
+    msg = messages.ScanQueueMessage(
+        scan_type="relative_hidden_direct_scan",
+        parameter={"args": [1.0], "kwargs": {"system_config": {"file_directory": "/tmp/data"}}},
+        queue="primary",
+    )
+
+    with mock.patch.object(assembler, "scan_manager", MockScanManager()):
+        with mock.patch(
+            "bec_server.scan_server.scans.scan_argument_modifier.get_scan_modifier",
+            return_value=RelativeHiddenModifier,
+        ):
+            request = assembler.assemble_direct_scan(msg, "scan_id")
+
+    assert request.target == 1.0
+    assert request.relative is False
+
+
+def test_scan_assembler_moves_defaulted_added_parameters_to_additional_scan_parameters(
+    dm_with_devices,
+):
+    parent = mock.MagicMock()
+    parent.device_manager = dm_with_devices
+    parent.connector = mock.MagicMock()
+    parent.queue_manager.instruction_handler = mock.MagicMock()
+    assembler = ScanAssembler(parent=parent)
+
+    class MockScanManager:
+        scan_dict = {"additional_params_direct_scan": AdditionalParamsDirectScan}
+
+    msg = messages.ScanQueueMessage(
+        scan_type="additional_params_direct_scan",
+        parameter={"args": [1.0], "kwargs": {"system_config": {"file_directory": "/tmp/data"}}},
+        queue="primary",
+    )
+
+    with mock.patch.object(assembler, "scan_manager", MockScanManager()):
+        with mock.patch(
+            "bec_server.scan_server.scans.scan_argument_modifier.get_scan_modifier",
+            return_value=AdditionalParamsModifier,
+        ):
+            request = assembler.assemble_direct_scan(msg, "scan_id")
+
+    assert request.target == 1.0
+    assert request.scan_info.additional_scan_parameters["integ_time"] == 0.5
+
+
+def test_scan_assembler_moves_provided_added_parameters_to_additional_scan_parameters(
+    dm_with_devices,
+):
+    parent = mock.MagicMock()
+    parent.device_manager = dm_with_devices
+    parent.connector = mock.MagicMock()
+    parent.queue_manager.instruction_handler = mock.MagicMock()
+    assembler = ScanAssembler(parent=parent)
+
+    class MockScanManager:
+        scan_dict = {"additional_params_direct_scan": AdditionalParamsDirectScan}
+
+    msg = messages.ScanQueueMessage(
+        scan_type="additional_params_direct_scan",
+        parameter={
+            "args": [1.0],
+            "kwargs": {"integ_time": 1.25, "system_config": {"file_directory": "/tmp/data"}},
+        },
+        queue="primary",
+    )
+
+    with mock.patch.object(assembler, "scan_manager", MockScanManager()):
+        with mock.patch(
+            "bec_server.scan_server.scans.scan_argument_modifier.get_scan_modifier",
+            return_value=AdditionalParamsModifier,
+        ):
+            request = assembler.assemble_direct_scan(msg, "scan_id")
+
+    assert request.scan_info.additional_scan_parameters["integ_time"] == 1.25
+
+
+def test_scan_assembler_maps_optional_positional_direct_scan_args_to_request_kwargs(
+    dm_with_devices,
+):
+    parent = mock.MagicMock()
+    parent.device_manager = dm_with_devices
+    parent.connector = mock.MagicMock()
+    parent.queue_manager.instruction_handler = mock.MagicMock()
+    assembler = ScanAssembler(parent=parent)
+
+    class MockScanManager:
+        scan_dict = {"_v4_acquire": Acquire}
+
+    msg = messages.ScanQueueMessage(
+        scan_type="_v4_acquire",
+        parameter={
+            "args": [0, 1, 0, 0, 0, 1],
+            "kwargs": {"system_config": {"file_directory": "/tmp/data"}},
+        },
+        queue="primary",
+    )
+
+    with mock.patch.object(assembler, "scan_manager", MockScanManager()):
+        request = assembler.assemble_direct_scan(msg, "scan_id")
+
+    assert request.exp_time == 0
+    assert request.frames_per_trigger == 1
+    assert request.readout_time == 0
+    assert request.burst_at_each_point == 1
+    assert request.scan_info.request_inputs["inputs"] == {}
+    assert request.scan_info.request_inputs["kwargs"] == {
+        "exp_time": 0,
+        "frames_per_trigger": 1,
+        "settling_time": 0,
+        "settling_time_after_trigger": 0,
+        "readout_time": 0,
+        "burst_at_each_point": 1,
+        "system_config": {"file_directory": "/tmp/data"},
+    }
+
+
+def test_scan_assembler_maps_mixed_direct_scan_args_and_kwargs_for_acquire(dm_with_devices):
+    parent = mock.MagicMock()
+    parent.device_manager = dm_with_devices
+    parent.connector = mock.MagicMock()
+    parent.queue_manager.instruction_handler = mock.MagicMock()
+    assembler = ScanAssembler(parent=parent)
+
+    class MockScanManager:
+        scan_dict = {"_v4_acquire": Acquire}
+
+    msg = messages.ScanQueueMessage(
+        scan_type="_v4_acquire",
+        parameter={
+            "args": [0, 1],
+            "kwargs": {
+                "readout_time": 0.25,
+                "burst_at_each_point": 3,
+                "system_config": {"file_directory": "/tmp/data"},
+            },
+        },
+        queue="primary",
+    )
+
+    with mock.patch.object(assembler, "scan_manager", MockScanManager()):
+        request = assembler.assemble_direct_scan(msg, "scan_id")
+
+    assert request.exp_time == 0
+    assert request.frames_per_trigger == 1
+    assert request.readout_time == 0.25
+    assert request.burst_at_each_point == 3
+    assert request.scan_info.request_inputs["inputs"] == {}
+    assert request.scan_info.request_inputs["kwargs"] == {
+        "exp_time": 0,
+        "frames_per_trigger": 1,
+        "readout_time": 0.25,
+        "burst_at_each_point": 3,
+        "system_config": {"file_directory": "/tmp/data"},
+    }

--- a/bec_server/tests/tests_scan_server/test_scan_modifier.py
+++ b/bec_server/tests/tests_scan_server/test_scan_modifier.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from bec_server.scan_server.scans.scan_modifier import (
+    ScanModifier,
+    get_scan_hooks_impl,
+    scan_hook,
+    scan_hook_impl,
+)
+
+
+class _DummyModifier:
+    @scan_hook_impl("stage", "before")
+    def before_stage(self):
+        pass
+
+    @scan_hook_impl("close_scan", "after")
+    def after_close_scan(self):
+        pass
+
+
+def test_scan_hook_marks_method_with_hook_info():
+    @scan_hook
+    def prepare_scan(self):
+        return "ok"
+
+    scan = SimpleNamespace(_scan_modifier_hooks={}, _scan_modifier=None)
+
+    assert prepare_scan._scan_hook_info == {"method_name": "prepare_scan"}  # type: ignore[attr-defined]
+    assert prepare_scan(scan) == "ok"
+
+
+def test_scan_hook_impl_registers_hook_metadata():
+    hooks = get_scan_hooks_impl(_DummyModifier)
+
+    assert hooks == {
+        "stage": {"before": "before_stage"},
+        "close_scan": {"after": "after_close_scan"},
+    }
+
+
+def test_scan_hook_impl_rejects_invalid_hook_name():
+    with pytest.raises(ValueError, match="Invalid scan hook"):
+        scan_hook_impl("not_a_hook")  # type: ignore[arg-type]
+
+
+def test_scan_hook_impl_rejects_invalid_hook_type():
+    with pytest.raises(ValueError, match="Invalid scan hook type"):
+        scan_hook_impl("stage", "during")  # type: ignore[arg-type]
+
+
+def test_scan_modifier_device_is_available_checks_presence_and_enabled_state():
+    scan = SimpleNamespace(
+        dev={"samx": SimpleNamespace(enabled=True), "samy": SimpleNamespace(enabled=False)},
+        actions=None,
+        components=None,
+        scan_info=None,
+    )
+    modifier = ScanModifier(scan)
+
+    assert modifier.device_is_available("samx") is True
+    assert modifier.device_is_available("missing") is False
+    assert modifier.device_is_available("samy") is False
+    assert modifier.device_is_available("samy", check_enabled=False) is True
+    assert modifier.device_is_available(["samx", "samy"], check_enabled=False) is True

--- a/bec_server/tests/tests_scan_server/test_scan_server_scan_manager.py
+++ b/bec_server/tests/tests_scan_server/test_scan_server_scan_manager.py
@@ -4,8 +4,10 @@ from unittest import mock
 import pytest
 
 from bec_lib.device import Device, DeviceBase, Positioner
+from bec_lib.scan_args import ScanArgument
 from bec_server.scan_server.scan_manager import ScanManager
 from bec_server.scan_server.scans import ScanArgType
+from bec_server.scan_server.scans.scan_base import ScanBase
 
 
 @pytest.fixture
@@ -47,3 +49,63 @@ def test_scan_manager_convert_arg_input_does_not_mutate(scan_manager):
     scan_manager.convert_arg_input(arg_input)
 
     assert arg_input == {"a": ScanArgType.FLOAT}
+
+
+class _GuiConfigScan(ScanBase):
+    scan_name = "gui_config_scan"
+    arg_input = {}
+    arg_bundle_size = {"bundle": 0, "min": None, "max": None}
+    gui_config = {"Timing": ["exp_time"]}
+
+    def __init__(self, *, exp_time: float = 0.1, **kwargs):
+        """
+        Dummy scan used for GUI config override tests.
+
+        Args:
+            exp_time (float): exposure time
+
+        Returns:
+            ScanReport
+        """
+        super().__init__(**kwargs)
+
+
+class _GuiConfigModifier:
+    @staticmethod
+    def scan_argument_overrides(scan_name, arguments, defaults):
+        arguments["integ_time"] = Annotated[float, ScanArgument(description="integration time")]
+        arguments["frames_per_trigger"] = Annotated[
+            int, ScanArgument(description="frames per trigger")
+        ]
+        defaults["integ_time"] = 0.5
+        defaults["frames_per_trigger"] = 1
+        return arguments, defaults
+
+    @staticmethod
+    def gui_config_overrides(scan_name, gui_config):
+        gui_config["Timing"].append("integ_time")
+        gui_config["Advanced"] = ["frames_per_trigger"]
+        return gui_config
+
+
+def test_scan_manager_does_not_apply_gui_config_overrides_to_legacy_gui_config(scan_manager):
+    with (
+        mock.patch.object(
+            ScanManager, "get_available_scans", return_value=[("gui", _GuiConfigScan)]
+        ),
+        mock.patch(
+            "bec_server.scan_server.scans.scan_argument_modifier.get_scan_modifier",
+            return_value=_GuiConfigModifier,
+        ),
+    ):
+        scan_manager.available_scans = {}
+        scan_manager.scan_dict = {}
+        scan_manager.update_available_scans()
+
+    gui_config = scan_manager.available_scans[_GuiConfigScan.scan_name]["gui_config"]
+    groups = {
+        group["name"]: [entry["name"] for entry in group["inputs"]]
+        for group in gui_config["kwarg_groups"]
+    }
+    assert groups["Timing"] == ["exp_time"]
+    assert "Advanced" not in groups


### PR DESCRIPTION
## Description

This PR adds proper support for scan modifiers, including scan argument modification and gui config modification. To this end, the scan doc string and the examples are now created dynamically through the defined scan arguments. This allows modifiers to freely add and remove arguments whilst keeping everything up to date. 

## Type of Change

- Add support for scan modifiers, gui_config and scan argument modifications
- Auto-generate doc strings + signature + examples based on the currently active modifiers (v4 only!)

## How to test

- Run unit tests
- Add a scan modifier to the plugin repo

## Additional Comments

I'm preparing a PR for the plugin repo to also run e2e tests against a modifier. Once we've merged this PR, we can merge the plugin repo and add the e2e test in here. 
