### PR TITLE
fix: more container cleanup

### DIFF
--- a/.github/actions/bec_e2e_install/action.yml
+++ b/.github/actions/bec_e2e_install/action.yml
@@ -75,6 +75,7 @@ runs:
         source ./bin/install_bec_dev.sh -t
         pip install -e ../ophyd_devices
         pip install -e ../bec_testing_plugin
+        podman system prune -f
         podman pod create --network=host local_bec
         python ./bec_ipython_client/tests/end-2-end/_ensure_requirements_container.py
         for i in {0..10}; do

--- a/.github/actions/bec_e2e_install/action.yml
+++ b/.github/actions/bec_e2e_install/action.yml
@@ -77,5 +77,7 @@ runs:
         pip install -e ../bec_testing_plugin
         podman pod create --network=host local_bec
         python ./bec_ipython_client/tests/end-2-end/_ensure_requirements_container.py
-        coverage run --branch --source=./bec_server/bec_server,./bec_lib/bec_lib,./bec_ipython_client/bec_ipython_client, --omit=*/bec_server/scan_server/scan_plugins/*,*/bec_ipython_client/bec_ipython_client/plugins/*,*/bec_ipython_client/scripts/*,*/bec_lib/bec_lib/tests/* -m pytest -v --files-path ./ --start-servers --random-order  ./bec_ipython_client/tests/end-2-end/
+        for i in {0..10}; do
+          coverage run --branch --source=./bec_server/bec_server,./bec_lib/bec_lib,./bec_ipython_client/bec_ipython_client, --omit=*/bec_server/scan_server/scan_plugins/*,*/bec_ipython_client/bec_ipython_client/plugins/*,*/bec_ipython_client/scripts/*,*/bec_lib/bec_lib/tests/* -m pytest -v --files-path ./ --start-servers --random-order  ./bec_ipython_client/tests/end-2-end/test_procedures_e2e.py;
+        done
         coverage xml -o coverage-e2e.xml

--- a/bec_ipython_client/tests/end-2-end/test_procedures_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_procedures_e2e.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from importlib.metadata import version
 from typing import TYPE_CHECKING, Callable, Generator
 from unittest.mock import patch
+from uuid import uuid4
 
 import pytest
 
@@ -41,16 +42,15 @@ class PATCHED_CONSTANTS:
 
 @pytest.fixture
 def client_logtool_and_manager(
-    bec_ipython_client_fixture_with_logtool: tuple[BECIPythonClient, "LogTestTool"],
+    bec_ipython_client_fixture_with_logtool: tuple[BECIPythonClient, "LogTestTool"], threads_check
 ) -> Generator[tuple[BECIPythonClient, "LogTestTool", ProcedureManager], None, None]:
     client, logtool = bec_ipython_client_fixture_with_logtool
     manager = ProcedureManager(
         f"{client.connector.host}:{client.connector.port}", ContainerProcedureWorker
     )
-    try:
-        yield client, logtool, manager
-    finally:
-        manager.shutdown()
+    yield client, logtool, manager
+    manager.shutdown()
+    time.sleep(1)
 
 
 def _wait_while(cond: Callable[[], bool], timeout_s):
@@ -61,7 +61,18 @@ def _wait_while(cond: Callable[[], bool], timeout_s):
         time.sleep(0.01)
 
 
-@pytest.mark.timeout(200)
+def _wait_while_with_cleanup(cond: Callable[[], bool], timeout_s, manager):
+    try:
+        _wait_while(cond, timeout_s)
+    except Exception as e:
+        with manager.lock:
+            for worker_entry in manager._active_workers.values():
+                worker = worker_entry.get("worker")
+                if worker is not None:
+                    worker.abort()
+                    raise Exception(worker.logs()) from e  # print the logs if there is an error
+
+
 def test_building_worker_image():
     podman_utils = get_backend()
     build = podman_utils.build_worker_image()
@@ -69,7 +80,6 @@ def test_building_worker_image():
     assert podman_utils.image_exists(f"bec_procedure_worker:v{version('bec_lib')}")
 
 
-@pytest.mark.timeout(200)
 @patch("bec_server.procedures.manager.procedure_registry.is_registered", lambda _: True)
 @patch("bec_server.procedures.oop_worker_base.PROCEDURE", PATCHED_CONSTANTS())
 @patch("bec_server.procedures.container_worker.PROCEDURE", PATCHED_CONSTANTS())
@@ -78,9 +88,10 @@ def test_procedure_runner_spawns_worker(
 ):
     client, _, manager = client_logtool_and_manager
     assert manager._active_workers == {}
+    queue = str(uuid4())
     endpoint = MessageEndpoints.procedure_request()
     msg = messages.ProcedureRequestMessage(
-        identifier="sleep", args_kwargs=((), {"time_s": 0.1}), queue="test"
+        identifier="sleep", args_kwargs=((), {"time_s": 0.1}), queue=queue
     )
 
     logs = []
@@ -89,23 +100,14 @@ def test_procedure_runner_spawns_worker(
         nonlocal logs
         logs = worker.logs()
 
-    manager.add_callback("test", cb)
+    manager.add_callback(queue, cb)
     client.connector.send(endpoint, msg)
 
     _wait_while(lambda: manager._active_workers == {}, 5)
-    try:
-        _wait_while(lambda: manager._active_workers != {}, 180)
-    except Exception as e:
-        with manager.lock:
-            worker = manager._active_workers.get("test", {}).get("worker")
-            if worker is not None:
-                worker.abort()
-                raise Exception(worker.logs()) from e  # print the logs if there is an error
-
-    assert logs != []
+    _wait_while_with_cleanup(lambda: manager._active_workers != {}, 120, manager)
+    _wait_while(lambda: logs == [], 20)
 
 
-@pytest.mark.timeout(200)
 @patch("bec_server.procedures.manager.procedure_registry.is_registered", lambda _: True)
 @patch("bec_server.procedures.oop_worker_base.PROCEDURE", PATCHED_CONSTANTS())
 @patch("bec_server.procedures.container_worker.PROCEDURE", PATCHED_CONSTANTS())
@@ -114,41 +116,40 @@ def test_happy_path_container_procedure_runner(
 ):
     test_args = (1, 2, 3)
     test_kwargs = {"a": "b", "c": "d"}
+    queue = str(uuid4())
     client, logtool, manager = client_logtool_and_manager
     assert manager._active_workers == {}
     conn = client.connector
     endpoint = MessageEndpoints.procedure_request()
     msg = messages.ProcedureRequestMessage(
-        identifier="_log_msg_args", args_kwargs=(test_args, test_kwargs)
+        identifier="_log_msg_args", args_kwargs=(test_args, test_kwargs), queue=queue
     )
     conn.send(endpoint, msg)
 
     _wait_while(lambda: manager._active_workers == {}, 10)
-    try:
-        _wait_while(lambda: manager._active_workers != {}, 180)
-    except Exception as e:
-        with manager.lock:
-            worker = manager._active_workers.get("primary", {}).get("worker")
-            if worker is not None:
-                worker.abort()
-                raise Exception(worker.logs()) from e  # print the logs if there is an error
+    _wait_while_with_cleanup(lambda: manager._active_workers != {}, 180, manager)
 
-    logtool.fetch()
-    assert logtool.is_present_in_any_message("procedure accepted: True, message:")
-    assert logtool.is_present_in_any_message(
-        "Procedure worker started container for queue primary"
-    ), f"Log content relating to procedures: {manager._logs}"
+    def _check_for_logs():
+        time.sleep(5)
+        logtool.fetch()
+        return all(
+            (
+                logtool.is_present_in_any_message("procedure accepted: True, message:"),
+                logtool.is_present_in_any_message(
+                    "Procedure worker started container for queue primary"
+                ),
+                logtool.are_present_in_order(
+                    [
+                        "Procedure worker 'primary' status update: IDLE",
+                        "Procedure worker 'primary' status update: RUNNING",
+                        "Procedure worker 'primary' status update: IDLE",
+                        "Procedure worker 'primary' status update: FINISHED",
+                    ]
+                ),
+                logtool.is_present_in_any_message(
+                    f"Builtin procedure log_message_args_kwargs called with args: {test_args} and kwargs: {test_kwargs}"
+                ),
+            )
+        )
 
-    res, msg = logtool.are_present_in_order(
-        [
-            "Procedure worker 'primary' status update: IDLE",
-            "Procedure worker 'primary' status update: RUNNING",
-            "Procedure worker 'primary' status update: IDLE",
-            "Procedure worker 'primary' status update: FINISHED",
-        ]
-    )
-    assert res, f"failed on {msg}"
-
-    assert logtool.is_present_in_any_message(
-        f"Builtin procedure log_message_args_kwargs called with args: {test_args} and kwargs: {test_kwargs}"
-    )
+    _wait_while_with_cleanup(lambda: not _check_for_logs(), 30, manager)

--- a/bec_ipython_client/tests/end-2-end/test_procedures_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_procedures_e2e.py
@@ -36,7 +36,7 @@ class PATCHED_CONSTANTS:
     CONTAINER = _CONTAINER()
     MANAGER_SHUTDOWN_TIMEOUT_S = 15
     BEC_VERSION = version("bec_lib")
-    REDIS_HOST = "redis"
+    REDIS_HOST = "localhost"
 
 
 @pytest.fixture
@@ -61,7 +61,7 @@ def _wait_while(cond: Callable[[], bool], timeout_s):
         time.sleep(0.01)
 
 
-@pytest.mark.timeout(100)
+@pytest.mark.timeout(200)
 def test_building_worker_image():
     podman_utils = get_backend()
     build = podman_utils.build_worker_image()
@@ -69,7 +69,7 @@ def test_building_worker_image():
     assert podman_utils.image_exists(f"bec_procedure_worker:v{version('bec_lib')}")
 
 
-@pytest.mark.timeout(100)
+@pytest.mark.timeout(200)
 @patch("bec_server.procedures.manager.procedure_registry.is_registered", lambda _: True)
 @patch("bec_server.procedures.oop_worker_base.PROCEDURE", PATCHED_CONSTANTS())
 @patch("bec_server.procedures.container_worker.PROCEDURE", PATCHED_CONSTANTS())
@@ -94,7 +94,7 @@ def test_procedure_runner_spawns_worker(
 
     _wait_while(lambda: manager._active_workers == {}, 5)
     try:
-        _wait_while(lambda: manager._active_workers != {}, 90)
+        _wait_while(lambda: manager._active_workers != {}, 180)
     except Exception as e:
         with manager.lock:
             worker = manager._active_workers.get("test", {}).get("worker")
@@ -105,7 +105,7 @@ def test_procedure_runner_spawns_worker(
     assert logs != []
 
 
-@pytest.mark.timeout(100)
+@pytest.mark.timeout(200)
 @patch("bec_server.procedures.manager.procedure_registry.is_registered", lambda _: True)
 @patch("bec_server.procedures.oop_worker_base.PROCEDURE", PATCHED_CONSTANTS())
 @patch("bec_server.procedures.container_worker.PROCEDURE", PATCHED_CONSTANTS())
@@ -123,9 +123,9 @@ def test_happy_path_container_procedure_runner(
     )
     conn.send(endpoint, msg)
 
-    _wait_while(lambda: manager._active_workers == {}, 5)
+    _wait_while(lambda: manager._active_workers == {}, 10)
     try:
-        _wait_while(lambda: manager._active_workers != {}, 90)
+        _wait_while(lambda: manager._active_workers != {}, 180)
     except Exception as e:
         with manager.lock:
             worker = manager._active_workers.get("primary", {}).get("worker")

--- a/bec_ipython_client/tests/end-2-end/test_procedures_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_procedures_e2e.py
@@ -16,6 +16,7 @@ from bec_server.procedures.constants import _CONTAINER, _WORKER
 from bec_server.procedures.container_utils import get_backend
 from bec_server.procedures.container_worker import ContainerProcedureWorker
 from bec_server.procedures.manager import ProcedureManager
+from bec_server.procedures.subprocess_worker import SubProcessWorker
 
 if TYPE_CHECKING:
     from pytest_bec_e2e.plugin import LogTestTool
@@ -33,9 +34,9 @@ pytestmark = pytest.mark.random_order(disabled=True)
 class PATCHED_CONSTANTS:
     WORKER = _WORKER()
     CONTAINER = _CONTAINER()
-    MANAGER_SHUTDOWN_TIMEOUT_S = 2
+    MANAGER_SHUTDOWN_TIMEOUT_S = 15
     BEC_VERSION = version("bec_lib")
-    REDIS_HOST = "localhost"
+    REDIS_HOST = "redis"
 
 
 @pytest.fixture
@@ -84,9 +85,9 @@ def test_procedure_runner_spawns_worker(
 
     logs = []
 
-    def cb(worker: ContainerProcedureWorker):
+    def cb(worker: SubProcessWorker):
         nonlocal logs
-        logs = worker._backend.logs(worker._container_id)
+        logs = worker.logs()
 
     manager.add_callback("test", cb)
     client.connector.send(endpoint, msg)
@@ -95,10 +96,11 @@ def test_procedure_runner_spawns_worker(
     try:
         _wait_while(lambda: manager._active_workers != {}, 90)
     except Exception as e:
-        worker = manager._active_workers["test"]["worker"]
-        raise Exception(
-            worker._backend.logs(worker._container_id)
-        ) from e  # print the logs if there is an error
+        with manager.lock:
+            worker = manager._active_workers.get("test", {}).get("worker")
+            if worker is not None:
+                worker.abort()
+                raise Exception(worker.logs()) from e  # print the logs if there is an error
 
     assert logs != []
 
@@ -122,7 +124,14 @@ def test_happy_path_container_procedure_runner(
     conn.send(endpoint, msg)
 
     _wait_while(lambda: manager._active_workers == {}, 5)
-    _wait_while(lambda: manager._active_workers != {}, 90)
+    try:
+        _wait_while(lambda: manager._active_workers != {}, 90)
+    except Exception as e:
+        with manager.lock:
+            worker = manager._active_workers.get("primary", {}).get("worker")
+            if worker is not None:
+                worker.abort()
+                raise Exception(worker.logs()) from e  # print the logs if there is an error
 
     logtool.fetch()
     assert logtool.is_present_in_any_message("procedure accepted: True, message:")

--- a/bec_server/bec_server/procedures/container_utils.py
+++ b/bec_server/bec_server/procedures/container_utils.py
@@ -149,7 +149,7 @@ class PodmanApiUtils(_PodmanUtilsBase):
             return client.images.exists(image_tag)
 
     def interrupt(self, id: str):
-        raise NotImplemented
+        raise NotImplementedError
 
     def kill(self, id: str):
         with PodmanClient(base_url=self.uri) as client:

--- a/bec_server/bec_server/procedures/container_worker.py
+++ b/bec_server/bec_server/procedures/container_worker.py
@@ -49,18 +49,28 @@ class ContainerProcedureWorker(OutOfProcessWorkerBase):
             PodmanContainerStates.STOPPING,
         ]
 
+    def _ended(self):
+        return self._backend.state(self._container_id) in [
+            PodmanContainerStates.STOPPED,
+            PodmanContainerStates.STOPPING,
+        ]
+
     def _kill_process(self):
-        if not self._ending_or_ended():
+        if not self._ended():
             self._backend.interrupt(self.container_name)
             start = time.monotonic()
             while time.monotonic() < start + PROCESS_TIMEOUT:
-                if self._ending_or_ended():
+                if self._ended():
                     return
                 time.sleep(0.2)
             logger.warning(
                 f"Procedure worker {self._container_id} for queue {self._queue} failed to shut down, killing."
             )
             self._backend.kill(self.container_name)
+            while time.monotonic() < start + PROCESS_TIMEOUT:
+                if self._ended():
+                    return
+                time.sleep(0.2)
 
     def abort_execution(self, execution_id: str):
         """Abort the execution with the given id. Has no effect if the given ID is not the current job"""

--- a/bec_server/bec_server/procedures/manager.py
+++ b/bec_server/bec_server/procedures/manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import atexit
+import threading
 from abc import ABC, abstractmethod
 from collections import deque
 from concurrent import futures
@@ -185,7 +186,7 @@ class ProcedureManagerBase(ABC, Generic[_ReqMsgT, _ExecMsgT]):
                         # redis unblock executor.client_id
                         worker.abort()
         self._wait_for_all_futures()
-        self.executor.shutdown()
+        self.executor.shutdown(cancel_futures=True)
 
     @abstractmethod
     def _define_endpoints(self):


### PR DESCRIPTION
In the case of an error during the test, call `worker.abort()` again in the main thread