### PR TITLE
fix(scilog): use marker instead of pen

### DIFF
--- a/bec_lib/bec_lib/messaging_services.py
+++ b/bec_lib/bec_lib/messaging_services.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import mimetypes
 import os
 from abc import ABC
-from typing import TYPE_CHECKING, Generic, Self, TypeVar
+from typing import TYPE_CHECKING, Generic, Literal, Self, TypeVar
 
 from bec_lib import messages
 from bec_lib.endpoints import MessageEndpoints
@@ -277,7 +277,7 @@ class SciLogMessageServiceObject(MessageServiceObject):
         text: str,
         bold: bool = False,
         italic: bool = False,
-        color: str | None = None,
+        color: Literal["red", "green", "black", "yellow", "pink", "blue"] | None = None,
         **kwargs,
     ) -> Self:
         """
@@ -290,8 +290,9 @@ class SciLogMessageServiceObject(MessageServiceObject):
             text: The text content.
             bold: Wrap the text in ``<strong>``.
             italic: Wrap the text in ``<em>``.
-            color: Highlight colour using SciLog's pen marks (e.g. ``"red"``,
-                ``"yellow"``, ``"green"``, ``"blue"``, ``"pink"``).
+            color: Highlight colour using SciLog's pens or markers.
+                Supported values for pens are: "red", "green" and "black".
+                Supported values for markers are: "yellow", "pink", "blue".
 
         Returns:
             SciLogMessageServiceObject: The updated message object.
@@ -305,7 +306,12 @@ class SciLogMessageServiceObject(MessageServiceObject):
             if italic:
                 text = f"<em>{text}</em>"
             if color:
-                text = f'<mark class="pen-{color}">{text}</mark>'
+                if color == "black":
+                    pass  # black is the default
+                elif color in ["red", "green"]:
+                    text = f'<mark class="pen-{color}">{text}</mark>'
+                elif color in ["yellow", "pink", "blue"]:
+                    text = f'<mark class="marker-{color}">{text}</mark>'
             text = f"<p>{text}</p>"
         return super().add_text(text)
 

--- a/bec_lib/tests/test_messaging_service.py
+++ b/bec_lib/tests/test_messaging_service.py
@@ -524,9 +524,20 @@ def test_scilog_add_text_italic(scilog_message):
     assert scilog_message._content[0].content == "<p><em>hello</em></p>"
 
 
-def test_scilog_add_text_color(scilog_message):
-    scilog_message.add_text("warn", color="yellow")
-    assert scilog_message._content[0].content == '<p><mark class="pen-yellow">warn</mark></p>'
+@pytest.mark.parametrize(
+    ("color", "expected_content"),
+    [
+        ("red", '<p><mark class="pen-red">warn</mark></p>'),
+        ("green", '<p><mark class="pen-green">warn</mark></p>'),
+        ("yellow", '<p><mark class="marker-yellow">warn</mark></p>'),
+        ("pink", '<p><mark class="marker-pink">warn</mark></p>'),
+        ("blue", '<p><mark class="marker-blue">warn</mark></p>'),
+        ("black", "<p>warn</p>"),
+    ],
+)
+def test_scilog_add_text_color(scilog_message, color, expected_content):
+    scilog_message.add_text("warn", color=color)
+    assert scilog_message._content[0].content == expected_content
 
 
 def test_scilog_add_text_bold_and_color(scilog_message, connected_connector):


### PR DESCRIPTION
## Description

There are only two pen colos in SciLog: red and green. Everything else has to be a marker. This PR fixes the html content accordingly. 

## Type of Change

- Use the pen class only for actual pens
- Extended the tests

## How to test

- Run unit tests
- Maybe connect to a logbook and try it yourself.

## Definition of Done
- [ ] Documentation is up-to-date. <- coming soon

