### PR TITLE
chore(device): add deprecation decorator and mark methods for removal…

### DIFF
--- a/bec_lib/bec_lib/device.py
+++ b/bec_lib/bec_lib/device.py
@@ -26,6 +26,7 @@ from bec_lib.atlas_models import _DeviceModelCore
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.logger import bec_logger
 from bec_lib.queue_items import QueueItem
+from bec_lib.utils.deprecation import deprecated
 from bec_lib.utils.import_utils import lazy_import
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -1315,10 +1316,18 @@ class Positioner(AdjustableMixin, Device):
         msg = messages.VariableMessage(value=[self.root.name])
         self.root.parent.parent.connector.send(MessageEndpoints.stop_devices(), msg)
 
+    @deprecated(
+        remove_in_version="4.0",
+        recommendation="If necessary, implement a custom ophyd signal with the desired functionality. For assistance, please contact the BEC team.",
+    )
     @rpc
     def settle_time(self):
         pass
 
+    @deprecated(
+        remove_in_version="4.0",
+        recommendation="If necessary, implement a custom ophyd signal with the desired functionality. For assistance, please contact the BEC team.",
+    )
     @rpc
     def timeout(self):
         pass
@@ -1326,14 +1335,26 @@ class Positioner(AdjustableMixin, Device):
     def egu(self):
         return self.describe_configuration().get("egu")
 
+    @deprecated(
+        remove_in_version="4.0",
+        recommendation="Use umv, umvr, mv, or mvr methods instead, depending on your use case. For assistance, please contact the BEC team.",
+    )
     def move(self, val: float, relative=False):
         return self.root.parent.parent.scans.mv(self, val, relative=relative)
 
     @property
+    @deprecated(
+        remove_in_version="4.0",
+        recommendation="Use the read method or .wm property instead to get the current position of the device. For assistance, please contact the BEC team.",
+    )
     @rpc
     def position(self):
         pass
 
+    @deprecated(
+        remove_in_version="4.0",
+        recommendation="Use the status object returned by the set method to check if the device is still moving. For assistance, please contact the BEC team.",
+    )
     @rpc
     def moving(self):
         pass

--- a/bec_lib/bec_lib/utils/deprecation.py
+++ b/bec_lib/bec_lib/utils/deprecation.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import warnings
+from functools import wraps
+
+warnings.formatwarning = lambda msg, *args, **kwargs: f">>> DEPRECATION: {msg}\n"
+
+
+def deprecated(remove_in_version: str | None = None, recommendation: str | None = None):
+    """
+    Decorator to mark functions as deprecated.
+
+    Args:
+        remove_in_version (str | None): Optional version string indicating when the function will be removed.
+        recommendation (str | None): Optional string suggesting an alternative function or approach to use.
+
+    Returns:
+        A decorator that can be applied to functions to mark them as deprecated.
+
+    Example usage:
+        @deprecated(remove_in_version="2.0", recommendation="Use new_function instead.")
+        def old_function():
+            pass
+
+        # This will print:
+        # "old_function is deprecated and will be removed in version 2.0. Use new_function instead"
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            message = f"{func.__name__} is deprecated"
+            if remove_in_version:
+                message += f" and will be removed in version {remove_in_version}"
+            if recommendation:
+                message += f". {recommendation}"
+            warnings.warn(message, category=DeprecationWarning)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
## Description

This PR adds a dedicated decorator for marking methods as deprecated and uses the decorator for declaring certain ophyd device methods as deprecated. The following positioner methods are affected:

* settle_time
* timeout
* move
* position
* moving


## Related Issues

[Cite any related issues or feature requests that are addressed or resolved by this pull request. Link the associated issue, for example, with `fixes #123` or `closes #123`.]

## Type of Change

- Change 1
- Change 2

## How to test

- Run unit tests

## Potential side effects

[Describe any potential side effects or risks of merging this PR.]

## Screenshots / GIFs (if applicable)

[Include any relevant screenshots or GIFs to showcase the changes made.]

## Additional Comments

[Add any additional comments or information that may be helpful for reviewers.]

## Definition of Done
- [ ] Documentation is up-to-date.

