### PR TITLE
fix(alarms): mark raised alarms as handled

### DIFF
--- a/bec_lib/bec_lib/alarm_handler.py
+++ b/bec_lib/bec_lib/alarm_handler.py
@@ -154,6 +154,7 @@ class AlarmHandler:
         for alarm in alarms:
             yield alarm
 
+    @threadlocked
     def raise_alarms(self, severity=Alarms.MAJOR):
         """Raise unhandled alarms with specified severity.
 

--- a/bec_lib/bec_lib/alarm_handler.py
+++ b/bec_lib/bec_lib/alarm_handler.py
@@ -166,6 +166,7 @@ class AlarmHandler:
         alarms = self.get_unhandled_alarms(severity=severity)
         if len(alarms) > 0:
             alarm = alarms.pop(0)
+            alarm.handled = True
             self._raised_alarms.append(alarm)
             raise alarm
 

--- a/bec_lib/tests/test_alarm_handler.py
+++ b/bec_lib/tests/test_alarm_handler.py
@@ -1,7 +1,7 @@
 import pytest
 
 from bec_lib import messages
-from bec_lib.alarm_handler import AlarmBase, Alarms
+from bec_lib.alarm_handler import AlarmBase, AlarmHandler, Alarms
 
 
 @pytest.mark.parametrize(
@@ -48,3 +48,21 @@ def test_alarm_base_printing(msg):
 
     # Test pretty_print method (just ensure it runs without error)
     alarm_msg.pretty_print()
+
+
+def test_raise_alarms_marks_alarm_handled():
+    error_info = messages.ErrorInfo(
+        error_message="This is a test alarm message for testing purposes.",
+        compact_error_message="Compact alarm content",
+        exception_type="TestAlarmType",
+        device="TestDevice",
+    )
+    alarm_msg = messages.AlarmMessage(severity=Alarms.MAJOR, info=error_info)
+    handler = AlarmHandler(connector=None)
+    handler.add_alarm(alarm_msg)
+
+    with pytest.raises(AlarmBase) as exc_info:
+        handler.raise_alarms()
+
+    assert exc_info.value.handled is True
+    assert handler.get_unhandled_alarms() == []


### PR DESCRIPTION
## Description

 - Raised alarms should be marked as handled to avoid race conditions.
 - Use a threadlock to avoid race conditions on raising



