### PR TITLE
Fix/rpc exception expire

### DIFF
--- a/bec_lib/bec_lib/bec_service.py
+++ b/bec_lib/bec_lib/bec_service.py
@@ -341,7 +341,9 @@ class BECService:
             )
             msg = messages.ServiceMetricMessage(name=self._service_name, metrics=data)
             try:
-                self.connector.set_and_publish(MessageEndpoints.metrics(self._service_name), msg)
+                self.connector.set_and_publish(
+                    MessageEndpoints.metrics(self._service_name), msg, expire=30
+                )
             # pylint: disable=broad-except
             except Exception:
                 # exception is not explicitly specified,

--- a/bec_server/bec_server/device_server/bec_message_handler.py
+++ b/bec_server/bec_server/device_server/bec_message_handler.py
@@ -71,9 +71,14 @@ class BECMessageHandler:
             return
 
         pipe = self.connector.pipeline()
-        self.connector.set_and_publish(MessageEndpoints.file_event(device_name), message, pipe=pipe)
         self.connector.set_and_publish(
-            MessageEndpoints.public_file(scan_id=scan_id, name=device_name), message, pipe=pipe
+            MessageEndpoints.file_event(device_name), message, pipe=pipe, expire=3600
+        )
+        self.connector.set_and_publish(
+            MessageEndpoints.public_file(scan_id=scan_id, name=device_name),
+            message,
+            pipe=pipe,
+            expire=3600,
         )
         pipe.execute()
 
@@ -94,7 +99,9 @@ class BECMessageHandler:
         message.metadata.update(
             {"scan_id": scan_status_msg.scan_id, "status": scan_status_msg.status}
         )
-        self.connector.set_and_publish(MessageEndpoints.device_progress(device_name), message)
+        self.connector.set_and_publish(
+            MessageEndpoints.device_progress(device_name), message, expire=3600
+        )
 
     def _handle_preview_signal(self, obj: bms.PreviewSignal, message: messages.BECMessage):
         if not isinstance(message, messages.DevicePreviewMessage):

--- a/bec_server/bec_server/device_server/devices/devicemanager.py
+++ b/bec_server/bec_server/device_server/devices/devicemanager.py
@@ -81,7 +81,7 @@ class DeviceProgress:
             success=success,
         )
         self.connector.set_and_publish(
-            MessageEndpoints.device_initialization_progress(), progress_msg
+            MessageEndpoints.device_initialization_progress(), progress_msg, expire=3600
         )
 
 
@@ -931,7 +931,9 @@ class DeviceManagerDS(DeviceManagerBase):
         msg = messages.ProgressMessage(
             value=value, max_value=max_value, done=done, metadata=metadata
         )
-        self.connector.set_and_publish(MessageEndpoints.device_progress(obj.root.name), msg)
+        self.connector.set_and_publish(
+            MessageEndpoints.device_progress(obj.root.name), msg, expire=3600
+        )
 
     def _obj_callback_file_event(
         self,
@@ -975,9 +977,14 @@ class DeviceManagerDS(DeviceManagerBase):
             metadata=metadata,
         )
         pipe = self.connector.pipeline()
-        self.connector.set_and_publish(MessageEndpoints.file_event(device_name), msg, pipe=pipe)
         self.connector.set_and_publish(
-            MessageEndpoints.public_file(scan_id=scan_id, name=device_name), msg, pipe=pipe
+            MessageEndpoints.file_event(device_name), msg, pipe=pipe, expire=3600
+        )
+        self.connector.set_and_publish(
+            MessageEndpoints.public_file(scan_id=scan_id, name=device_name),
+            msg,
+            pipe=pipe,
+            expire=3600,
         )
         pipe.execute()
 

--- a/bec_server/bec_server/device_server/rpc_handler.py
+++ b/bec_server/bec_server/device_server/rpc_handler.py
@@ -139,6 +139,7 @@ class RPCHandler:
             messages.DeviceRPCMessage(
                 device=instr.content["device"], return_val=None, out=error_info, success=False
             ),
+            expire=1800,
         )
         diid = instr.metadata.get("device_instr_id", "")
         request = self.requests_handler.get_request(diid)

--- a/bec_server/bec_server/file_writer/async_writer.py
+++ b/bec_server/bec_server/file_writer/async_writer.py
@@ -235,6 +235,7 @@ class AsyncWriter(threading.Thread):
                 },
                 metadata={},
             ),
+            expire=3600,
         )
 
     def stop(self) -> None:

--- a/bec_server/bec_server/file_writer/file_writer.py
+++ b/bec_server/bec_server/file_writer/file_writer.py
@@ -315,7 +315,9 @@ class HDF5FileWriter:
             file_data[key] = val if not isinstance(val, list) else merge_dicts(val)
         msg_data = {"file_path": file_path, "data": file_data, "scan_info": info_storage}
         msg = messages.FileContentMessage(**msg_data)
-        self.file_writer_manager.connector.set_and_publish(MessageEndpoints.file_content(), msg)
+        self.file_writer_manager.connector.set_and_publish(
+            MessageEndpoints.file_content(), msg, expire=3600
+        )
 
         # Write to temporary file first
         tmp_file_path = file_path.replace(".h5", ".tmp")

--- a/bec_server/tests/tests_device_server/test_device_manager_ds.py
+++ b/bec_server/tests/tests_device_server/test_device_manager_ds.py
@@ -175,6 +175,7 @@ def test_obj_callback_progress(dm_with_devices):
             messages.ProgressMessage(
                 value=1, max_value=2, done=False, metadata={"scan_id": "12345"}
             ),
+            expire=3600,
         )
 
 

--- a/bec_server/tests/tests_device_server/test_rpc_handler.py
+++ b/bec_server/tests/tests_device_server/test_rpc_handler.py
@@ -162,6 +162,7 @@ def test_send_rpc_exception(rpc_cls: RPCHandler, instr: messages.DeviceInstructi
             ),
             success=False,
         ),
+        expire=1800,
     )
 
 


### PR DESCRIPTION
## Description

Unique endpoints must expire to avoid piling up stale endpoints. 



