### PR TITLE
Fix/scan report raise

### DIFF
--- a/bec_lib/bec_lib/scan_report.py
+++ b/bec_lib/bec_lib/scan_report.py
@@ -10,13 +10,14 @@ import traceback
 from math import inf
 from typing import TYPE_CHECKING
 
+from bec_lib import messages
+from bec_lib.alarm_handler import AlarmBase, Alarms
 from bec_lib.bec_errors import ScanAbortion
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.logger import bec_logger
 from bec_lib.scan_items import ScanItem
 
 if TYPE_CHECKING:  # pragma: no cover
-    from bec_lib import messages
     from bec_lib.client import BECClient
     from bec_lib.queue_items import QueueItem
     from bec_lib.request_items import RequestItem
@@ -111,6 +112,15 @@ class ScanReport:
         )
         if request_status is None:
             return False
+        for status_container in request_status:
+            if "data" not in status_container:
+                return False
+            status = status_container["data"]
+            if not status.success:
+                alarm_message = messages.AlarmMessage(
+                    severity=Alarms.MAJOR, info=status.metadata["error_info"]
+                )
+                raise AlarmBase(alarm=alarm_message, severity=Alarms.MAJOR)
         if len(request_status) == len(motors):
             return True
         return False

--- a/bec_lib/tests/test_scan_report.py
+++ b/bec_lib/tests/test_scan_report.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 from bec_lib import messages
+from bec_lib.alarm_handler import AlarmBase
 from bec_lib.bec_errors import ScanAbortion
 from bec_lib.scan_report import ScanReport
 
@@ -149,6 +150,34 @@ def test_scan_report_get_mv_status(scan_report, xread_return, expected):
     with mock.patch.object(scan_report._client.device_manager.connector, "xread") as mock_xread:
         mock_xread.return_value = xread_return
         assert scan_report._get_mv_status() == expected
+
+
+def test_scan_report_get_mv_status_raises_alarm_on_failed_move(scan_report):
+    error_info = messages.ErrorInfo(
+        error_message="Motor move failed",
+        compact_error_message="RuntimeError: Motor move failed",
+        exception_type="RuntimeError",
+        device="samx",
+    )
+    scan_report.request.request = messages.ScanQueueMessage(
+        scan_type="mv", parameter={"args": {"samx": [5]}}
+    )
+    with mock.patch.object(scan_report._client.device_manager.connector, "xread") as mock_xread:
+        mock_xread.return_value = [
+            {
+                "data": messages.DeviceReqStatusMessage(
+                    device="samx",
+                    success=False,
+                    request_id="request-id",
+                    metadata={"error_info": error_info},
+                )
+            }
+        ]
+        with pytest.raises(AlarmBase) as exc_info:
+            scan_report._get_mv_status()
+
+    assert exc_info.value.severity.name == "MAJOR"
+    assert exc_info.value.alarm.info == error_info
 
 
 def test_scan_report_file_written(scan_report):

--- a/bec_server/bec_server/device_server/device_server.py
+++ b/bec_server/bec_server/device_server/device_server.py
@@ -216,10 +216,12 @@ class RequestHandler:
         if len(request_info["status_objects"]) != request_info["num_status_objects"]:
             return
 
-        if all(status_obj.done for status_obj in self._storage[instr_id]["status_objects"]):
+        status_objects = request_info["status_objects"]
+
+        if all(status_obj.done for status_obj in status_objects):
             exceptions = [
                 (status_obj.exception(), status_obj)
-                for status_obj in self._storage[instr_id]["status_objects"]
+                for status_obj in status_objects
                 if isinstance(status_obj, StatusBase)
             ]
             if any(val for val, _ in exceptions):

--- a/bec_server/bec_server/device_server/device_server.py
+++ b/bec_server/bec_server/device_server/device_server.py
@@ -793,7 +793,7 @@ class DeviceServer(BECService):
                 MessageEndpoints.device_req_status(request_id),
                 {"data": dev_msg},
                 pipe=pipe,
-                expire=60,
+                expire=3600,
             )
         pipe.execute()
 

--- a/bec_server/bec_server/device_server/device_server.py
+++ b/bec_server/bec_server/device_server/device_server.py
@@ -777,6 +777,11 @@ class DeviceServer(BECService):
             # if the user requested a response on a single status object, we need to send it
             # to the device_req_status_container
             request_id = status.instruction.metadata["RID"]
+            metadata["error_info"] = (
+                self.requests_handler.get_error_info(status.exception(), status)
+                if status.exception()
+                else None
+            )
             dev_msg = messages.DeviceReqStatusMessage(
                 device=device_name, success=status.success, request_id=request_id, metadata=metadata
             )

--- a/bec_server/bec_server/scihub/atlas/atlas_metadata_handler.py
+++ b/bec_server/bec_server/scihub/atlas/atlas_metadata_handler.py
@@ -147,15 +147,18 @@ class AtlasMetadataHandler:
         if self._account is None:
             return
         info = self._deployment_info
-        if info is None:
-            return
-        if info.active_session is None:
-            return
-        if info.active_session.experiment is None:
-            return
-        if info.active_session.experiment.pgroup == self._account:
-            return
-        self.send_atlas_update({"account": self._account})
+
+        def is_account_same(info: messages.DeploymentInfoMessage | None) -> bool:
+            if info is None:
+                return False
+            if info.active_session is None:
+                return False
+            if info.active_session.experiment is None:
+                return False
+            return info.active_session.experiment.pgroup == self._account
+
+        if not is_account_same(info):
+            self.send_atlas_update({"account": self._account})
 
     def _handle_account_info(self, msg, emit_update=True, **_kwargs) -> None:
         """

--- a/bec_server/tests/tests_device_server/test_device_server.py
+++ b/bec_server/tests/tests_device_server/test_device_server.py
@@ -1107,3 +1107,29 @@ def test_request_handler_ignores_response_if_stop_id(device_server_mock, stop_id
             stop_mock.assert_called()
         status.set_exception(RuntimeError("Test exception"))
         send_mock.assert_not_called()
+
+
+def test_request_handler_update_instruction_uses_snapshot_when_request_removed(device_server_mock):
+    device_server = device_server_mock
+    request = messages.DeviceInstructionMessage(
+        device="test_device", action="complete", parameter={}, metadata={"device_instr_id": "diid"}
+    )
+
+    status = StatusBase()
+    status.set_finished()
+    request_info = {
+        "instr": request,
+        "status_objects": [status],
+        "num_status_objects": 1,
+        "done": False,
+        "is_status_obj": True,
+    }
+
+    with mock.patch.object(
+        device_server.requests_handler, "get_request", return_value=request_info
+    ):
+        with mock.patch.object(device_server.requests_handler, "set_finished") as set_finished_mock:
+            device_server.requests_handler._storage.clear()
+            device_server.requests_handler._update_instruction("diid", is_status_obj=True)
+
+    set_finished_mock.assert_called_once_with("diid", success=True)

--- a/bec_server/tests/tests_device_server/test_device_server.py
+++ b/bec_server/tests/tests_device_server/test_device_server.py
@@ -130,6 +130,49 @@ def test_device_server_status_callback(
             logger.remove(sink_id)
 
 
+@pytest.mark.parametrize("status_success", [True, False])
+def test_device_server_status_callback_response_includes_error_info(
+    device_server_mock, ophyd_device_mock, status_success
+):
+    device_server = device_server_mock
+    dev = ophyd_device_mock
+    dev._kind = Kind.normal
+    instr = messages.DeviceInstructionMessage(
+        device=dev.name,
+        action="set",
+        parameter={},
+        metadata={
+            "stream": "primary",
+            "device_instr_id": "diid",
+            "RID": "request-id",
+            "response": True,
+        },
+    )
+
+    status = DeviceStatus(dev)
+    device_server._add_status_object_info(status, instruction=instr, device=dev)
+    if status_success:
+        status.set_finished()
+    else:
+        status.set_exception(RuntimeError("motor failed"))
+
+    with mock.patch.object(device_server, "_read_device") as mock_read_device:
+        with mock.patch.object(device_server.connector, "xadd") as xadd_mock:
+            device_server.status_callback(status)
+
+    mock_read_device.assert_called_once_with(instr)
+    xadd_mock.assert_called_once()
+    dev_msg = xadd_mock.call_args.args[1]["data"]
+    assert isinstance(dev_msg, messages.DeviceReqStatusMessage)
+    assert dev_msg.success is status_success
+    if status_success:
+        assert dev_msg.metadata["error_info"] is None
+    else:
+        assert dev_msg.metadata["error_info"] is not None
+        assert dev_msg.metadata["error_info"].exception_type == "RuntimeError"
+        assert "motor failed" in dev_msg.metadata["error_info"].error_message
+
+
 @pytest.mark.parametrize(
     "instr",
     [


### PR DESCRIPTION
## Description

Various smaller fixes based on the feedback from PX. 

## Type of Change

- Forward error info on request response
- Check success state on mv command's .wait()
- Update atlas account info if deployment info is empty or only partially filled.

## How to test

- Run unit tests

## Additional Comments

Once merged, I will redeploy it on PX and verify that it works. 

## Definition of Done
- [x] Documentation is up-to-date.

