### PR TITLE
fix: add checks for scan item start and end time 

### DIFF
--- a/bec_ipython_client/bec_ipython_client/callbacks/live_table.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/live_table.py
@@ -363,6 +363,10 @@ class LiveUpdatesTable(LiveUpdatesBase):
         """close the table and print the footer"""
         if not self.table:
             return
+        if not self.scan_item:
+            return
+        if not self.scan_item.start_time or not self.scan_item.end_time:
+            return
         elapsed_time = self.scan_item.end_time - self.scan_item.start_time
         print(
             self.table.get_footer(


### PR DESCRIPTION
## Description

Minor changes to not print the elapsed time when the scan was aborted from another client.

