### PR TITLE
fix(device serializer): fix support for signal alias

### DIFF
--- a/bec_server/bec_server/device_server/devices/device_serializer.py
+++ b/bec_server/bec_server/device_server/devices/device_serializer.py
@@ -208,13 +208,23 @@ def get_device_info(
                             }
                         }
                     )
-                signal_names.append(obj_name)
-        # Read attrs are only available if the device is connected
-        unique_signal_names = set(signal_names)
-        if len(unique_signal_names) < len(signal_names):
-            raise DeviceConfigError(
-                f"Signal names of {obj.name} must be unique, found duplicates. All signal names: {signal_names}. \n Unique signal names: {unique_signal_names}."
-            )
+                if obj_name not in signal_names:
+                    signal_names.append(obj_name)
+                else:
+                    # Check if it is merely an alias and the components are the same object. If not, raise an error for duplicate signal names.
+                    # This is done by fetching all signals that have the same obj_name
+                    same_name_signals = [
+                        getattr(obj, signal_info["component_name"])
+                        for signal_info in signals.values()
+                        if signal_info["obj_name"] == obj_name
+                    ]
+                    if not all(signal is same_name_signals[0] for signal in same_name_signals):
+                        raise DeviceConfigError(
+                            f"Signal name {obj_name} of {obj.name} is duplicated but the components "
+                            f"are not the same object. Please rename the signal to have unique signal "
+                            f"names or use the same signal as an alias."
+                        )
+
     sub_devices = []
 
     if hasattr(obj, "walk_subdevices") and connect:

--- a/bec_server/tests/tests_device_server/test_device_serializer.py
+++ b/bec_server/tests/tests_device_server/test_device_serializer.py
@@ -78,6 +78,12 @@ class DummyDeviceWithConflictingDuplicateSignalNames(Device):
         self.signal_custom.custom.name = self.signal_custom.name
 
 
+class DummyDeviceWithAliasedSignalNames(Device):
+    """Expose the same signal object via two component names."""
+
+    signal_alias = signal = Cpt(Signal, value=1)
+
+
 @pytest.mark.parametrize(
     "obj",
     [
@@ -117,3 +123,12 @@ def test_get_device_info_USER_ACCESS():
     _ = get_device_info(device, connect=False)
     with pytest.raises(DeviceConfigError):
         _ = get_device_info(device, connect=True)
+
+
+def test_get_device_info_allows_aliased_signal_names():
+    device = DummyDeviceWithAliasedSignalNames(name="test")
+
+    info = get_device_info(device, connect=True)
+
+    assert info["device_info"]["signals"]["signal"]["obj_name"] == "test_signal"
+    assert info["device_info"]["signals"]["signal_alias"]["obj_name"] == "test_signal"


### PR DESCRIPTION
## Description

Fixes the support for using signal aliases in component definitions, e.g. 

```python 
class MyDevice(Device):
    signal_alias = signal = Cpt(Signal...)
```

Note that the readout will not be duplicated, i.e. `device.signal_alias.read()` will return the same content as `device.signal.read()` and the entry will be called "signal", not "signal_alias". 

