### PR TITLE
fix: clean procedure worker shutdown

### DIFF
--- a/bec_ipython_client/tests/end-2-end/test_procedures_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_procedures_e2e.py
@@ -46,8 +46,10 @@ def client_logtool_and_manager(
     manager = ProcedureManager(
         f"{client.connector.host}:{client.connector.port}", ContainerProcedureWorker
     )
-    yield client, logtool, manager
-    manager.shutdown()
+    try:
+        yield client, logtool, manager
+    finally:
+        manager.shutdown()
 
 
 def _wait_while(cond: Callable[[], bool], timeout_s):

--- a/bec_lib/bec_lib/bec_service.py
+++ b/bec_lib/bec_lib/bec_service.py
@@ -168,7 +168,9 @@ class BECService:
         # Log the server address
         logger.info(f"Connecting to Redis server at {self.bootstrap_server}")
         self.connector: RedisConnector = (
-            connector_cls(self.bootstrap_server) if connector is None else connector
+            connector_cls(self.bootstrap_server, name=f"{self._name} RedisConnector")
+            if connector is None
+            else connector
         )
         self.acl = BECAccess(self.connector)
         self.acl._bec_service_login(prompt_for_acl, self._service_config.config.get("acl"))

--- a/bec_lib/bec_lib/redis_connector.py
+++ b/bec_lib/bec_lib/redis_connector.py
@@ -17,7 +17,6 @@ import threading
 import time
 import traceback
 import warnings
-from collections import defaultdict
 from collections.abc import MutableMapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
@@ -406,15 +405,23 @@ class RedisConnector:
 
     RETRY_ON_TIMEOUT: int = 20
 
-    def __init__(self, bootstrap: list[str] | str, redis_cls: type[Redis] = Redis, **kwargs):
+    def __init__(
+        self,
+        bootstrap: list[str] | str,
+        redis_cls: type[Redis] = Redis,
+        name: str = "RedisConnector",
+        **kwargs,
+    ):
         """
         Initialize the connector
 
         Args:
             bootstrap (list): list of strings in the form "host:port"
             redis_cls (redis.client, optional): redis client class. Defaults to the standard client redis.Redis. Must not be an async client.
+            name (str): Name to identify this instance
             **kwargs: additional keyword arguments to pass to the redis client.
         """
+        self.name = name
         self.host, self.port = (
             bootstrap[0].split(":") if isinstance(bootstrap, list) else bootstrap.split(":")
         )
@@ -457,6 +464,10 @@ class RedisConnector:
         self.stream_keys: dict[str, str] = {}  # for explicit reads, not subscriptions
 
         self._generator_executor = ThreadPoolExecutor()
+
+    @property
+    def connection_error_str(self):
+        return f"{self.name} failed to connect to redis ({self.host}:{self.port}). Is the server running?"
 
     def authenticate(self, *, username: str = "default", password: str | None = "null"):
         """
@@ -513,6 +524,7 @@ class RedisConnector:
         self._stop_events_listener_thread.clear()
         if self._events_listener_thread is None:
             self._events_listener_thread = threading.Thread(target=self._get_messages_loop)
+            self._events_listener_thread.name += f" ({self.name})"
             self._events_listener_thread.start()
 
     def _get_retry_policy(self) -> Retry:
@@ -552,6 +564,7 @@ class RedisConnector:
         Shutdown the connector
         """
         self.set_retry_enabled(False)
+
         if self._events_listener_thread:
             self._stop_events_listener_thread.set()
             self._events_listener_thread.join(timeout=per_thread_timeout_s)
@@ -567,7 +580,6 @@ class RedisConnector:
 
         # this will take care of shutting down direct listening threads
         self._unregister_stream(self._stream_subs.all_topics)
-
         # release all connections
         self._pubsub_conn.close()
         self._redis_conn.close()
@@ -703,6 +715,7 @@ class RedisConnector:
             self._events_dispatcher_thread = threading.Thread(
                 target=self._dispatch_events, args=(started_event,)
             )
+            self._events_dispatcher_thread.name += f" ({self.name})"
             self._events_dispatcher_thread.start()
             started_event.wait()  # synchronization of thread start
 
@@ -801,6 +814,7 @@ class RedisConnector:
         if self._events_listener_thread is None:
             # create the thread that will get all messages for this connector;
             self._events_listener_thread = threading.Thread(target=self._get_messages_loop)
+            self._events_listener_thread.name += f" ({self.name})"
             self._events_listener_thread.start()
 
         if patterns is not None:
@@ -846,6 +860,7 @@ class RedisConnector:
         thread = threading.Thread(
             target=self._direct_stream_listener, args=(topic, stop_event, cb_ref, kwargs)
         )
+        thread.name += f" ({self.name})"
         return DirectReadStreamSubInfo(cb_ref, kwargs, stop_event, thread)
 
     def _direct_stream_listener(self, topic: str, stop_event: threading.Event, cb_ref, kwargs):
@@ -856,7 +871,7 @@ class RedisConnector:
                 continue
             redis_id, msg_dict = response[0]  # type: ignore : we are using Redis synchronously
             timestamp, _, ind = redis_id.partition(b"-")
-            read_id = f"{timestamp.decode()}-{int(ind.decode())+1}"
+            read_id = f"{timestamp.decode()}-{int(ind.decode()) + 1}"
             stream_msg = StreamMessage(
                 {key.decode(): MsgpackSerialization.loads(val) for key, val in msg_dict.items()},
                 ((cb_ref, kwargs),),
@@ -886,7 +901,7 @@ class RedisConnector:
             else:
                 return self._redis_conn.xread(topics_ids, block=200) or []  # type: ignore strs are fine key and id types
         except redis.exceptions.ConnectionError:
-            logger.error("Failed to connect to redis. Is the server running?")
+            logger.error(self.connection_error_str)
         except redis.exceptions.NoPermissionError:
             logger.error(f"Permission denied for stream topics: {set(topics_ids.keys())}")
         # pylint: disable=broad-except
@@ -984,6 +999,7 @@ class RedisConnector:
             self._stream_events_listener_thread = threading.Thread(
                 target=self._get_stream_messages_loop
             )
+            self._stream_events_listener_thread.name += f" ({self.name})"
             self._stream_events_listener_thread.start()
 
     def _filter_topics_cb(self, topics: list, cb: Callable | None):
@@ -1060,7 +1076,7 @@ class RedisConnector:
             except redis.exceptions.ConnectionError:
                 if not error:
                     error = True
-                    bec_logger.logger.error("Failed to connect to redis. Is the server running?")
+                    bec_logger.logger.error(self.connection_error_str)
                 self._stop_events_listener_thread.wait(timeout=1)
             # pylint: disable=broad-except
             except Exception:
@@ -1501,7 +1517,9 @@ class RedisConnector:
     @validate_endpoint("topic")
     def get_set_members(self, topic: str, pipe: Pipeline | None = None) -> set:
         """fetch the items in the set as a set'"""
-        return set(MsgpackSerialization.loads(msg) for msg in (pipe or self._redis_conn).smembers(topic))  # type: ignore
+        return set(
+            MsgpackSerialization.loads(msg) for msg in (pipe or self._redis_conn).smembers(topic)
+        )  # type: ignore
 
     def blocking_list_pop_to_set_add(
         self,

--- a/bec_lib/bec_lib/tests/utils.py
+++ b/bec_lib/bec_lib/tests/utils.py
@@ -508,7 +508,12 @@ class SignalMock:  # pragma: no cover
 class ConnectorMock(RedisConnector):  # pragma: no cover
     RETRY_ON_TIMEOUT = 0
 
-    def __init__(self, bootstrap_server: list[str] | str = "localhost:0000", store_data=True):
+    def __init__(
+        self,
+        bootstrap_server: list[str] | str = "localhost:0000",
+        store_data=True,
+        name="ConnectorMock",
+    ):
         if isinstance(bootstrap_server, list):
             bootstrap_server = bootstrap_server[0]
         if ":" not in bootstrap_server:

--- a/bec_server/bec_server/procedures/container_utils.py
+++ b/bec_server/bec_server/procedures/container_utils.py
@@ -218,6 +218,9 @@ class PodmanCliUtils(_PodmanUtilsBase):
         _environment = _multi_args_from_dict("-e", environment)  # type: ignore # this is actually a dict[str, str]
         _pod_arg = ["--pod", pod_name] if pod_name else []
         _name_arg = ["--replace", "--name", container_name] if container_name else []
+        if container_name:
+            # in case of incomplete cleanup previously, even with --replace it is possible to get an error
+            _run_and_capture_error("podman", "rm", "-f", container_name)
         return (
             _run_and_capture_error(
                 "podman",

--- a/bec_server/bec_server/procedures/manager.py
+++ b/bec_server/bec_server/procedures/manager.py
@@ -81,7 +81,7 @@ class ProcedureManagerBase(ABC, Generic[_ReqMsgT, _ExecMsgT]):
         )
 
         self._logs = deque([], maxlen=1000)
-        self._conn = RedisConnector([redis])
+        self._conn = RedisConnector([redis], name="ProcedureManager RedisConnector")
 
         self._active_workers: dict[str, ProcedureWorkerEntry] = {}
         self.executor = ThreadPoolExecutor(

--- a/bec_server/bec_server/procedures/oop_worker_base.py
+++ b/bec_server/bec_server/procedures/oop_worker_base.py
@@ -114,8 +114,9 @@ def _resolve_timeout(timeout_s: str) -> float:
         return PROCEDURE.WORKER.QUEUE_TIMEOUT_S
 
 
-def _create_client(client_type: BecClientType, redis: dict[str, str]):
+def _create_client(client_type: BecClientType, redis: dict[str, str], name=None):
     config = ServiceConfig(redis=redis, config={"procedures": {"enable_procedures": False}})
+
     if client_type == BecClientType.BECIPythonClient:
         return BECIPythonClient(config=config, wait_for_server=False, mode=OperationMode.Procedure)
     elif client_type == BecClientType.BECClient:
@@ -141,7 +142,9 @@ def setup(env: OopWorkerEnv):
     host, port = env["redis_server"].split(":")
     redis = {"host": host, "port": port}
 
-    client = _create_client(env["client_class"], redis=redis)
+    client = _create_client(
+        env["client_class"], redis=redis, name=f"[OOP worker client: {env['queue']}]"
+    )
 
     logger.debug("starting client")
     client.start()

--- a/bec_server/bec_server/procedures/worker_base.py
+++ b/bec_server/bec_server/procedures/worker_base.py
@@ -47,7 +47,7 @@ class ProcedureWorker(ABC):
         self._active_procs_endpoint = MessageEndpoints.active_procedure_executions()
         self.status = ProcedureWorkerStatus.IDLE
         self._redis_server = server
-        self._conn = RedisConnector([server])
+        self._conn = RedisConnector([server], name=f"ProcedureWorker-{queue} RedisConnector")
         self._helper = BackendProcedureHelper(self._conn)
         self.client_id = self._conn.client_id()
         self._current_execution_id: str | None = None
@@ -86,6 +86,7 @@ class ProcedureWorker(ABC):
     def abort(self):
         """Abort the entire worker"""
         self._aborted.set()
+        self._conn.shutdown()
         self._kill_process()
 
     @abstractmethod

--- a/bec_server/tests/tests_device_server/test_device_instructions.py
+++ b/bec_server/tests/tests_device_server/test_device_instructions.py
@@ -38,7 +38,7 @@ def _convert_to_db_config(yaml_config: dict) -> None:
 @pytest.fixture
 def fakeredis_connector(connected_connector, **kwargs):
     connected_connector.set_retry_enabled(False)
-    return lambda x: connected_connector
+    return lambda x, **_: connected_connector
 
 
 @pytest.fixture

--- a/pytest_bec_e2e/pytest_bec_e2e/plugin.py
+++ b/pytest_bec_e2e/pytest_bec_e2e/plugin.py
@@ -69,8 +69,8 @@ def pytest_addoption(parser):
 redis_server_fixture = None
 bec_redis_fixture = None
 _start_servers = False
-bec_servers_scope = (
-    lambda fixture_name, config: config.getoption("--flush-redis") and "function" or "session"
+bec_servers_scope = lambda fixture_name, config: (
+    config.getoption("--flush-redis") and "function" or "session"
 )
 
 


### PR DESCRIPTION
Makes sure that the procedure worker's `RedisConnector` is shut down when the worker is aborted. Mainly comes up in tests; I couldn't reproduce it manually, but I think it happens when pytest intercepts cleanup and the test finishes before the worker context manager exits, which is what would normally call `_conn.shutdown()`.

Additionally, Podman doesn't seem to respect `--replace` option if there is some error state from a previous cleanup, resulting in flaky tests. This change forces the cleanup before starting a container but doesn't resolve the root issue.

Also adds names to the RedisConnector threads to make it easier to identify which is which.