### PR TITLE
chore: disable codecov for dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
 
   upload-coverage:
     needs: [unit-test, end2end-test]
-    if: needs.check_pr_status.outputs.branch-pr == ''
+    if: needs.check_pr_status.outputs.branch-pr == '' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/sync-issues-pr.yml
+++ b/.github/workflows/sync-issues-pr.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   sync-project:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     permissions:
@@ -14,11 +15,11 @@ jobs:
       contents: read
 
     env:
-        PROJECT_NUMBER: 3 # BEC Project
-        ORG: 'bec-project'
-        REPO: 'bec'
-        TOKEN: ${{ secrets.ADD_ISSUE_TO_PROJECT }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
+      PROJECT_NUMBER: 3 # BEC Project
+      ORG: "bec-project"
+      REPO: "bec"
+      TOKEN: ${{ secrets.ADD_ISSUE_TO_PROJECT }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
 
     steps:
       - name: Set up python environment


### PR DESCRIPTION
don't run `upload-coverage` on dependabot PRs