### PR TITLE
fix(redis_connector): filter_topics_cb `!=` instead of `is not`

### DIFF
--- a/bec_lib/bec_lib/redis_connector.py
+++ b/bec_lib/bec_lib/redis_connector.py
@@ -1009,7 +1009,7 @@ class RedisConnector:
                 topics_cb = self._topics_cb[topic]
                 # remove callback from list
                 self._topics_cb[topic] = list(
-                    filter(lambda item: cb and item[0]() is not cb, topics_cb)
+                    filter(lambda item: cb and item[0]() != cb, topics_cb)
                 )
                 if not self._topics_cb[topic]:
                     # no callbacks left, unsubscribe


### PR DESCRIPTION
## Description

Hotfix for unsubscribing with `!=` check. Previous indentity check would never unsubscribe bound methods (so basically anything from BEC Widgets) leading to pile up redis.
