### PR TITLE
fix: update account message format in send_atlas_update method

### DIFF
--- a/bec_server/bec_server/scihub/atlas/atlas_metadata_handler.py
+++ b/bec_server/bec_server/scihub/atlas/atlas_metadata_handler.py
@@ -158,7 +158,8 @@ class AtlasMetadataHandler:
             return info.active_session.experiment.pgroup == self._account
 
         if not is_account_same(info):
-            self.send_atlas_update({"account": self._account})
+            msg = messages.VariableMessage(value=self._account)
+            self.send_atlas_update({"account": msg})
 
     def _handle_account_info(self, msg, emit_update=True, **_kwargs) -> None:
         """

--- a/bec_server/tests/tests_scihub/test_atlas_metadata_handler.py
+++ b/bec_server/tests/tests_scihub/test_atlas_metadata_handler.py
@@ -298,7 +298,9 @@ def test_update_account_if_needed_different_account_forwards(atlas_connector):
     with mock.patch.object(handler, "send_atlas_update") as mock_send_update:
         handler._update_account_if_needed()
 
-    mock_send_update.assert_called_once_with({"account": "local-account"})
+    mock_send_update.assert_called_once_with(
+        {"account": messages.VariableMessage(value="local-account")}
+    )
 
 
 def test_handle_deployment_info_valid(atlas_connector):


### PR DESCRIPTION
## Description

Account updates must be sent as variable message, not just plain dict

## Definition of Done
- [ ] Documentation is up-to-date.

