### PR TITLE
fix: update separator in publish_metrics method from '-' to '_'

### DIFF
--- a/bec_lib/bec_lib/redis_connector.py
+++ b/bec_lib/bec_lib/redis_connector.py
@@ -1563,7 +1563,7 @@ class RedisConnector:
         return MsgpackSerialization.loads(raw_msg[1])  # type: ignore # list pop returns one item
 
     def publish_metrics(
-        self, group_name: str, metrics: dict[str, str | int | float | bool], separator="-"
+        self, group_name: str, metrics: dict[str, str | int | float | bool], separator="_"
     ):
         if str in set(map(type, metrics.values())):
             bec_logger.logger.warning(

--- a/bec_lib/tests/test_redis_connector_fakeredis.py
+++ b/bec_lib/tests/test_redis_connector_fakeredis.py
@@ -607,10 +607,10 @@ def test_connector_publish_metrics(connected_connector):
     res = data[0]
     assert isinstance(res, messages.DynamicMetricMessage)
     assert start <= res.timestamp <= stop
-    assert res.metrics["-m1"].value == 5
-    assert res.metrics["-m2"].value == 5.5
-    assert res.metrics["-m3"].value == "test"
-    assert res.metrics["-m4"].value is True
+    assert res.metrics["_m1"].value == 5
+    assert res.metrics["_m2"].value == 5.5
+    assert res.metrics["_m3"].value == "test"
+    assert res.metrics["_m4"].value is True
 
 
 def test_merging_streams_does_not_skip_messages(connected_connector: RedisConnector):


### PR DESCRIPTION
## Description

Mimir does not support "-" in the name, so the separator should be "_" instead

