### PR TITLE
fix: add optional separator to dynamic metrics

### DIFF
--- a/bec_lib/bec_lib/messages.py
+++ b/bec_lib/bec_lib/messages.py
@@ -1225,11 +1225,13 @@ class DynamicMetricMessage(BECMessage):
     timestamp: float = Field(default_factory=time.time)
 
     @classmethod
-    def from_dict(cls, metrics: dict[str, str | int | float | bool]):
+    def from_dict(cls, metrics: dict[str, str | int | float | bool], separator: str = "-"):
         return cls.model_validate(
             {
                 "metrics": {
-                    k: {"value": v, "type_name": type(v).__name__} for k, v in metrics.items()
+                    # Metric names are concatenated with the group in the ingestor
+                    separator + k: {"value": v, "type_name": type(v).__name__}
+                    for k, v in metrics.items()
                 }
             }
         )

--- a/bec_lib/bec_lib/redis_connector.py
+++ b/bec_lib/bec_lib/redis_connector.py
@@ -1562,12 +1562,14 @@ class RedisConnector:
             return None
         return MsgpackSerialization.loads(raw_msg[1])  # type: ignore # list pop returns one item
 
-    def publish_metrics(self, group_name: str, metrics: dict[str, str | int | float | bool]):
+    def publish_metrics(
+        self, group_name: str, metrics: dict[str, str | int | float | bool], separator="-"
+    ):
         if str in set(map(type, metrics.values())):
             bec_logger.logger.warning(
-                "Dynamic string metrics are currently not supported and will be ignored in the ingestor."
+                f"String type found in dynamic metric: {group_name}. String metrics are currently not supported and will be ignored in the ingestor."
             )
-        msg = DynamicMetricMessage.from_dict(metrics)
+        msg = DynamicMetricMessage.from_dict(metrics, separator=separator)
         ep = MessageEndpoints.dynamic_metric(group_name)
         self._redis_conn.publish(ep.endpoint, MsgpackSerialization.dumps(msg))
 

--- a/bec_lib/tests/test_bec_messages.py
+++ b/bec_lib/tests/test_bec_messages.py
@@ -686,10 +686,10 @@ def test_dynamic_metric_message():
     message = messages.DynamicMetricMessage.from_dict(
         {"m1": 5, "m2": 5.5, "m3": "test", "m4": True}
     )
-    assert isinstance(message.metrics["m1"], messages._IntDynamicMetricValue)
-    assert isinstance(message.metrics["m2"], messages._FloatDynamicMetricValue)
-    assert isinstance(message.metrics["m3"], messages._StrDynamicMetricValue)
-    assert isinstance(message.metrics["m4"], messages._BoolDynamicMetricValue)
+    assert isinstance(message.metrics["-m1"], messages._IntDynamicMetricValue)
+    assert isinstance(message.metrics["-m2"], messages._FloatDynamicMetricValue)
+    assert isinstance(message.metrics["-m3"], messages._StrDynamicMetricValue)
+    assert isinstance(message.metrics["-m4"], messages._BoolDynamicMetricValue)
 
 
 def test_feedback_message():

--- a/bec_lib/tests/test_redis_connector_fakeredis.py
+++ b/bec_lib/tests/test_redis_connector_fakeredis.py
@@ -607,10 +607,10 @@ def test_connector_publish_metrics(connected_connector):
     res = data[0]
     assert isinstance(res, messages.DynamicMetricMessage)
     assert start <= res.timestamp <= stop
-    assert res.metrics["m1"].value == 5
-    assert res.metrics["m2"].value == 5.5
-    assert res.metrics["m3"].value == "test"
-    assert res.metrics["m4"].value is True
+    assert res.metrics["-m1"].value == 5
+    assert res.metrics["-m2"].value == 5.5
+    assert res.metrics["-m3"].value == "test"
+    assert res.metrics["-m4"].value is True
 
 
 def test_merging_streams_does_not_skip_messages(connected_connector: RedisConnector):


### PR DESCRIPTION
Add a string (default `"-"`) to the beginning of dynamic metric names, so that they are separated when concatenated with the group name in the ingestor.