### PR TITLE
fix: client startup tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ concurrency:
 permissions:
   pull-requests: write
 
+env:
+  PYTHONUTF8: 1
+
 jobs:
   check_pr_status:
     uses: ./.github/workflows/check_pr.yml

--- a/bec_ipython_client/bec_ipython_client/main.py
+++ b/bec_ipython_client/bec_ipython_client/main.py
@@ -38,7 +38,6 @@ logger = bec_logger.logger
 
 
 class CLIBECClient(BECClient):
-
     def _wait_for_server(self):
         super()._wait_for_server()
 
@@ -54,7 +53,6 @@ class CLIBECClient(BECClient):
 
 
 class BECIPythonClient:
-
     # local_only_types is a container for objects that should not be resolved through
     # the CLIBECClient but directly through the BECIPythonClient. While this is not
     # needed for normal usage, it is required, e.g. for mocks.
@@ -398,6 +396,7 @@ def main():
     main_dict["startup_file"] = args.post_startup_file
 
     app = TerminalIPythonApp()
+    app.display_banner = False
     app.interact = True
     app.initialize(argv=["-i", os.path.join(os.path.dirname(__file__), "bec_startup.py")])
 

--- a/bec_ipython_client/tests/client_tests/test_bec_client.py
+++ b/bec_ipython_client/tests/client_tests/test_bec_client.py
@@ -58,11 +58,11 @@ finally:
     # all_completions('bec.') should return a list of strings, one of which is 'bec.device_manager'
     # we can therefore limit the output to lines that start with '[' and end with ']'
     output_lines = [out for out in output.split("\n") if out.startswith("[") and out.endswith("]")]
-    assert "bec.device_manager" in output_lines[0]
+    assert "bec.device_manager" in output_lines[0], output
     assert (
         "BECIPythonClient" not in output_lines[1]
-    )  # just to ensure something we don't want is really not there
-    assert "test_gui_id" in output
+    ), output  # just to ensure something we don't want is really not there
+    assert "test_gui_id" in output, output
 
 
 def test_bec_load_hli_tab_completion(tmpdir):


### PR DESCRIPTION
`test_bec_entry_point_globals_and_post_startup` is flaky - this improves error reporting and fixes it

It failed because of the "tips" printed in the ipython startup banner, which are mostly only ascii, but occasionally include a greek character,  eg:

```
Python 3.13.13 (main, Apr 13 2026, 14:58:37) [GCC 15.2.1 20260209]
Type 'copyright', 'credits' or 'license' for more information
IPython 9.14.0 -- An enhanced Interactive Python. Type '?' for help.
Tip: You can find how to type a LaTeX symbol by back-completing it, eg `\θ<tab>` will expand to `\theta`.
```

And the github runner locale does not [make python start in utf-8 mode](https://peps.python.org/pep-0540/).

These are both changed - an env var is added to the workflow to set python to UTF-8 mode, and the banner is no longer displayed on client startup