### PR TITLE
feat(signal): add support for sending messages directly to phone numbers

### DIFF
--- a/bec_lib/bec_lib/messaging_services.py
+++ b/bec_lib/bec_lib/messaging_services.py
@@ -121,6 +121,7 @@ class MessagingService(ABC, Generic[MessageObjectT]):
 
     _SERVICE_NAME = "generic"
     _MESSAGE_OBJECT_CLASS: type[MessageObjectT] = MessageServiceObject  # type: ignore
+    _SUPPORTS_EMPTY_SCOPES = False
 
     def __init__(self, redis_connector: RedisConnector) -> None:
         self._redis_connector = redis_connector
@@ -203,8 +204,9 @@ class MessagingService(ABC, Generic[MessageObjectT]):
                 service.scope if isinstance(service.scope, list) else [service.scope]
             )
 
-        # If there are no scopes available for this service, or all are disabled, mark the service as disabled
-        if not self._scopes:
+        # Some services require configured scopes, while others can address
+        # recipients directly without any pre-registered scope.
+        if not self._scopes and not self._SUPPORTS_EMPTY_SCOPES:
             self._enabled = False
 
     def new(self, text: str | None = None) -> MessageObjectT:
@@ -396,9 +398,56 @@ class SignalMessageServiceObject(MessageServiceObject):
         self._content.append(messages.MessagingServiceStickerContent(sticker_id=sticker))
         return self
 
+    def send(self, scope: str | list[str] | None = None) -> None:
+        """
+        Send the message using the associated messaging service.
+
+        For Signal, the scope can be either a registered scope for a group or one
+        or more phone numbers for direct messages. Valid phone numbers are
+        normalized before sending; unparsable values are left untouched and treated
+        as regular scopes.
+
+        Args:
+            scope (str | list[str] | None): The scope or recipient for the
+                message. If None, uses the default scope set for the service.
+        """
+        if scope is None:
+            return super().send(scope=scope)
+        normalized_scope = self._service._normalize_scope(scope)  # type: ignore[attr-defined]
+        return super().send(scope=normalized_scope)
+
 
 class SignalMessagingService(MessagingService[SignalMessageServiceObject]):
     """Messaging service for Signal platform."""
 
     _SERVICE_NAME = "signal"
     _MESSAGE_OBJECT_CLASS = SignalMessageServiceObject
+    _SUPPORTS_EMPTY_SCOPES = True
+
+    @staticmethod
+    def _normalize_phone_number(value: str) -> str:
+        """
+        Normalize a valid phone number to E.164 format.
+
+        If parsing or validation fails, the original value is returned so it can
+        still be interpreted as a named Signal scope.
+        """
+        import phonenumbers
+
+        candidate = value.strip()
+        region = None if candidate.startswith("+") else "CH"
+        try:
+            parsed_number = phonenumbers.parse(candidate, region)
+        except phonenumbers.NumberParseException:
+            return value
+
+        if not phonenumbers.is_valid_number(parsed_number):
+            return value
+
+        return phonenumbers.format_number(parsed_number, phonenumbers.PhoneNumberFormat.E164)
+
+    def _normalize_scope(self, scope: str | list[str]) -> str | list[str]:
+        """Normalize Signal phone numbers while preserving plain scopes."""
+        if isinstance(scope, str):
+            return self._normalize_phone_number(scope)
+        return [self._normalize_phone_number(entry) for entry in scope]

--- a/bec_lib/pyproject.toml
+++ b/bec_lib/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "python-dotenv~=1.0",
     "python-slugify~=8.0",
     "questionary~=2.0",
+    "phonenumbers~=9.0",
 ]
 
 

--- a/bec_lib/tests/test_messaging_service.py
+++ b/bec_lib/tests/test_messaging_service.py
@@ -338,6 +338,31 @@ def test_signal_messaging_service_send_with_sticker(signal_service, connected_co
     assert sticker_part.sticker_id == "sticker_123"
 
 
+def test_signal_service_can_create_message_without_configured_scopes(connected_connector):
+    """Test that Signal remains enabled even without predefined scopes."""
+    service = SignalMessagingService(connected_connector)
+    available_services = messages.AvailableMessagingServicesMessage(
+        config=messages.MessagingConfig(
+            signal=messages.MessagingServiceScopeConfig(enabled=True),
+            teams=messages.MessagingServiceScopeConfig(enabled=False),
+            scilog=messages.MessagingServiceScopeConfig(enabled=False),
+        ),
+        deployment_services=[],
+        session_services=[],
+    )
+    service._on_new_scope_change_msg(message={"data": available_services})
+
+    message = service.new("Direct Signal message")
+    message.send(scope="+41791234567")
+    out = connected_connector.xread(
+        MessageEndpoints.message_service_queue(), from_start=True, count=1
+    )
+    assert len(out) == 1
+    out = out[0]["data"]
+    assert out.service_name == "signal"
+    assert out.scope == "+41791234567"
+
+
 def test_scilog_add_tags_with_string(scilog_message, connected_connector):
     """Test that add_tags works with a string input."""
     message = scilog_message
@@ -392,6 +417,31 @@ def test_signal_message_service_uses_default_scope(connected_connector):
         ValueError, match="Scope 'invalid_scope' is not available for this messaging service."
     ):
         service.set_default_scope("invalid_scope")
+
+
+@pytest.mark.parametrize(
+    ("scope", "expected_scope"),
+    [
+        ("079 123 45 67", "+41791234567"),
+        ("0041 79 123 45 67", "+41791234567"),
+        ("beamline-ops", "beamline-ops"),
+        (["079 123 45 67", "beamline-ops"], ["+41791234567", "beamline-ops"]),
+        ("+41791234567", "+41791234567"),
+    ],
+)
+def test_signal_message_service_normalizes_scope_inputs(
+    signal_service, connected_connector, scope, expected_scope
+):
+    """Test that Signal normalizes phone numbers while preserving named scopes."""
+    message = signal_service.new("Signal recipient test")
+
+    message.send(scope=scope)
+    out = connected_connector.xread(
+        MessageEndpoints.message_service_queue(), from_start=True, count=1
+    )
+    assert len(out) == 1
+    out = out[0]["data"]
+    assert out.scope == expected_scope
 
 
 def test_scilog_message_add_tags_with_default_tags(scilog_message, connected_connector):


### PR DESCRIPTION
## Description

This PR adds support for sending messages through the signal service merely by providing phone numbers, that is without setting up signal groups. This should allow us to receive updates during debugging sessions. 

## Type of Change

- Allow empty scopes for Signal
- Add phone number parsing to signal message objects

## How to test

- Run unit tests
- Connect to atlas dev and send messages to your phone number

## Definition of Done
- [ ] Documentation is up-to-date. <- I will add a new PR to bec_docs later

