### PR TITLE
feat: implement AtlasActiveClientEmitter for tracking active clients …

### DIFF
--- a/bec_server/bec_server/scihub/atlas/__init__.py
+++ b/bec_server/bec_server/scihub/atlas/__init__.py
@@ -1,1 +1,2 @@
+from .atlas_active_client_emitter import AtlasActiveClientEmitter
 from .atlas_connector import AtlasConnector

--- a/bec_server/bec_server/scihub/atlas/atlas_active_client_emitter.py
+++ b/bec_server/bec_server/scihub/atlas/atlas_active_client_emitter.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from bec_lib import messages
+from bec_lib.endpoints import MessageEndpoints
+
+if TYPE_CHECKING:  # pragma: no cover
+    from bec_server.scihub.atlas.atlas_connector import AtlasConnector
+
+_INTERNAL_SERVICE_PREFIXES = (
+    "DeviceServer",
+    "FileWriterManager",
+    "DAPServer",
+    "ScanBundler",
+    "ScanServer",
+    "SciHub",
+)
+
+
+class AtlasActiveClientEmitter:
+
+    def __init__(self, atlas_connector: AtlasConnector) -> None:
+        self.atlas_connector = atlas_connector
+        self._last_active_client_metrics: dict[str, messages.DynamicMetricValue] | None = None
+        self._start_service_status_subscription()
+        self._emit_active_client_metrics()
+
+    def _start_service_status_subscription(self):
+        self.atlas_connector.connector.register(
+            patterns=MessageEndpoints.service_status("*"), cb=self._handle_service_status
+        )
+
+    def _handle_service_status(self, _msg, **_kwargs) -> None:
+        self._emit_active_client_metrics()
+
+    def _emit_active_client_metrics(self) -> None:
+        metrics = self._get_active_client_metrics()
+        if metrics == self._last_active_client_metrics:
+            return
+        self._last_active_client_metrics = metrics
+        metric_msg = messages.DynamicMetricMessage(metrics=metrics)
+        self.atlas_connector.connector.set_and_publish(
+            MessageEndpoints.dynamic_metric("active_clients"), metric_msg
+        )
+
+    def _get_active_client_metrics(self) -> dict[str, messages._StrDynamicMetricValue]:
+        active_clients = {}
+        for service_name, status_msg in self.atlas_connector.scihub.service_status.items():
+            if self._is_internal_service(service_name):
+                continue
+            if status_msg.status != messages.BECStatus.RUNNING:
+                continue
+            info = status_msg.info
+            hostname = (
+                info.hostname if isinstance(info, messages.ServiceInfo) else info.get("hostname")
+            )
+            if hostname:
+                active_clients[service_name] = messages._StrDynamicMetricValue(value=hostname)
+        return active_clients
+
+    @classmethod
+    def _is_internal_service(cls, service_name: str) -> bool:
+        return service_name.startswith(_INTERNAL_SERVICE_PREFIXES)
+
+    def shutdown(self):
+        self.atlas_connector.connector.unregister(
+            patterns=MessageEndpoints.service_status("*"), cb=self._handle_service_status
+        )

--- a/bec_server/bec_server/scihub/atlas/atlas_active_client_emitter.py
+++ b/bec_server/bec_server/scihub/atlas/atlas_active_client_emitter.py
@@ -39,12 +39,9 @@ class AtlasActiveClientEmitter:
         if metrics == self._last_active_client_metrics:
             return
         self._last_active_client_metrics = metrics
-        metric_msg = messages.DynamicMetricMessage(metrics=metrics)
-        self.atlas_connector.connector.set_and_publish(
-            MessageEndpoints.dynamic_metric("active_clients"), metric_msg
-        )
+        self.atlas_connector.connector.publish_metrics("active_clients", metrics)
 
-    def _get_active_client_metrics(self) -> dict[str, messages._StrDynamicMetricValue]:
+    def _get_active_client_metrics(self) -> dict[str, str]:
         active_clients = {}
         for service_name, status_msg in self.atlas_connector.scihub.service_status.items():
             if self._is_internal_service(service_name):
@@ -56,7 +53,7 @@ class AtlasActiveClientEmitter:
                 info.hostname if isinstance(info, messages.ServiceInfo) else info.get("hostname")
             )
             if hostname:
-                active_clients[service_name] = messages._StrDynamicMetricValue(value=hostname)
+                active_clients[service_name] = hostname
         return active_clients
 
     @classmethod

--- a/bec_server/bec_server/scihub/atlas/atlas_active_client_emitter.py
+++ b/bec_server/bec_server/scihub/atlas/atlas_active_client_emitter.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from bec_lib import messages
+from bec_lib.endpoints import MessageEndpoints
+
+if TYPE_CHECKING:  # pragma: no cover
+    from bec_server.scihub.atlas.atlas_connector import AtlasConnector
+
+_INTERNAL_SERVICE_PREFIXES = (
+    "DeviceServer",
+    "FileWriterManager",
+    "DAPServer",
+    "ScanBundler",
+    "ScanServer",
+    "SciHub",
+)
+
+
+class AtlasActiveClientEmitter:
+
+    def __init__(self, atlas_connector: AtlasConnector) -> None:
+        self.atlas_connector = atlas_connector
+        self._last_active_client_metrics: dict[str, messages.DynamicMetricValue] | None = None
+        self._start_service_status_subscription()
+        self._emit_active_client_metrics()
+
+    def _start_service_status_subscription(self):
+        self.atlas_connector.connector.register(
+            patterns=MessageEndpoints.service_status("*"), cb=self._handle_service_status
+        )
+
+    def _handle_service_status(self, _msg, **_kwargs) -> None:
+        self._emit_active_client_metrics()
+
+    def _emit_active_client_metrics(self) -> None:
+        metrics = self._get_active_client_metrics()
+        if metrics == self._last_active_client_metrics:
+            return
+        self._last_active_client_metrics = metrics
+        self.atlas_connector.connector.publish_metrics("active_clients", metrics)
+
+    def _get_active_client_metrics(self) -> dict[str, str]:
+        active_clients = {}
+        for service_name, status_msg in self.atlas_connector.scihub.service_status.items():
+            if self._is_internal_service(service_name):
+                continue
+            if status_msg.status != messages.BECStatus.RUNNING:
+                continue
+            info = status_msg.info
+            hostname = (
+                info.hostname if isinstance(info, messages.ServiceInfo) else info.get("hostname")
+            )
+            if hostname:
+                active_clients[service_name] = hostname
+        return active_clients
+
+    @classmethod
+    def _is_internal_service(cls, service_name: str) -> bool:
+        return service_name.startswith(_INTERNAL_SERVICE_PREFIXES)
+
+    def shutdown(self):
+        self.atlas_connector.connector.unregister(
+            patterns=MessageEndpoints.service_status("*"), cb=self._handle_service_status
+        )

--- a/bec_server/bec_server/scihub/atlas/atlas_connector.py
+++ b/bec_server/bec_server/scihub/atlas/atlas_connector.py
@@ -11,6 +11,7 @@ from bec_lib.logger import bec_logger
 from bec_lib.redis_connector import RedisConnector
 from bec_lib.signature_serializer import signature_to_dict
 
+from .atlas_active_client_emitter import AtlasActiveClientEmitter
 from .atlas_forwarder import AtlasForwarder
 from .atlas_metadata_handler import AtlasMetadataHandler
 from .config_handler import ConfigHandler
@@ -39,12 +40,14 @@ class AtlasConnector:
         self._config_request_handler = None
         self.config_handler = None
         self.metadata_handler = None
+        self.active_client_emitter = None
         self.atlas_forwarder = None
 
     def start(self):
         self.connect_to_atlas()
         self.config_handler = ConfigHandler(self, self.connector)
         self._start_config_request_handler()
+        self.active_client_emitter = AtlasActiveClientEmitter(self)
         if self.connected_to_atlas:
             self.metadata_handler = AtlasMetadataHandler(self)
             self.atlas_forwarder = AtlasForwarder(self)
@@ -255,6 +258,8 @@ class AtlasConnector:
             self._config_request_handler.shutdown()
         if self.metadata_handler:
             self.metadata_handler.shutdown()
+        if self.active_client_emitter:
+            self.active_client_emitter.shutdown()
         if self.atlas_forwarder:
             self.atlas_forwarder.shutdown()
         if self.redis_atlas:

--- a/bec_server/bec_server/scihub/atlas/atlas_connector.py
+++ b/bec_server/bec_server/scihub/atlas/atlas_connector.py
@@ -53,6 +53,9 @@ class AtlasConnector:
             self.atlas_forwarder = AtlasForwarder(self)
         self.update_acls()
         self.update_available_endpoints()
+        self.connector.publish_metrics(
+            "atlas_connection", {"connected": self.connected_to_atlas, "host": self.host or ""}
+        )
 
     @property
     def config(self):

--- a/bec_server/bec_server/scihub/atlas/atlas_metadata_handler.py
+++ b/bec_server/bec_server/scihub/atlas/atlas_metadata_handler.py
@@ -181,11 +181,8 @@ class AtlasMetadataHandler:
         logger.info(f"Updated account to: {self._account}")
 
     def _emit_current_account_metric(self, account: str) -> None:
-        metric_msg = messages.DynamicMetricMessage(
-            metrics={"active_account": messages._StrDynamicMetricValue(value=account)}
-        )
-        self.atlas_connector.connector.set_and_publish(
-            MessageEndpoints.dynamic_metric("active_account"), metric_msg
+        self.atlas_connector.connector.publish_metrics(
+            "active_account", {"active_account": account}
         )
 
     def _handle_scan_status(self, msg, **_kwargs) -> None:

--- a/bec_server/bec_server/scihub/atlas/atlas_metadata_handler.py
+++ b/bec_server/bec_server/scihub/atlas/atlas_metadata_handler.py
@@ -27,7 +27,6 @@ class AtlasMetadataHandler:
 
     def __init__(self, atlas_connector: AtlasConnector) -> None:
         self.atlas_connector = atlas_connector
-        self._scan_status_register = None
         self._account = None
         self._deployment_info: messages.DeploymentInfoMessage | None = None
         self._start_account_subscription()
@@ -59,12 +58,12 @@ class AtlasMetadataHandler:
         )
 
     def _start_scan_subscription(self):
-        self._scan_status_register = self.atlas_connector.connector.register(
+        self.atlas_connector.connector.register(
             MessageEndpoints.scan_status(), cb=self._handle_scan_status
         )
 
     def _start_scan_history_subscription(self):
-        self._scan_history_register = self.atlas_connector.connector.register(
+        self.atlas_connector.connector.register(
             MessageEndpoints.scan_history(), cb=self._handle_scan_history
         )
 
@@ -137,6 +136,7 @@ class AtlasMetadataHandler:
             self.atlas_connector.connector.xadd(
                 MessageEndpoints.account(), {"data": msg}, max_size=1, approximate=False
             )
+            self._emit_current_account_metric(account)
             logger.info(f"Updated local account to: {account}")
 
     def _update_account_if_needed(self):
@@ -175,9 +175,15 @@ class AtlasMetadataHandler:
             # Account is the same as the current one, no need to update
             return
         self._account = msg.value
+        self._emit_current_account_metric(msg.value)
         if emit_update:
             self.send_atlas_update({"account": msg})
         logger.info(f"Updated account to: {self._account}")
+
+    def _emit_current_account_metric(self, account: str) -> None:
+        self.atlas_connector.connector.publish_metrics(
+            "active_account", {"active_account": account}
+        )
 
     def _handle_scan_status(self, msg, **_kwargs) -> None:
         msg = msg.value
@@ -234,5 +240,18 @@ class AtlasMetadataHandler:
         """
         Shutdown the metadata handler
         """
-        if self._scan_status_register:
-            self._scan_status_register.shutdown()
+        self.atlas_connector.connector.unregister(
+            MessageEndpoints.account(), cb=self._handle_account_info
+        )
+        self.atlas_connector.connector.unregister(
+            MessageEndpoints.scan_status(), cb=self._handle_scan_status
+        )
+        self.atlas_connector.connector.unregister(
+            MessageEndpoints.scan_history(), cb=self._handle_scan_history
+        )
+        self.atlas_connector.connector.unregister(
+            MessageEndpoints.message_service_queue(), cb=self._handle_messaging
+        )
+        self.atlas_connector.connector.unregister(
+            MessageEndpoints.user_feedback(), cb=self._handle_feedback
+        )

--- a/bec_server/bec_server/scihub/atlas/atlas_metadata_handler.py
+++ b/bec_server/bec_server/scihub/atlas/atlas_metadata_handler.py
@@ -27,7 +27,6 @@ class AtlasMetadataHandler:
 
     def __init__(self, atlas_connector: AtlasConnector) -> None:
         self.atlas_connector = atlas_connector
-        self._scan_status_register = None
         self._account = None
         self._deployment_info: messages.DeploymentInfoMessage | None = None
         self._start_account_subscription()
@@ -59,12 +58,12 @@ class AtlasMetadataHandler:
         )
 
     def _start_scan_subscription(self):
-        self._scan_status_register = self.atlas_connector.connector.register(
+        self.atlas_connector.connector.register(
             MessageEndpoints.scan_status(), cb=self._handle_scan_status
         )
 
     def _start_scan_history_subscription(self):
-        self._scan_history_register = self.atlas_connector.connector.register(
+        self.atlas_connector.connector.register(
             MessageEndpoints.scan_history(), cb=self._handle_scan_history
         )
 
@@ -137,6 +136,7 @@ class AtlasMetadataHandler:
             self.atlas_connector.connector.xadd(
                 MessageEndpoints.account(), {"data": msg}, max_size=1, approximate=False
             )
+            self._emit_current_account_metric(account)
             logger.info(f"Updated local account to: {account}")
 
     def _update_account_if_needed(self):
@@ -175,9 +175,18 @@ class AtlasMetadataHandler:
             # Account is the same as the current one, no need to update
             return
         self._account = msg.value
+        self._emit_current_account_metric(msg.value)
         if emit_update:
             self.send_atlas_update({"account": msg})
         logger.info(f"Updated account to: {self._account}")
+
+    def _emit_current_account_metric(self, account: str) -> None:
+        metric_msg = messages.DynamicMetricMessage(
+            metrics={"active_account": messages._StrDynamicMetricValue(value=account)}
+        )
+        self.atlas_connector.connector.set_and_publish(
+            MessageEndpoints.dynamic_metric("active_account"), metric_msg
+        )
 
     def _handle_scan_status(self, msg, **_kwargs) -> None:
         msg = msg.value
@@ -234,5 +243,18 @@ class AtlasMetadataHandler:
         """
         Shutdown the metadata handler
         """
-        if self._scan_status_register:
-            self._scan_status_register.shutdown()
+        self.atlas_connector.connector.unregister(
+            MessageEndpoints.account(), cb=self._handle_account_info
+        )
+        self.atlas_connector.connector.unregister(
+            MessageEndpoints.scan_status(), cb=self._handle_scan_status
+        )
+        self.atlas_connector.connector.unregister(
+            MessageEndpoints.scan_history(), cb=self._handle_scan_history
+        )
+        self.atlas_connector.connector.unregister(
+            MessageEndpoints.message_service_queue(), cb=self._handle_messaging
+        )
+        self.atlas_connector.connector.unregister(
+            MessageEndpoints.user_feedback(), cb=self._handle_feedback
+        )

--- a/bec_server/tests/tests_scihub/test_atlas_active_client_emitter.py
+++ b/bec_server/tests/tests_scihub/test_atlas_active_client_emitter.py
@@ -43,30 +43,24 @@ def test_get_active_client_metrics_filters_internal_services(atlas_connector):
 
 def test_handle_service_status_emits_active_client_metric(atlas_connector):
     emitter = atlas_connector.active_client_emitter
-    received = []
     service_status = {
         "BECIPythonClient/client-1": create_status_message(
             "BECIPythonClient/client-1", hostname="client-host-1"
         ),
         "ScanServer": create_status_message("ScanServer", hostname="server-host"),
     }
-    atlas_connector.connector.register(
-        MessageEndpoints.dynamic_metric("active_clients"),
-        cb=lambda msg: received.append(msg.value),
-        start_thread=False,
-    )
 
-    with mock.patch.object(
-        type(atlas_connector.scihub), "service_status", new_callable=mock.PropertyMock
-    ) as mock_service_status:
+    with (
+        mock.patch.object(
+            type(atlas_connector.scihub), "service_status", new_callable=mock.PropertyMock
+        ) as mock_service_status,
+        mock.patch.object(atlas_connector.connector, "publish_metrics") as mock_publish_metrics,
+    ):
         mock_service_status.return_value = service_status
         emitter._handle_service_status(None)
-        atlas_connector.connector.poll_messages(timeout=1)
-
-    dynamic_metric = received[-1]
-    assert isinstance(dynamic_metric, messages.DynamicMetricMessage)
-    assert dynamic_metric.metrics["BECIPythonClient/client-1"].value == "client-host-1"
-    assert "ScanServer" not in dynamic_metric.metrics
+    mock_publish_metrics.assert_called_once_with(
+        "active_clients", {"BECIPythonClient/client-1": "client-host-1"}
+    )
 
 
 def test_handle_service_status_does_not_emit_unchanged_metric(atlas_connector):

--- a/bec_server/tests/tests_scihub/test_atlas_active_client_emitter.py
+++ b/bec_server/tests/tests_scihub/test_atlas_active_client_emitter.py
@@ -1,0 +1,83 @@
+from unittest import mock
+
+from bec_lib import messages
+from bec_lib.endpoints import MessageEndpoints
+
+
+def create_status_message(
+    name: str,
+    *,
+    status: messages.BECStatus = messages.BECStatus.RUNNING,
+    hostname: str = "localhost",
+):
+    return messages.StatusMessage(
+        name=name, status=status, info=messages.ServiceInfo(user="test-user", hostname=hostname)
+    )
+
+
+def test_get_active_client_metrics_filters_internal_services(atlas_connector):
+    emitter = atlas_connector.active_client_emitter
+    service_status = {
+        "BECIPythonClient/client-1": create_status_message(
+            "BECIPythonClient/client-1", hostname="client-host-1"
+        ),
+        "BECClient/client-2": create_status_message("BECClient/client-2", hostname="client-host-2"),
+        "SciHub": create_status_message("SciHub", hostname="internal-host"),
+        "DAPServer/image-analysis": create_status_message(
+            "DAPServer/image-analysis", hostname="internal-dap-host"
+        ),
+        "BECIPythonClient/not-running": create_status_message(
+            "BECIPythonClient/not-running", status=messages.BECStatus.IDLE, hostname="idle-host"
+        ),
+    }
+
+    with mock.patch.object(
+        type(atlas_connector.scihub), "service_status", new_callable=mock.PropertyMock
+    ) as mock_service_status:
+        mock_service_status.return_value = service_status
+        assert emitter._get_active_client_metrics() == {
+            "BECIPythonClient/client-1": messages._StrDynamicMetricValue(value="client-host-1"),
+            "BECClient/client-2": messages._StrDynamicMetricValue(value="client-host-2"),
+        }
+
+
+def test_handle_service_status_emits_active_client_metric(atlas_connector):
+    emitter = atlas_connector.active_client_emitter
+    service_status = {
+        "BECIPythonClient/client-1": create_status_message(
+            "BECIPythonClient/client-1", hostname="client-host-1"
+        ),
+        "ScanServer": create_status_message("ScanServer", hostname="server-host"),
+    }
+
+    with mock.patch.object(
+        type(atlas_connector.scihub), "service_status", new_callable=mock.PropertyMock
+    ) as mock_service_status:
+        mock_service_status.return_value = service_status
+        emitter._handle_service_status(None)
+
+    dynamic_metric = atlas_connector.connector.get(
+        MessageEndpoints.dynamic_metric("active_clients")
+    )
+    assert isinstance(dynamic_metric, messages.DynamicMetricMessage)
+    assert dynamic_metric.metrics["BECIPythonClient/client-1"].value == "client-host-1"
+    assert "ScanServer" not in dynamic_metric.metrics
+
+
+def test_handle_service_status_does_not_emit_unchanged_metric(atlas_connector):
+    emitter = atlas_connector.active_client_emitter
+    service_status = {
+        "BECIPythonClient/client-1": create_status_message(
+            "BECIPythonClient/client-1", hostname="client-host-1"
+        )
+    }
+
+    with mock.patch.object(
+        type(atlas_connector.scihub), "service_status", new_callable=mock.PropertyMock
+    ) as mock_service_status:
+        mock_service_status.return_value = service_status
+        emitter._emit_active_client_metrics()
+        with mock.patch.object(atlas_connector.connector, "set_and_publish") as mock_publish:
+            emitter._handle_service_status(None)
+
+    mock_publish.assert_not_called()

--- a/bec_server/tests/tests_scihub/test_atlas_active_client_emitter.py
+++ b/bec_server/tests/tests_scihub/test_atlas_active_client_emitter.py
@@ -36,29 +36,34 @@ def test_get_active_client_metrics_filters_internal_services(atlas_connector):
     ) as mock_service_status:
         mock_service_status.return_value = service_status
         assert emitter._get_active_client_metrics() == {
-            "BECIPythonClient/client-1": messages._StrDynamicMetricValue(value="client-host-1"),
-            "BECClient/client-2": messages._StrDynamicMetricValue(value="client-host-2"),
+            "BECIPythonClient/client-1": "client-host-1",
+            "BECClient/client-2": "client-host-2",
         }
 
 
 def test_handle_service_status_emits_active_client_metric(atlas_connector):
     emitter = atlas_connector.active_client_emitter
+    received = []
     service_status = {
         "BECIPythonClient/client-1": create_status_message(
             "BECIPythonClient/client-1", hostname="client-host-1"
         ),
         "ScanServer": create_status_message("ScanServer", hostname="server-host"),
     }
+    atlas_connector.connector.register(
+        MessageEndpoints.dynamic_metric("active_clients"),
+        cb=lambda msg: received.append(msg.value),
+        start_thread=False,
+    )
 
     with mock.patch.object(
         type(atlas_connector.scihub), "service_status", new_callable=mock.PropertyMock
     ) as mock_service_status:
         mock_service_status.return_value = service_status
         emitter._handle_service_status(None)
+        atlas_connector.connector.poll_messages(timeout=1)
 
-    dynamic_metric = atlas_connector.connector.get(
-        MessageEndpoints.dynamic_metric("active_clients")
-    )
+    dynamic_metric = received[-1]
     assert isinstance(dynamic_metric, messages.DynamicMetricMessage)
     assert dynamic_metric.metrics["BECIPythonClient/client-1"].value == "client-host-1"
     assert "ScanServer" not in dynamic_metric.metrics
@@ -77,7 +82,7 @@ def test_handle_service_status_does_not_emit_unchanged_metric(atlas_connector):
     ) as mock_service_status:
         mock_service_status.return_value = service_status
         emitter._emit_active_client_metrics()
-        with mock.patch.object(atlas_connector.connector, "set_and_publish") as mock_publish:
+        with mock.patch.object(atlas_connector.connector, "publish_metrics") as mock_publish:
             emitter._handle_service_status(None)
 
     mock_publish.assert_not_called()

--- a/bec_server/tests/tests_scihub/test_atlas_active_client_emitter.py
+++ b/bec_server/tests/tests_scihub/test_atlas_active_client_emitter.py
@@ -1,0 +1,82 @@
+from unittest import mock
+
+from bec_lib import messages
+from bec_lib.endpoints import MessageEndpoints
+
+
+def create_status_message(
+    name: str,
+    *,
+    status: messages.BECStatus = messages.BECStatus.RUNNING,
+    hostname: str = "localhost",
+):
+    return messages.StatusMessage(
+        name=name, status=status, info=messages.ServiceInfo(user="test-user", hostname=hostname)
+    )
+
+
+def test_get_active_client_metrics_filters_internal_services(atlas_connector):
+    emitter = atlas_connector.active_client_emitter
+    service_status = {
+        "BECIPythonClient/client-1": create_status_message(
+            "BECIPythonClient/client-1", hostname="client-host-1"
+        ),
+        "BECClient/client-2": create_status_message("BECClient/client-2", hostname="client-host-2"),
+        "SciHub": create_status_message("SciHub", hostname="internal-host"),
+        "DAPServer/image-analysis": create_status_message(
+            "DAPServer/image-analysis", hostname="internal-dap-host"
+        ),
+        "BECIPythonClient/not-running": create_status_message(
+            "BECIPythonClient/not-running", status=messages.BECStatus.IDLE, hostname="idle-host"
+        ),
+    }
+
+    with mock.patch.object(
+        type(atlas_connector.scihub), "service_status", new_callable=mock.PropertyMock
+    ) as mock_service_status:
+        mock_service_status.return_value = service_status
+        assert emitter._get_active_client_metrics() == {
+            "BECIPythonClient/client-1": "client-host-1",
+            "BECClient/client-2": "client-host-2",
+        }
+
+
+def test_handle_service_status_emits_active_client_metric(atlas_connector):
+    emitter = atlas_connector.active_client_emitter
+    service_status = {
+        "BECIPythonClient/client-1": create_status_message(
+            "BECIPythonClient/client-1", hostname="client-host-1"
+        ),
+        "ScanServer": create_status_message("ScanServer", hostname="server-host"),
+    }
+
+    with (
+        mock.patch.object(
+            type(atlas_connector.scihub), "service_status", new_callable=mock.PropertyMock
+        ) as mock_service_status,
+        mock.patch.object(atlas_connector.connector, "publish_metrics") as mock_publish_metrics,
+    ):
+        mock_service_status.return_value = service_status
+        emitter._handle_service_status(None)
+    mock_publish_metrics.assert_called_once_with(
+        "active_clients", {"BECIPythonClient/client-1": "client-host-1"}
+    )
+
+
+def test_handle_service_status_does_not_emit_unchanged_metric(atlas_connector):
+    emitter = atlas_connector.active_client_emitter
+    service_status = {
+        "BECIPythonClient/client-1": create_status_message(
+            "BECIPythonClient/client-1", hostname="client-host-1"
+        )
+    }
+
+    with mock.patch.object(
+        type(atlas_connector.scihub), "service_status", new_callable=mock.PropertyMock
+    ) as mock_service_status:
+        mock_service_status.return_value = service_status
+        emitter._emit_active_client_metrics()
+        with mock.patch.object(atlas_connector.connector, "publish_metrics") as mock_publish:
+            emitter._handle_service_status(None)
+
+    mock_publish.assert_not_called()

--- a/bec_server/tests/tests_scihub/test_atlas_metadata_handler.py
+++ b/bec_server/tests/tests_scihub/test_atlas_metadata_handler.py
@@ -87,23 +87,17 @@ def test_atlas_metadata_handler(atlas_connector):
 
 def test_handle_account_info_valid(atlas_connector):
     msg = {"data": messages.VariableMessage(value="account2")}
-    received = []
-    atlas_connector.connector.register(
-        MessageEndpoints.dynamic_metric("active_account"),
-        cb=lambda msg: received.append(msg.value),
-        start_thread=False,
-    )
-    with mock.patch.object(
-        atlas_connector.metadata_handler, "send_atlas_update"
-    ) as mock_send_update:
+    with (
+        mock.patch.object(
+            atlas_connector.metadata_handler, "send_atlas_update"
+        ) as mock_send_update,
+        mock.patch.object(atlas_connector.connector, "publish_metrics") as mock_publish_metrics,
+    ):
         atlas_connector.metadata_handler._handle_account_info(
             msg, parent=atlas_connector.metadata_handler
         )
         mock_send_update.assert_called_once()
-    atlas_connector.connector.poll_messages(timeout=1)
-    dynamic_metric = received[-1]
-    assert isinstance(dynamic_metric, messages.DynamicMetricMessage)
-    assert dynamic_metric.metrics["active_account"].value == "account2"
+    mock_publish_metrics.assert_called_once_with("active_account", {"active_account": "account2"})
 
 
 def test_handle_account_info_same_account(atlas_connector):
@@ -194,13 +188,17 @@ def test_update_local_account_new_account(atlas_connector):
     handler = atlas_connector.metadata_handler
     handler._account = "old_account"
     deployment_info = create_dummy_deployment_info()
-    handler.update_local_account(deployment_info)
+    with mock.patch.object(
+        handler.atlas_connector.connector, "publish_metrics"
+    ) as mock_publish_metrics:
+        handler.update_local_account(deployment_info)
 
     # Verify that account update was sent
     stored_account = handler.atlas_connector.connector.get_last(MessageEndpoints.account())
     assert stored_account is not None
     assert isinstance(stored_account["data"], messages.VariableMessage)
     assert stored_account["data"].value == "p12345"
+    mock_publish_metrics.assert_called_once_with("active_account", {"active_account": "p12345"})
 
 
 def test_update_local_account_same_account(atlas_connector):
@@ -225,7 +223,7 @@ def test_update_local_account_same_account_does_not_emit_metric(atlas_connector)
     handler._account = "p12345"
     deployment_info = create_dummy_deployment_info()
 
-    with mock.patch.object(handler.atlas_connector.connector, "set_and_publish") as mock_publish:
+    with mock.patch.object(handler.atlas_connector.connector, "publish_metrics") as mock_publish:
         handler.update_local_account(deployment_info)
 
     mock_publish.assert_not_called()

--- a/bec_server/tests/tests_scihub/test_atlas_metadata_handler.py
+++ b/bec_server/tests/tests_scihub/test_atlas_metadata_handler.py
@@ -87,6 +87,12 @@ def test_atlas_metadata_handler(atlas_connector):
 
 def test_handle_account_info_valid(atlas_connector):
     msg = {"data": messages.VariableMessage(value="account2")}
+    received = []
+    atlas_connector.connector.register(
+        MessageEndpoints.dynamic_metric("active_account"),
+        cb=lambda msg: received.append(msg.value),
+        start_thread=False,
+    )
     with mock.patch.object(
         atlas_connector.metadata_handler, "send_atlas_update"
     ) as mock_send_update:
@@ -94,9 +100,8 @@ def test_handle_account_info_valid(atlas_connector):
             msg, parent=atlas_connector.metadata_handler
         )
         mock_send_update.assert_called_once()
-    dynamic_metric = atlas_connector.connector.get(
-        MessageEndpoints.dynamic_metric("active_account")
-    )
+    atlas_connector.connector.poll_messages(timeout=1)
+    dynamic_metric = received[-1]
     assert isinstance(dynamic_metric, messages.DynamicMetricMessage)
     assert dynamic_metric.metrics["active_account"].value == "account2"
 
@@ -189,7 +194,6 @@ def test_update_local_account_new_account(atlas_connector):
     handler = atlas_connector.metadata_handler
     handler._account = "old_account"
     deployment_info = create_dummy_deployment_info()
-
     handler.update_local_account(deployment_info)
 
     # Verify that account update was sent
@@ -197,11 +201,6 @@ def test_update_local_account_new_account(atlas_connector):
     assert stored_account is not None
     assert isinstance(stored_account["data"], messages.VariableMessage)
     assert stored_account["data"].value == "p12345"
-    dynamic_metric = handler.atlas_connector.connector.get(
-        MessageEndpoints.dynamic_metric("active_account")
-    )
-    assert isinstance(dynamic_metric, messages.DynamicMetricMessage)
-    assert dynamic_metric.metrics["active_account"].value == "p12345"
 
 
 def test_update_local_account_same_account(atlas_connector):

--- a/bec_server/tests/tests_scihub/test_atlas_metadata_handler.py
+++ b/bec_server/tests/tests_scihub/test_atlas_metadata_handler.py
@@ -94,6 +94,11 @@ def test_handle_account_info_valid(atlas_connector):
             msg, parent=atlas_connector.metadata_handler
         )
         mock_send_update.assert_called_once()
+    dynamic_metric = atlas_connector.connector.get(
+        MessageEndpoints.dynamic_metric("active_account")
+    )
+    assert isinstance(dynamic_metric, messages.DynamicMetricMessage)
+    assert dynamic_metric.metrics["active_account"].value == "account2"
 
 
 def test_handle_account_info_same_account(atlas_connector):
@@ -192,6 +197,11 @@ def test_update_local_account_new_account(atlas_connector):
     assert stored_account is not None
     assert isinstance(stored_account["data"], messages.VariableMessage)
     assert stored_account["data"].value == "p12345"
+    dynamic_metric = handler.atlas_connector.connector.get(
+        MessageEndpoints.dynamic_metric("active_account")
+    )
+    assert isinstance(dynamic_metric, messages.DynamicMetricMessage)
+    assert dynamic_metric.metrics["active_account"].value == "p12345"
 
 
 def test_update_local_account_same_account(atlas_connector):
@@ -208,6 +218,18 @@ def test_update_local_account_same_account(atlas_connector):
         handler.update_local_account(deployment_info)
         # Verify that no account update was sent
         mock_xadd.assert_not_called()
+
+
+def test_update_local_account_same_account_does_not_emit_metric(atlas_connector):
+    """Test that unchanged local account does not emit a new dynamic metric"""
+    handler = atlas_connector.metadata_handler
+    handler._account = "p12345"
+    deployment_info = create_dummy_deployment_info()
+
+    with mock.patch.object(handler.atlas_connector.connector, "set_and_publish") as mock_publish:
+        handler.update_local_account(deployment_info)
+
+    mock_publish.assert_not_called()
 
 
 def test_update_local_account_no_session(atlas_connector):

--- a/bec_server/tests/tests_scihub/test_atlas_metadata_handler.py
+++ b/bec_server/tests/tests_scihub/test_atlas_metadata_handler.py
@@ -87,13 +87,17 @@ def test_atlas_metadata_handler(atlas_connector):
 
 def test_handle_account_info_valid(atlas_connector):
     msg = {"data": messages.VariableMessage(value="account2")}
-    with mock.patch.object(
-        atlas_connector.metadata_handler, "send_atlas_update"
-    ) as mock_send_update:
+    with (
+        mock.patch.object(
+            atlas_connector.metadata_handler, "send_atlas_update"
+        ) as mock_send_update,
+        mock.patch.object(atlas_connector.connector, "publish_metrics") as mock_publish_metrics,
+    ):
         atlas_connector.metadata_handler._handle_account_info(
             msg, parent=atlas_connector.metadata_handler
         )
         mock_send_update.assert_called_once()
+    mock_publish_metrics.assert_called_once_with("active_account", {"active_account": "account2"})
 
 
 def test_handle_account_info_same_account(atlas_connector):
@@ -184,14 +188,17 @@ def test_update_local_account_new_account(atlas_connector):
     handler = atlas_connector.metadata_handler
     handler._account = "old_account"
     deployment_info = create_dummy_deployment_info()
-
-    handler.update_local_account(deployment_info)
+    with mock.patch.object(
+        handler.atlas_connector.connector, "publish_metrics"
+    ) as mock_publish_metrics:
+        handler.update_local_account(deployment_info)
 
     # Verify that account update was sent
     stored_account = handler.atlas_connector.connector.get_last(MessageEndpoints.account())
     assert stored_account is not None
     assert isinstance(stored_account["data"], messages.VariableMessage)
     assert stored_account["data"].value == "p12345"
+    mock_publish_metrics.assert_called_once_with("active_account", {"active_account": "p12345"})
 
 
 def test_update_local_account_same_account(atlas_connector):
@@ -208,6 +215,18 @@ def test_update_local_account_same_account(atlas_connector):
         handler.update_local_account(deployment_info)
         # Verify that no account update was sent
         mock_xadd.assert_not_called()
+
+
+def test_update_local_account_same_account_does_not_emit_metric(atlas_connector):
+    """Test that unchanged local account does not emit a new dynamic metric"""
+    handler = atlas_connector.metadata_handler
+    handler._account = "p12345"
+    deployment_info = create_dummy_deployment_info()
+
+    with mock.patch.object(handler.atlas_connector.connector, "publish_metrics") as mock_publish:
+        handler.update_local_account(deployment_info)
+
+    mock_publish.assert_not_called()
 
 
 def test_update_local_account_no_session(atlas_connector):


### PR DESCRIPTION
## Description

* Add an emitter for active clients metric in BEC
* Emit the currently active account
* Emit connection status for BEC Atlas
