### PR TITLE
fix: add logging option for directory creation in get_full_path

### DIFF
--- a/bec_lib/bec_lib/file_utils.py
+++ b/bec_lib/bec_lib/file_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import time
 import warnings
 from typing import TYPE_CHECKING
 
@@ -202,6 +203,27 @@ def get_full_path(
             logger.warning(f"Directory {os.path.dirname(full_path)} does not exist. Creating it.")
         os.makedirs(os.path.dirname(full_path), exist_ok=True)
     return full_path
+
+
+def wait_for_directory(path: str, timeout: float = 10.0, interval: float = 0.1) -> None:
+    """
+    Wait for a directory to be created.
+
+    Args:
+        path (str): Path to the directory to wait for.
+        timeout (float, optional): Maximum time to wait in seconds. Defaults to 10.
+        interval (float, optional): Time to wait between checks in seconds. Defaults to 0.1.
+
+    Raises:
+        FileWriterError: If the timeout is reached before the directory is created.
+
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if os.path.isdir(path):
+            return
+        time.sleep(interval)
+    raise FileWriterError(f"Timeout reached while waiting for directory {path} to be created.")
 
 
 class FileWriter:

--- a/bec_lib/bec_lib/file_utils.py
+++ b/bec_lib/bec_lib/file_utils.py
@@ -163,13 +163,19 @@ def compile_file_components(
     return (file_path_component, file_extension)
 
 
-def get_full_path(scan_status_msg: ScanStatusMessage, name: str, create_dir: bool = True) -> str:
+def get_full_path(
+    scan_status_msg: ScanStatusMessage,
+    name: str,
+    create_dir: bool = True,
+    log_if_dir_does_not_exist: bool = True,
+) -> str:
     """Get the full file path for a given scan status message and additional name.
 
     Args:
         scan_status_msg (ScanStatusMessage): Scan status message
         name (str): Additional name (i.e. device name) to add to the file path
         create_dir (bool, optional): Create the directory if it does not exist. Defaults to True.
+        log_if_dir_does_not_exist (bool, optional): Log a warning if the directory does not exist. Defaults to True.
     """
 
     if name == "":
@@ -192,6 +198,8 @@ def get_full_path(scan_status_msg: ScanStatusMessage, name: str, create_dir: boo
     # Compile full file path
     full_path = f"{file_base_path}_{name}.{file_extension}"
     if create_dir:
+        if log_if_dir_does_not_exist and not os.path.exists(os.path.dirname(full_path)):
+            logger.warning(f"Directory {os.path.dirname(full_path)} does not exist. Creating it.")
         os.makedirs(os.path.dirname(full_path), exist_ok=True)
     return full_path
 

--- a/bec_lib/tests/test_file_utils.py
+++ b/bec_lib/tests/test_file_utils.py
@@ -2,6 +2,8 @@
 
 # pylint: skip-file
 import os
+import threading
+import time
 from unittest import mock
 
 import pytest
@@ -15,6 +17,7 @@ from bec_lib.file_utils import (
     LogWriter,
     compile_file_components,
     get_full_path,
+    wait_for_directory,
 )
 from bec_lib.messages import ScanStatusMessage
 from bec_lib.tests.utils import ConnectorMock
@@ -257,6 +260,30 @@ def test_compile_file_components_valid_paths(kwargs, expected_path, description)
     file_path, extension = compile_file_components(base_path="/tmp", scan_nr=10, **kwargs)
     assert extension == "h5", description
     assert file_path == expected_path, description
+
+
+def test_wait_for_directory_returns_when_directory_appears(tmpdir):
+    """wait_for_directory should stop polling once the directory exists."""
+    dir_path = tmpdir.join("created-later")
+
+    def _create_directory():
+        time.sleep(0.02)
+        dir_path.mkdir()
+
+    creator = threading.Thread(target=_create_directory)
+    creator.start()
+    try:
+        wait_for_directory(str(dir_path), timeout=1.0, interval=0.01)
+    finally:
+        creator.join()
+
+
+def test_wait_for_directory_raises_on_timeout(tmpdir):
+    """wait_for_directory should raise when the directory never appears."""
+    dir_path = tmpdir.join("never-created")
+
+    with pytest.raises(FileWriterError, match="Timeout reached while waiting for directory"):
+        wait_for_directory(str(dir_path), timeout=0.05, interval=0.01)
 
 
 @pytest.mark.parametrize(

--- a/bec_lib/tests/test_file_utils.py
+++ b/bec_lib/tests/test_file_utils.py
@@ -324,3 +324,47 @@ def test_get_full_path(scan_info, name, expect_error):
             full_path = f"{file_components[0]}_{name}_{suffix}.{file_components[1]}"
         ret = get_full_path(scan_info, name, create_dir=False)
         assert ret == full_path
+
+
+def test_get_full_path_creates_directory_and_logs_when_missing(tmpdir):
+    base_dir = tmpdir.join("S00000-00999").join("S00005")
+    scan_msg = ScanStatusMessage(
+        scan_id="1111",
+        scan_parameters={"system_config": {"file_directory": None, "file_suffix": None}},
+        info={"scan_number": 5, "file_components": (str(base_dir.join("S00005")), "h5")},
+        status="closed",
+    )
+
+    with mock.patch("bec_lib.file_utils.logger.warning") as mock_warning:
+        ret = get_full_path(scan_msg, "detector", create_dir=True)
+
+    assert ret == str(base_dir.join("S00005_detector.h5"))
+    assert os.path.isdir(str(base_dir))
+    mock_warning.assert_called_once_with(f"Directory {str(base_dir)} does not exist. Creating it.")
+
+
+@pytest.mark.parametrize("dir_exists, log_if_dir_does_not_exist", [(True, True), (False, False)])
+def test_get_full_path_create_dir_skips_warning_when_not_needed(
+    tmpdir, dir_exists, log_if_dir_does_not_exist
+):
+    base_dir = tmpdir.join("S00000-00999").join("S00005")
+    if dir_exists:
+        base_dir.ensure(dir=True)
+    scan_msg = ScanStatusMessage(
+        scan_id="1111",
+        scan_parameters={"system_config": {"file_directory": None, "file_suffix": None}},
+        info={"scan_number": 5, "file_components": (str(base_dir.join("S00005")), "h5")},
+        status="closed",
+    )
+
+    with mock.patch("bec_lib.file_utils.logger.warning") as mock_warning:
+        ret = get_full_path(
+            scan_msg,
+            "detector",
+            create_dir=True,
+            log_if_dir_does_not_exist=log_if_dir_does_not_exist,
+        )
+
+    assert ret == str(base_dir.join("S00005_detector.h5"))
+    assert os.path.isdir(str(base_dir))
+    mock_warning.assert_not_called()

--- a/bec_server/bec_server/file_writer/file_writer_manager.py
+++ b/bec_server/bec_server/file_writer/file_writer_manager.py
@@ -251,7 +251,7 @@ class FileWriterManager(BECService):
         if status == "open" and not scan_storage.start_time:
             scan_storage.start_time = msg.content.get("timestamp")
             scan_storage.async_writer = AsyncWriter(
-                get_full_path(scan_status_msg=msg, name="master"),
+                get_full_path(scan_status_msg=msg, name="master", log_if_dir_does_not_exist=False),
                 scan_id=scan_id,
                 scan_number=msg.scan_number,
                 connector=self.connector,
@@ -391,7 +391,11 @@ class FileWriterManager(BECService):
         start_time = time.time()
 
         try:
-            file_path = get_full_path(scan_status_msg=storage.status_msg, name=file_suffix)
+            file_path = get_full_path(
+                scan_status_msg=storage.status_msg,
+                name=file_suffix,
+                log_if_dir_does_not_exist=False,
+            )
             successful = True
 
             # If we've already written device data, we need to append to the file


### PR DESCRIPTION
## Description

`get_full_path` creates the directory by default. To be able to migrate to a less-permissive service account, we need to move the file access to the file writer service. For now, we should get a better awareness of methods that actually create them. To this end, I propose to add a log to the directory creation. We can monitor it later with grafana. 
I would expect that they actually don't create the directory as the file writer should create it as soon as the scan is opened but there could be a timing issue. 

## Type of Change

- Add log to the get_full_path 
- Add a `wait_for_directory` helper method

