### PR TITLE
Bugfix for set not raising during a mv command.

### DIFF
--- a/bec_server/bec_server/device_server/device_server.py
+++ b/bec_server/bec_server/device_server/device_server.py
@@ -698,8 +698,11 @@ class DeviceServer(BECService):
                 sub_id = obj.subscribe(self.device_manager._obj_callback_readback, run=True)
         else:
             obj = device_obj.obj
-
-        status = obj.set(val)
+        try:
+            status = obj.set(val)
+        except Exception as exc:  # pylint: disable=broad-except
+            status = StatusBase()
+            status.set_exception(exc)
         self._add_status_object_info(status, instr, obj)
         status.__dict__["sub_id"] = sub_id
         self.requests_handler.add_status_object(instr.metadata["device_instr_id"], status)

--- a/bec_server/bec_server/device_server/device_server.py
+++ b/bec_server/bec_server/device_server/device_server.py
@@ -10,7 +10,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any
 
 import ophyd
-from ophyd import Kind, OphydObject, Staged, StatusBase
+from ophyd import DeviceStatus, Kind, OphydObject, Staged, StatusBase
 from ophyd.utils import errors as ophyd_errors
 
 from bec_lib import messages
@@ -701,7 +701,7 @@ class DeviceServer(BECService):
         try:
             status = obj.set(val)
         except Exception as exc:  # pylint: disable=broad-except
-            status = StatusBase()
+            status = DeviceStatus(device=obj)
             status.set_exception(exc)
         self._add_status_object_info(status, instr, obj)
         status.__dict__["sub_id"] = sub_id

--- a/bec_server/tests/tests_device_server/test_device_instructions.py
+++ b/bec_server/tests/tests_device_server/test_device_instructions.py
@@ -108,7 +108,7 @@ def test_device_server_init(device_server):
                 ),
                 instruction_id="test",
                 result=None,
-                result_is_status=None,
+                result_is_status=True,
             ),
         ),
     ],

--- a/bec_server/tests/tests_device_server/test_device_server.py
+++ b/bec_server/tests/tests_device_server/test_device_server.py
@@ -701,10 +701,21 @@ def test_set_device(device_server_mock, instr):
     with mock.patch.object(
         device_server.device_manager.devices.samx.obj, "set", side_effect=Exception("Set failed")
     ):
-        with mock.patch.object(device_server.requests_handler, "set_finished") as set_finished_mock:
+        with mock.patch.object(
+            device_server.requests_handler, "send_device_instruction_response"
+        ) as mock_send_response:
             device_server._set_device(instr)
-            set_finished_mock.assert_called_with(
-                instr.metadata["device_instr_id"], success=False, error_info=ANY
+            # Call arg list should not contain any duplicate calls, error response should only be sent once
+            assert (
+                mock_send_response.call_count == 3
+            )  # Make sure that there are no duplicate calls for error response.
+            mock_send_response.assert_called_with(
+                instr.metadata["device_instr_id"],
+                False,
+                done=True,
+                error_info=ANY,
+                result=None,
+                is_status_obj=True,
             )
 
 

--- a/bec_server/tests/tests_device_server/test_device_server.py
+++ b/bec_server/tests/tests_device_server/test_device_server.py
@@ -697,6 +697,16 @@ def test_set_device(device_server_mock, instr):
     msg = res[0]["msg"]
     assert msg.metadata["RID"] == "test"
 
+    # Test that if _set raises an exception, the status is set as failed
+    with mock.patch.object(
+        device_server.device_manager.devices.samx.obj, "set", side_effect=Exception("Set failed")
+    ):
+        with mock.patch.object(device_server.requests_handler, "set_finished") as set_finished_mock:
+            device_server._set_device(instr)
+            set_finished_mock.assert_called_with(
+                instr.metadata["device_instr_id"], success=False, error_info=ANY
+            )
+
 
 @pytest.mark.parametrize(
     "instr",


### PR DESCRIPTION
PR to fix a bug that the `mv` command would not properly raise if `.set` failed. The `umv` command was handling this properly as raising the exception was properly captured and awaited for in contrast to the `mv` which occurs fully asynchronously. 