### PR TITLE
implement plugin reload functionality

### DIFF
--- a/bec_ipython_client/bec_ipython_client/main.py
+++ b/bec_ipython_client/bec_ipython_client/main.py
@@ -174,7 +174,7 @@ class BECIPythonClient:
                 self._ip.user_global_ns[name] = obj
         elif action == "remove":
             for name, obj in ns_objects.items():
-                self._ip.user_global_ns.pop(name)
+                self._ip.user_global_ns.pop(name, None)
 
     def _set_error(self):
         if self._ip is not None:

--- a/bec_lib/bec_lib/client.py
+++ b/bec_lib/bec_lib/client.py
@@ -265,12 +265,14 @@ class BECClient(BECService):
             self.connector.lpush(MessageEndpoints.pre_scan_macros(), msg)
 
     def _load_scans(self):
-        self.scans = Scans(self._parent)
+        if not isinstance(self.scans_namespace, SimpleNamespace):
+            self.scans_namespace = SimpleNamespace()
+        if getattr(self, "scans", None) is None:
+            self.scans = Scans(self._parent)
+        else:
+            self.scans._refresh_available_scans()
         builtins.__dict__["scans"] = self.scans
-        self.scans_namespace = SimpleNamespace(
-            scan_def=self.scans.scan_def,
-            **{scan_name: scan.run for scan_name, scan in self.scans._available_scans.items()},
-        )
+        self.scans_namespace.scan_def = self.scans.scan_def
 
     def load_high_level_interface(self, module_name: str) -> None:
         """Load a high level interface module.
@@ -404,6 +406,13 @@ class BECClient(BECService):
         self._load_scans()
         self.device_manager._load_session()
         print("Server restarted successfully.")
+
+    def _request_scan_reload(self):
+        if self.connector is None or self.device_manager is None:
+            raise RuntimeError("Client not initialized. Cannot reload scans.")
+
+        msg = ServiceRequestMessage(action="reload_scans")
+        self.connector.send(MessageEndpoints.service_request(), msg)
 
     def _run_script(self, script_id: str):
         executor = ScriptExecutor(self.connector)

--- a/bec_lib/bec_lib/endpoints.py
+++ b/bec_lib/bec_lib/endpoints.py
@@ -818,7 +818,7 @@ class MessageEndpoints:
         return EndpointInfo(
             endpoint=endpoint,
             message_type=messages.AvailableResourceMessage,
-            message_op=MessageOp.KEY_VALUE,
+            message_op=MessageOp.SET_PUBLISH,
         )
 
     @staticmethod

--- a/bec_lib/bec_lib/messages.py
+++ b/bec_lib/bec_lib/messages.py
@@ -1440,12 +1440,12 @@ class ServiceRequestMessage(BECMessage):
     """Message for service requests
 
     Args:
-        action (Literal["restart"]): Action to be executed by the service
+        action (Literal["restart", "reload_scans"]): Action to be executed by the service
         metadata (dict, optional): Metadata. Defaults to None.
     """
 
     msg_type: ClassVar[str] = "service_request_message"
-    action: Literal["restart"]
+    action: Literal["restart", "reload_scans"]
 
 
 class ProcedureRequestMessage(BECMessage):

--- a/bec_lib/bec_lib/plugin_helper.py
+++ b/bec_lib/bec_lib/plugin_helper.py
@@ -4,6 +4,7 @@ import importlib
 import importlib.metadata
 import inspect
 import json
+import sys
 from functools import cache, lru_cache
 from typing import TYPE_CHECKING, Any, Literal, Type
 
@@ -175,6 +176,26 @@ def plugin_repo_path() -> str:
     if not dist_info.get("dir_info", {}).get("editable", False):
         raise ValueError("Plugin repo must be installed in editable mode")
     return dist_info.get("url")[5:]  # cut off "file:" prefix # type: ignore # this must exist
+
+
+def reload_plugin_modules() -> None:
+    """Reload the installed plugin package and all loaded submodules."""
+    logger.info("Reloading plugin modules...")
+    _get_available_plugins.cache_clear()
+    _import_module.cache_clear()
+    get_metadata_schema_registry.cache_clear()
+    try:
+        _plugin_package_name = plugin_package_name()
+    except ValueError:
+        return
+    plugin_module = importlib.import_module(_plugin_package_name)
+    module_names = [
+        name
+        for name in sys.modules
+        if name == plugin_module.__name__ or name.startswith(f"{plugin_module.__name__}.")
+    ]
+    for module_name in sorted(module_names, key=lambda name: name.count("."), reverse=True):
+        importlib.reload(sys.modules[module_name])
 
 
 def _filter_plugins(module) -> bool:

--- a/bec_lib/bec_lib/scans.py
+++ b/bec_lib/bec_lib/scans.py
@@ -17,6 +17,7 @@ from toolz import partition
 from typeguard import typechecked
 
 from bec_lib.bec_errors import ScanAbortion
+from bec_lib.callback_handler import EventType
 from bec_lib.device import DeviceBase
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.logger import bec_logger
@@ -172,7 +173,10 @@ class Scans:
         self.parent = parent
         self._available_scans = {}
         self._input_validator = ScanInputValidator(device_manager=self.parent.device_manager)
-        self._import_scans()
+        self.parent.connector.register(
+            MessageEndpoints.available_scans(), cb=self._available_scans_update
+        )
+        self._refresh_available_scans()
         self._scan_group = None
         self._scan_def_id = None
         self._interactive_scan = False
@@ -185,15 +189,44 @@ class Scans:
         self._scan_export = None
         setattr(self.interactive_scan, "__doc__", InteractiveScan.__doc__)
 
-    def _import_scans(self):
-        """Import scans from the scan server"""
+    def _refresh_available_scans(self) -> None:
+        """Refresh scans from the scan server state."""
         available_scans = self.parent.connector.get(MessageEndpoints.available_scans())
         if available_scans is None:
             logger.warning("No scans available. Are redis and the BEC server running?")
             return
+        self._update_available_scans(available_scans, notify=False)
+
+    def _available_scans_update(self, msg) -> None:
+        self._update_available_scans(msg.value, notify=True)
+
+    def _update_available_scans(
+        self, available_scans: messages.AvailableResourceMessage, notify: bool
+    ) -> None:
+        if not isinstance(available_scans, messages.AvailableResourceMessage):
+            logger.error(
+                f"Received invalid message type for available scans: {type(available_scans)}"
+            )
+            return
+
+        existing_scans = self._available_scans
+        removed_scans = {
+            scan_name: scan.run
+            for scan_name, scan in existing_scans.items()
+            if scan_name not in available_scans.resource
+        }
+        updated_scans = {}
+
+        for scan_name in removed_scans:
+            if hasattr(self, scan_name):
+                delattr(self, scan_name)
+
+        self._available_scans = {}
         for scan_name, scan_info in available_scans.resource.items():
-            self._available_scans[scan_name] = ScanObject(scan_name, scan_info, client=self.parent)
-            setattr(self, scan_name, self._available_scans[scan_name].run)
+            scan_object = ScanObject(scan_name, scan_info, client=self.parent)
+            self._available_scans[scan_name] = scan_object
+            updated_scans[scan_name] = scan_object.run
+            setattr(self, scan_name, scan_object.run)
             setattr(getattr(self, scan_name), "__doc__", scan_info.get("doc"))
             setattr(
                 getattr(self, scan_name),
@@ -201,6 +234,23 @@ class Scans:
                 dict_to_signature(
                     self._strip_scan_signature_annotations(scan_info.get("signature"))
                 ),
+            )
+
+        scans_namespace = getattr(self.parent, "scans_namespace", None)
+        if scans_namespace is not None:
+            for scan_name in removed_scans:
+                if hasattr(scans_namespace, scan_name):
+                    delattr(scans_namespace, scan_name)
+            for scan_name, scan_run in updated_scans.items():
+                setattr(scans_namespace, scan_name, scan_run)
+
+        if notify and removed_scans:
+            self.parent.callbacks.run(
+                EventType.NAMESPACE_UPDATE, action="remove", ns_objects=removed_scans
+            )
+        if notify and updated_scans:
+            self.parent.callbacks.run(
+                EventType.NAMESPACE_UPDATE, action="add", ns_objects=updated_scans
             )
 
     @staticmethod

--- a/bec_lib/tests/test_client.py
+++ b/bec_lib/tests/test_client.py
@@ -2,7 +2,9 @@
 
 import pytest
 
+from bec_lib import messages
 from bec_lib.client import SystemConfig
+from bec_lib.endpoints import MessageEndpoints
 from bec_lib.tests.fixtures import bec_client_mock
 
 
@@ -30,3 +32,21 @@ def test_show_all_commands(bec_client_mock, capsys):
     captured = capsys.readouterr()
     assert "User macros" in captured.out
     assert "Scans" in captured.out
+
+
+def test_request_scan_reload(bec_client_mock):
+    client = bec_client_mock
+
+    client._request_scan_reload()
+
+    client.connector.send.assert_called_once_with(
+        MessageEndpoints.service_request(), messages.ServiceRequestMessage(action="reload_scans")
+    )
+
+
+def test_request_scan_reload_requires_initialized_client(bec_client_mock):
+    client = bec_client_mock
+    client.connector = None
+
+    with pytest.raises(RuntimeError, match="Client not initialized. Cannot reload scans."):
+        client._request_scan_reload()

--- a/bec_lib/tests/test_plugin_helper.py
+++ b/bec_lib/tests/test_plugin_helper.py
@@ -1,3 +1,6 @@
+import sys
+from unittest import mock
+
 import pytest
 
 import bec_lib
@@ -25,3 +28,39 @@ def test_module_dist_info():
     result = plugin_helper.module_dist_info("bec_lib")
     assert result["dir_info"] == {"editable": True}
     assert result["url"] is not None
+
+
+def test_reload_plugin_modules_reloads_plugin_tree():
+    plugin_module = mock.MagicMock()
+    plugin_module.__name__ = "bec_plugin"
+    plugin_scans_module = mock.MagicMock()
+    plugin_scans_module.__name__ = "bec_plugin.scans"
+    plugin_scan_submodule = mock.MagicMock()
+    plugin_scan_submodule.__name__ = "bec_plugin.scans.custom_scan"
+    importlib_mock = mock.MagicMock()
+    importlib_mock.import_module.return_value = plugin_module
+
+    with (
+        mock.patch("bec_lib.plugin_helper.plugin_package_name", return_value="bec_plugin"),
+        mock.patch.object(plugin_helper, "importlib", importlib_mock),
+        mock.patch(
+            "bec_lib.plugin_helper._get_available_plugins.cache_clear"
+        ) as clear_available_plugins,
+        mock.patch("bec_lib.plugin_helper._import_module.cache_clear") as clear_import_module,
+        mock.patch.dict(
+            sys.modules,
+            {
+                plugin_module.__name__: plugin_module,
+                plugin_scans_module.__name__: plugin_scans_module,
+                plugin_scan_submodule.__name__: plugin_scan_submodule,
+            },
+            clear=False,
+        ),
+    ):
+        plugin_helper.reload_plugin_modules()
+
+    clear_available_plugins.assert_called_once_with()
+    clear_import_module.assert_called_once_with()
+    importlib_mock.reload.assert_any_call(plugin_module)
+    importlib_mock.reload.assert_any_call(plugin_scans_module)
+    importlib_mock.reload.assert_any_call(plugin_scan_submodule)

--- a/bec_server/bec_server/device_server/devices/config_update_handler.py
+++ b/bec_server/bec_server/device_server/devices/config_update_handler.py
@@ -11,6 +11,7 @@ from bec_lib.alarm_handler import Alarms
 from bec_lib.devicemanager import CancelledError, DeviceConfigError
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.logger import bec_logger
+from bec_lib.plugin_helper import reload_plugin_modules
 
 if TYPE_CHECKING:
     from bec_server.device_server.devices.devicemanager import DeviceManagerDS
@@ -237,6 +238,8 @@ class ConfigUpdateHandler:
 
     def _reload_config(self, cancel_event: threading.Event) -> None:
         self._flush_config()
+        reload_plugin_modules()
+
         self.device_manager._get_config(cancel_event=cancel_event)
         if self.device_manager.failed_devices:
             self.handle_failed_device_inits()

--- a/bec_server/bec_server/scan_server/scan_assembler.py
+++ b/bec_server/bec_server/scan_server/scan_assembler.py
@@ -34,7 +34,6 @@ class ScanAssembler:
         self.connector = self.parent.connector
         self.scan_manager = self.parent.scan_manager
         self.input_validator = ScanInputValidator(device_manager=self.device_manager)
-        self.scan_modifier_cls = get_scan_modifier()
 
     def is_scan_message(self, msg: messages.ScanQueueMessage) -> bool:
         """Check if the scan queue message would construct a new scan.
@@ -132,7 +131,7 @@ class ScanAssembler:
             *resolved_args,
             device_manager=self.device_manager,
             redis_connector=self.connector,
-            scan_modifier=self.scan_modifier_cls,
+            scan_modifier=get_scan_modifier(),
             metadata=msg.metadata,
             instruction_handler=self.parent.queue_manager.instruction_handler,
             scan_id=scan_id,

--- a/bec_server/bec_server/scan_server/scan_manager.py
+++ b/bec_server/bec_server/scan_server/scan_manager.py
@@ -10,7 +10,7 @@ import inspect
 import pkgutil
 from typing import TYPE_CHECKING, Type
 
-from bec_lib import plugin_helper
+from bec_lib import messages, plugin_helper
 from bec_lib.alarm_handler import Alarms
 from bec_lib.device import DeviceBase
 from bec_lib.endpoints import MessageEndpoints
@@ -19,6 +19,7 @@ from bec_lib.messages import AvailableResourceMessage, ErrorInfo
 from bec_lib.signature_serializer import serialize_dtype, signature_to_dict
 from bec_server.scan_server.scan_gui_models import GUIConfig
 from bec_server.scan_server.scans.scan_argument_modifier import (
+    get_scan_modifier,
     scan_doc_with_modifiers,
     scan_signature_with_modifiers,
 )
@@ -56,6 +57,9 @@ class ScanManager:
         self.available_scans = {}
         self.scan_dict: dict[str, type[scans_module.RequestBase] | type[ScanBaseV4]] = {}
         self._plugins = {}
+        self.parent.connector.register(
+            MessageEndpoints.service_request(), cb=self.handle_reload_scans_request
+        )
         self.update_available_scans()
         self.publish_available_scans()
 
@@ -93,8 +97,19 @@ class ScanManager:
             members.remove(item)
         return members
 
-    def update_available_scans(self):
+    @classmethod
+    def _reload_scan_discovery(cls) -> None:
+        get_scan_modifier.cache_clear()
+        cls.get_available_scans.cache_clear()
+        plugin_helper.reload_plugin_modules()
+
+    def update_available_scans(self, reload: bool = False):
         """load all scans and plugin scans"""
+        if reload:
+            self._reload_scan_discovery()
+
+        self.available_scans = {}
+        self.scan_dict = {}
         members = ScanManager.get_available_scans()
 
         for name, scan_cls in members:
@@ -211,6 +226,12 @@ class ScanManager:
             converted_arg_input[key] = serialize_dtype(dtype)
         return converted_arg_input
 
+    def handle_reload_scans_request(self, msg):
+        message: messages.ServiceRequestMessage = msg.value
+        if message.action == "reload_scans":
+            self.update_available_scans(reload=True)
+            self.publish_available_scans()
+
     @staticmethod
     def _get_scan_plugins() -> dict[str, type]:
         verified_plugins = {}
@@ -244,7 +265,7 @@ class ScanManager:
 
     def publish_available_scans(self):
         """send all available scans to the broker"""
-        self.parent.connector.set(
+        self.parent.connector.set_and_publish(
             MessageEndpoints.available_scans(),
             AvailableResourceMessage(resource=self.available_scans),
         )

--- a/bec_server/tests/tests_scan_server/test_scan_server_scan_manager.py
+++ b/bec_server/tests/tests_scan_server/test_scan_server_scan_manager.py
@@ -3,7 +3,10 @@ from unittest import mock
 
 import pytest
 
+from bec_lib import messages
 from bec_lib.device import Device, DeviceBase, Positioner
+from bec_lib.endpoints import MessageEndpoints
+from bec_lib.redis_connector import MessageObject
 from bec_lib.scan_args import ScanArgument
 from bec_server.scan_server.scan_manager import ScanManager
 from bec_server.scan_server.scans import ScanArgType
@@ -109,3 +112,67 @@ def test_scan_manager_does_not_apply_gui_config_overrides_to_legacy_gui_config(s
     }
     assert groups["Timing"] == ["exp_time"]
     assert "Advanced" not in groups
+
+
+def test_scan_manager_update_available_scans_resets_existing_entries(scan_manager):
+    with mock.patch.object(
+        ScanManager, "get_available_scans", return_value=[("gui", _GuiConfigScan)]
+    ):
+        scan_manager.update_available_scans()
+        first_result = scan_manager.available_scans.copy()
+
+        scan_manager.update_available_scans()
+
+    assert scan_manager.available_scans == first_result
+    assert scan_manager.scan_dict == {_GuiConfigScan.scan_name: _GuiConfigScan}
+
+
+def test_scan_manager_update_available_scans_reload_forces_discovery_refresh(scan_manager):
+    with (
+        mock.patch.object(ScanManager, "_reload_scan_discovery") as reload_scan_discovery,
+        mock.patch.object(ScanManager, "get_available_scans", return_value=[]),
+    ):
+        scan_manager.update_available_scans(reload=True)
+
+    reload_scan_discovery.assert_called_once_with()
+
+
+def test_scan_manager_handle_reload_scans_request_forces_reload(scan_manager):
+    msg = messages.ServiceRequestMessage(action="reload_scans")
+    msg_obj = MessageObject(topic="test", value=msg)
+
+    with (
+        mock.patch.object(scan_manager, "update_available_scans") as update_available_scans,
+        mock.patch.object(scan_manager, "publish_available_scans") as publish_available_scans,
+    ):
+        scan_manager.handle_reload_scans_request(msg_obj)
+
+    update_available_scans.assert_called_once_with(reload=True)
+    publish_available_scans.assert_called_once_with()
+
+
+def test_scan_manager_publish_available_scans_uses_set_and_publish(scan_manager):
+    scan_manager.parent.connector.set_and_publish.reset_mock()
+    scan_manager.available_scans = {"test_scan": {"doc": "test"}}
+
+    scan_manager.publish_available_scans()
+
+    scan_manager.parent.connector.set_and_publish.assert_called_once()
+    endpoint, message = scan_manager.parent.connector.set_and_publish.call_args.args
+    assert endpoint == MessageEndpoints.available_scans()
+    assert message.resource == scan_manager.available_scans
+
+
+def test_scan_manager_reload_scan_discovery_reloads_plugin_scan_modules():
+    with (
+        mock.patch(
+            "bec_server.scan_server.scan_manager.plugin_helper.reload_plugin_modules"
+        ) as reload_plugin_modules,
+        mock.patch(
+            "bec_server.scan_server.scan_manager.get_scan_modifier.cache_clear"
+        ) as clear_modifier_cache,
+    ):
+        ScanManager._reload_scan_discovery()
+
+    clear_modifier_cache.assert_called_once_with()
+    reload_plugin_modules.assert_called_once_with()


### PR DESCRIPTION
## Description

This PR adds the ability to reload plugins and leverages it for reloading scans on demand and the devices on every config reload. Note that it does not reload bec, ophyd devices or ophyd, merely the plugin repo.
Initially, I only wanted to simplify my test for scan plugins but I think it is generally useful during development and may prevent outdated runs with devices and scans. 
Moreover, my hope would be that this enables us to reduce the direct interaction with tmux to restart the server. 

## Related Issues

closes #314 

## Type of Change

- Add plugin utility to reload all imports of the plugin repo
- Extend service instruction message to also allow scan reloads and expose it through (for now) a private method in bec. 
- To this end, the available scans endpoint is now set_and_publish, not just set. 

## How to test

- Run unit tests
- Make some modifications e.g. to the doc string of a scan and run 

```python 
bec._request_scan_reload()
```

you should now see the updated doc string in the client. 

## Additional Comments

Due to the change to `set_and_publish`, some tests in BW need to be adjusted: https://github.com/bec-project/bec_widgets/pull/1147

