### PR TITLE
Add Error handling for data of invalid array shape for add_slice in Async filewriter 

### DIFF
--- a/bec_server/bec_server/file_writer/async_writer.py
+++ b/bec_server/bec_server/file_writer/async_writer.py
@@ -432,7 +432,21 @@ class AsyncWriter(threading.Thread):
 
         if len(max_shape) != 2:
             # We currently only support 2D datasets for the 'add_slice' async update type
-            msg = f"Invalid max_shape for async update type 'add_slice': {max_shape}. max_shape cannot exceed two dimensions. Data will not be written."
+            msg = f"Invalid max_shape for signal group {signal_group.name} async update type 'add_slice': {max_shape}. max_shape cannot exceed two dimensions. Data will not be written."
+            self.connector.raise_alarm(
+                severity=Alarms.WARNING,
+                info=messages.ErrorInfo(
+                    error_message=msg,
+                    compact_error_message=msg,
+                    exception_type="ValueError",
+                    device=signal_group.name,
+                ),
+                metadata={"scan_id": self.scan_id, "scan_number": self.scan_number},
+            )
+            return
+
+        if value.ndim != 1:
+            msg = f"Invalid data shape for signal group {signal_group.name} async update type 'add_slice': {value.shape}. Data must be 1D. Data will not be written."
             self.connector.raise_alarm(
                 severity=Alarms.WARNING,
                 info=messages.ErrorInfo(

--- a/bec_server/tests/tests_file_writer/test_async_file_writer.py
+++ b/bec_server/tests/tests_file_writer/test_async_file_writer.py
@@ -1,8 +1,11 @@
+from unittest import mock
+
 import h5py
 import numpy as np
 import pytest
 
 from bec_lib import messages
+from bec_lib.alarm_handler import Alarms
 from bec_lib.endpoints import MessageEndpoints
 from bec_server.file_writer.async_writer import AsyncWriter
 
@@ -205,6 +208,29 @@ def test_async_writer_add_slice_var_size(async_writer, data):
     assert out.shape == (2,)
     assert out[0].shape == (20,)
     assert out[1].shape == (10,)
+
+
+def test_async_writer_add_slice_var_size_2D_data_warns(async_writer):
+    """
+    Test that adding a slice with 2D data when max_shape is [None, None] raises a warning and skips writing the data.
+    """
+    endpoint = MessageEndpoints.device_async_readback("scan_id", "monitor_async")
+    data = [
+        messages.DeviceMessage(
+            signals={"monitor_async": {"value": np.random.rand(10, 10), "timestamp": 1}},
+            metadata={"async_update": {"type": "add_slice", "index": 0, "max_shape": [None, None]}},
+        )
+    ]
+    for entry in data:
+        async_writer.connector.xadd(endpoint, msg_dict={"data": entry})
+        with mock.patch.object(async_writer.connector, "raise_alarm") as mock_raise_alarm:
+            async_writer.poll_and_write_data()
+            mock_raise_alarm.assert_called_once()
+            args, kwargs = mock_raise_alarm.call_args
+            assert kwargs["severity"] == Alarms.WARNING
+            assert any(
+                signal_name in kwargs["info"].error_message for signal_name in entry.signals.keys()
+            )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
There was a bug in the NIDAQ backend code from the beamline that showed that we should check the dimensions of the data that we receive, and properly lock the error message in case of data coming with an invalid shape. This PR adds this capabilities.