### PR TITLE
Fix sub device config access raises proper error

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -54,10 +54,6 @@ persistent=yes
 # the version used to run pylint.
 py-version=3.11
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no

--- a/bec_lib/bec_lib/device.py
+++ b/bec_lib/bec_lib/device.py
@@ -79,13 +79,20 @@ class RPCError(AlarmBase):
 class NotImplementedOnSubdeviceError(AlarmBase):
     """Exception raised when a method is not implemented for a subdevice."""
 
-    def __init__(self, device: str, sub_device: str, method: str) -> None:
+    def __init__(
+        self, device: str, sub_device: str, method: str, additional_info: str | None = None
+    ) -> None:
+        compact_error_message = f"Method '{method}' is not implemented for subdevice '{sub_device}' of device '{device}'."
+        error_message = compact_error_message
+        if additional_info:
+            error_message += f" Additional info: {additional_info}"
+
         alarm = messages.AlarmMessage(
             severity=Alarms.MAJOR,
             info=messages.ErrorInfo(
                 exception_type="NotImplemented",
-                error_message=f"Method '{method}' is not implemented for subdevice '{sub_device}' of device '{device}'.",
-                compact_error_message=f"Method '{method}' is not implemented for subdevice '{sub_device}' of device '{device}'.",
+                error_message=error_message,
+                compact_error_message=compact_error_message,
             ),
         )
         super().__init__(alarm, Alarms.MAJOR, handled=False)
@@ -799,7 +806,10 @@ class DeviceBaseWithConfig(DeviceBase):
         """
         if self.name != self.root.name:
             raise NotImplementedOnSubdeviceError(
-                device=self.root.name, sub_device=self.dotted_name, method="_update_config"
+                device=self.root.name,
+                sub_device=self.dotted_name,
+                method="_update_config",
+                additional_info=f"Received update: {update}",
             )
         self.root.parent.config_helper.send_config_request(
             action="update", config={self.name: update}

--- a/bec_lib/bec_lib/device.py
+++ b/bec_lib/bec_lib/device.py
@@ -76,6 +76,21 @@ class RPCError(AlarmBase):
         super().__init__(alarm, Alarms.MAJOR, handled=False)
 
 
+class NotImplementedOnSubdeviceError(AlarmBase):
+    """Exception raised when a method is not implemented for a subdevice."""
+
+    def __init__(self, device: str, sub_device: str, method: str) -> None:
+        alarm = messages.AlarmMessage(
+            severity=Alarms.MAJOR,
+            info=messages.ErrorInfo(
+                exception_type="NotImplemented",
+                error_message=f"Method '{method}' is not implemented for subdevice '{sub_device}' of device '{device}'.",
+                compact_error_message=f"Method '{method}' is not implemented for subdevice '{sub_device}' of device '{device}'.",
+            ),
+        )
+        super().__init__(alarm, Alarms.MAJOR, handled=False)
+
+
 class ScanRequestError(Exception):
     """Exception raised when a scan request is rejected."""
 
@@ -767,6 +782,10 @@ class DeviceBaseWithConfig(DeviceBase):
     @enabled.setter
     def enabled(self, val):
         # pylint: disable=protected-access
+        if self.name != self.root.name:
+            raise NotImplementedOnSubdeviceError(
+                device=self.root.name, sub_device=self.dotted_name, method="enabled"
+            )
         self._update_config({"enabled": val})
         self.root._config["enabled"] = val
 
@@ -778,6 +797,10 @@ class DeviceBaseWithConfig(DeviceBase):
             update (dict): The update dictionary.
 
         """
+        if self.name != self.root.name:
+            raise NotImplementedOnSubdeviceError(
+                device=self.root.name, sub_device=self.dotted_name, method="_update_config"
+            )
         self.root.parent.config_helper.send_config_request(
             action="update", config={self.name: update}
         )
@@ -791,6 +814,10 @@ class DeviceBaseWithConfig(DeviceBase):
     def set_device_tags(self, val: Iterable):
         """set the device tags for this device - any duplicates will be discarded"""
         # pylint: disable=protected-access
+        if self.name != self.root.name:
+            raise NotImplementedOnSubdeviceError(
+                device=self.root.name, sub_device=self.dotted_name, method="set_device_tags"
+            )
         self.root._config["deviceTags"] = set(val)
         return self.root.parent.config_helper.send_config_request(
             action="update", config={self.name: {"deviceTags": self.root._config["deviceTags"]}}
@@ -800,6 +827,10 @@ class DeviceBaseWithConfig(DeviceBase):
     def add_device_tag(self, val: str):
         """add a device tag for this device"""
         # pylint: disable=protected-access
+        if self.name != self.root.name:
+            raise NotImplementedOnSubdeviceError(
+                device=self.root.name, sub_device=self.dotted_name, method="add_device_tag"
+            )
         self.root._config["deviceTags"].add(val)
         return self.root.parent.config_helper.send_config_request(
             action="update", config={self.name: {"deviceTags": self.root._config["deviceTags"]}}
@@ -808,6 +839,10 @@ class DeviceBaseWithConfig(DeviceBase):
     def remove_device_tag(self, val: str):
         """remove a device tag for this device"""
         # pylint: disable=protected-access
+        if self.name != self.root.name:
+            raise NotImplementedOnSubdeviceError(
+                device=self.root.name, sub_device=self.dotted_name, method="remove_device_tag"
+            )
         self.root._config["deviceTags"].remove(val)
         return self.root.parent.config_helper.send_config_request(
             action="update", config={self.name: {"deviceTags": self.root._config["deviceTags"]}}
@@ -816,6 +851,10 @@ class DeviceBaseWithConfig(DeviceBase):
     @property
     def wm(self) -> None:
         """get the current position of a device"""
+        if self.name != self.root.name:
+            raise NotImplementedOnSubdeviceError(
+                device=self.root.name, sub_device=self.dotted_name, method="wm"
+            )
         self.parent.devices.wm(self.name)
 
     @property
@@ -829,6 +868,10 @@ class DeviceBaseWithConfig(DeviceBase):
         """set the readout priority for this device"""
         if not isinstance(val, ReadoutPriority):
             val = ReadoutPriority(val)
+        if self.name != self.root.name:
+            raise NotImplementedOnSubdeviceError(
+                device=self.root.name, sub_device=self.dotted_name, method="readout_priority"
+            )
         # pylint: disable=protected-access
         self.root._config["readoutPriority"] = val
         return self.root.parent.config_helper.send_config_request(
@@ -846,6 +889,10 @@ class DeviceBaseWithConfig(DeviceBase):
         """set the failure behaviour for this device"""
         if not isinstance(val, OnFailure):
             val = OnFailure(val)
+        if self.name != self.root.name:
+            raise NotImplementedOnSubdeviceError(
+                device=self.root.name, sub_device=self.dotted_name, method="on_failure"
+            )
         # pylint: disable=protected-access
         self.root._config["onFailure"] = val
         return self.root.parent.config_helper.send_config_request(
@@ -862,6 +909,10 @@ class DeviceBaseWithConfig(DeviceBase):
     def read_only(self, value: bool):
         """Whether or not the device is read only"""
         # pylint: disable=protected-access
+        if self.name != self.root.name:
+            raise NotImplementedOnSubdeviceError(
+                device=self.root.name, sub_device=self.dotted_name, method="read_only"
+            )
         self.root.parent.config_helper.send_config_request(
             action="update", config={self.name: {"readOnly": value}}
         )
@@ -877,6 +928,10 @@ class DeviceBaseWithConfig(DeviceBase):
     def software_trigger(self, value: bool):
         """Whether or not the device can be software triggered"""
         # pylint: disable=protected-access
+        if self.name != self.root.name:
+            raise NotImplementedOnSubdeviceError(
+                device=self.root.name, sub_device=self.dotted_name, method="software_trigger"
+            )
         self.root.parent.config_helper.send_config_request(
             action="update", config={self.name: {"softwareTrigger": value}}
         )
@@ -891,6 +946,10 @@ class DeviceBaseWithConfig(DeviceBase):
     @typechecked
     def set_user_parameter(self, val: dict):
         """set the user parameter for this device"""
+        if self.name != self.root.name:
+            raise NotImplementedOnSubdeviceError(
+                device=self.root.name, sub_device=self.dotted_name, method="set_user_parameter"
+            )
         self.root.parent.config_helper.send_config_request(
             action="update", config={self.name: {"userParameter": val}}
         )
@@ -1176,6 +1235,10 @@ class AdjustableMixin:
 
     @limits.setter
     def limits(self, val: list):
+        if self.name != self.root.name:
+            raise NotImplementedOnSubdeviceError(
+                device=self.root.name, sub_device=self.dotted_name, method="limits"
+            )
         self._update_config({"deviceConfig": {"limits": val}})
 
     @property
@@ -1187,6 +1250,10 @@ class AdjustableMixin:
 
     @low_limit.setter
     def low_limit(self, val: float):
+        if self.name != self.root.name:
+            raise NotImplementedOnSubdeviceError(
+                device=self.root.name, sub_device=self.dotted_name, method="low_limit"
+            )
         limits = [val, self.high_limit]
         self._update_config({"deviceConfig": {"limits": limits}})
 
@@ -1199,6 +1266,10 @@ class AdjustableMixin:
 
     @high_limit.setter
     def high_limit(self, val: float):
+        if self.name != self.root.name:
+            raise NotImplementedOnSubdeviceError(
+                device=self.root.name, sub_device=self.dotted_name, method="high_limit"
+            )
         limits = [self.low_limit, val]
         self._update_config({"deviceConfig": {"limits": limits}})
 

--- a/bec_lib/bec_lib/device.py
+++ b/bec_lib/bec_lib/device.py
@@ -805,10 +805,10 @@ class DeviceBaseWithConfig(DeviceBase):
             action="update", config={self.name: update}
         )
 
-    def get_device_tags(self) -> list:
+    def get_device_tags(self) -> set:
         """get the device tags for this device"""
         # pylint: disable=protected-access
-        return self.root._config.get("deviceTags", [])
+        return self.root._config.get("deviceTags", set())
 
     @typechecked
     def set_device_tags(self, val: Iterable):

--- a/bec_lib/bec_lib/device.py
+++ b/bec_lib/bec_lib/device.py
@@ -82,7 +82,7 @@ class NotImplementedOnSubdeviceError(AlarmBase):
     def __init__(
         self, device: str, sub_device: str, method: str, additional_info: str | None = None
     ) -> None:
-        compact_error_message = f"Method '{method}' is not implemented for subdevice '{sub_device}' of device '{device}'."
+        compact_error_message = f"Method '{method}' is not implemented for subdevice '{sub_device}' of device '{device}'. Try to access the root device '{device}' instead."
         error_message = compact_error_message
         if additional_info:
             error_message += f" Additional info: {additional_info}"
@@ -789,7 +789,7 @@ class DeviceBaseWithConfig(DeviceBase):
     @enabled.setter
     def enabled(self, val):
         # pylint: disable=protected-access
-        if self.name != self.root.name:
+        if self.root != self:
             raise NotImplementedOnSubdeviceError(
                 device=self.root.name, sub_device=self.dotted_name, method="enabled"
             )
@@ -804,7 +804,7 @@ class DeviceBaseWithConfig(DeviceBase):
             update (dict): The update dictionary.
 
         """
-        if self.name != self.root.name:
+        if self.root != self:
             raise NotImplementedOnSubdeviceError(
                 device=self.root.name,
                 sub_device=self.dotted_name,
@@ -824,7 +824,7 @@ class DeviceBaseWithConfig(DeviceBase):
     def set_device_tags(self, val: Iterable):
         """set the device tags for this device - any duplicates will be discarded"""
         # pylint: disable=protected-access
-        if self.name != self.root.name:
+        if self.root != self:
             raise NotImplementedOnSubdeviceError(
                 device=self.root.name, sub_device=self.dotted_name, method="set_device_tags"
             )
@@ -837,7 +837,7 @@ class DeviceBaseWithConfig(DeviceBase):
     def add_device_tag(self, val: str):
         """add a device tag for this device"""
         # pylint: disable=protected-access
-        if self.name != self.root.name:
+        if self.root != self:
             raise NotImplementedOnSubdeviceError(
                 device=self.root.name, sub_device=self.dotted_name, method="add_device_tag"
             )
@@ -849,7 +849,7 @@ class DeviceBaseWithConfig(DeviceBase):
     def remove_device_tag(self, val: str):
         """remove a device tag for this device"""
         # pylint: disable=protected-access
-        if self.name != self.root.name:
+        if self.root != self:
             raise NotImplementedOnSubdeviceError(
                 device=self.root.name, sub_device=self.dotted_name, method="remove_device_tag"
             )
@@ -861,7 +861,7 @@ class DeviceBaseWithConfig(DeviceBase):
     @property
     def wm(self) -> None:
         """get the current position of a device"""
-        if self.name != self.root.name:
+        if self.root != self:
             raise NotImplementedOnSubdeviceError(
                 device=self.root.name, sub_device=self.dotted_name, method="wm"
             )
@@ -878,7 +878,7 @@ class DeviceBaseWithConfig(DeviceBase):
         """set the readout priority for this device"""
         if not isinstance(val, ReadoutPriority):
             val = ReadoutPriority(val)
-        if self.name != self.root.name:
+        if self.root != self:
             raise NotImplementedOnSubdeviceError(
                 device=self.root.name, sub_device=self.dotted_name, method="readout_priority"
             )
@@ -899,7 +899,7 @@ class DeviceBaseWithConfig(DeviceBase):
         """set the failure behaviour for this device"""
         if not isinstance(val, OnFailure):
             val = OnFailure(val)
-        if self.name != self.root.name:
+        if self.root != self:
             raise NotImplementedOnSubdeviceError(
                 device=self.root.name, sub_device=self.dotted_name, method="on_failure"
             )
@@ -919,7 +919,7 @@ class DeviceBaseWithConfig(DeviceBase):
     def read_only(self, value: bool):
         """Whether or not the device is read only"""
         # pylint: disable=protected-access
-        if self.name != self.root.name:
+        if self.root != self:
             raise NotImplementedOnSubdeviceError(
                 device=self.root.name, sub_device=self.dotted_name, method="read_only"
             )
@@ -938,7 +938,7 @@ class DeviceBaseWithConfig(DeviceBase):
     def software_trigger(self, value: bool):
         """Whether or not the device can be software triggered"""
         # pylint: disable=protected-access
-        if self.name != self.root.name:
+        if self.root != self:
             raise NotImplementedOnSubdeviceError(
                 device=self.root.name, sub_device=self.dotted_name, method="software_trigger"
             )
@@ -956,7 +956,7 @@ class DeviceBaseWithConfig(DeviceBase):
     @typechecked
     def set_user_parameter(self, val: dict):
         """set the user parameter for this device"""
-        if self.name != self.root.name:
+        if self.root != self:
             raise NotImplementedOnSubdeviceError(
                 device=self.root.name, sub_device=self.dotted_name, method="set_user_parameter"
             )
@@ -1245,7 +1245,7 @@ class AdjustableMixin:
 
     @limits.setter
     def limits(self, val: list):
-        if self.name != self.root.name:
+        if self.root != self:
             raise NotImplementedOnSubdeviceError(
                 device=self.root.name, sub_device=self.dotted_name, method="limits"
             )
@@ -1260,7 +1260,7 @@ class AdjustableMixin:
 
     @low_limit.setter
     def low_limit(self, val: float):
-        if self.name != self.root.name:
+        if self.root != self:
             raise NotImplementedOnSubdeviceError(
                 device=self.root.name, sub_device=self.dotted_name, method="low_limit"
             )
@@ -1276,7 +1276,7 @@ class AdjustableMixin:
 
     @high_limit.setter
     def high_limit(self, val: float):
-        if self.name != self.root.name:
+        if self.root != self:
             raise NotImplementedOnSubdeviceError(
                 device=self.root.name, sub_device=self.dotted_name, method="high_limit"
             )

--- a/bec_lib/tests/test_devices.py
+++ b/bec_lib/tests/test_devices.py
@@ -762,11 +762,11 @@ def test_attribute_access_on_sub_device(positioner_as_subdevice):
 
 @pytest.fixture()
 def adj():
-    (adj := AdjustableMixin()).root = mock.MagicMock()
+    adj = AdjustableMixin()
+    adj.root = adj
+    adj.parent = mock.MagicMock()
     adj._update_config = mock.MagicMock()
-    # attributes that exist on the DeviceBase
     adj.name = "test_mixin"
-    adj.root.name = "test_mixin"
     return adj
 
 

--- a/bec_lib/tests/test_devices.py
+++ b/bec_lib/tests/test_devices.py
@@ -739,9 +739,9 @@ def test_attribute_access_on_sub_device(positioner_as_subdevice):
         dev.enabled = False
 
     # Readout priority
-    assert dev.readout_priority == ReadoutPriority.MONITORED.value
+    assert dev.readout_priority == ReadoutPriority.MONITORED
     with pytest.raises(NotImplementedOnSubdeviceError):
-        dev.readout_priority = ReadoutPriority.BASELINE.value
+        dev.readout_priority = ReadoutPriority.BASELINE
 
     # Device tags
     assert dev.get_device_tags() == set()

--- a/bec_lib/tests/test_devices.py
+++ b/bec_lib/tests/test_devices.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from typing import Any, Callable, Literal
 from unittest import mock
 
@@ -12,6 +13,7 @@ from bec_lib.device import (
     ComputedSignal,
     Device,
     DeviceBaseWithConfig,
+    NotImplementedOnSubdeviceError,
     Positioner,
     ReadoutPriority,
     RPCError,
@@ -702,9 +704,69 @@ def test_show_all(dm_with_override):
 
 
 @pytest.fixture()
+def positioner_as_subdevice(dm_with_override):
+    dm_with_override.connector = ConnectorMock("")
+    dev = Device(name="test_device", config=BASIC_CONFIG, parent=dm_with_override)
+    positioner = Positioner(name="positioner1", config=BASIC_CONFIG, parent=dev)
+    return positioner
+
+
+def test_limits_on_sub_device(positioner_as_subdevice):
+    with mock.patch.object(positioner_as_subdevice.root.parent.connector, "get") as mock_get:
+        mock_get.return_value = None
+        assert positioner_as_subdevice.limits == [0, 0]
+    with pytest.raises(NotImplementedOnSubdeviceError):
+        positioner_as_subdevice.limits = [-10, 10]
+
+    with pytest.raises(NotImplementedOnSubdeviceError):
+        positioner_as_subdevice.low_limit = -10
+
+    with pytest.raises(NotImplementedOnSubdeviceError):
+        positioner_as_subdevice.high_limit = 10
+
+
+def test_attribute_access_on_sub_device(positioner_as_subdevice):
+    dev = positioner_as_subdevice
+
+    # Read-only
+    assert dev.read_only == False
+    with pytest.raises(NotImplementedOnSubdeviceError):
+        dev.read_only = True
+
+    # Enabled
+    assert dev.enabled == True
+    with pytest.raises(NotImplementedOnSubdeviceError):
+        dev.enabled = False
+
+    # Readout priority
+    assert dev.readout_priority == ReadoutPriority.MONITORED.value
+    with pytest.raises(NotImplementedOnSubdeviceError):
+        dev.readout_priority = ReadoutPriority.BASELINE.value
+
+    # Device tags
+    assert dev.get_device_tags() == set()
+    with pytest.raises(NotImplementedOnSubdeviceError):
+        dev.set_device_tags({"tag1", "tag2"})
+    with pytest.raises(NotImplementedOnSubdeviceError):
+        dev.add_device_tag("tag1")
+    with pytest.raises(NotImplementedOnSubdeviceError):
+        dev.remove_device_tag("tag1")
+
+    # User parameter
+    assert dev.user_parameter == {}
+    with pytest.raises(NotImplementedOnSubdeviceError):
+        dev.set_user_parameter({"param1": 1})
+    with pytest.raises(NotImplementedOnSubdeviceError):
+        dev.update_user_parameter({"param1": 1})
+
+
+@pytest.fixture()
 def adj():
     (adj := AdjustableMixin()).root = mock.MagicMock()
     adj._update_config = mock.MagicMock()
+    # attributes that exist on the DeviceBase
+    adj.name = "test_mixin"
+    adj.root.name = "test_mixin"
     return adj
 
 


### PR DESCRIPTION
Changing config attributes of sub-devices is not supported for RPC devices, i.e. read_only, readoutPriority, limits etc. Previously, the error message for this was rather obscure:

<img width="1193" height="159" alt="image" src="https://github.com/user-attachments/assets/cc30f809-7401-491f-8e74-197920d149e7" />

This PR fixes this. Error messages for access of relevant attributes of sub-devices has been improved.

<img width="1084" height="327" alt="image" src="https://github.com/user-attachments/assets/8d9fde68-8110-453c-9fd0-c5c4008efdfd" />
