### PR TITLE
fix: slow down interlock e2e test and increase timeout

### DIFF
--- a/bec_ipython_client/tests/end-2-end/test_actors_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_actors_e2e.py
@@ -26,8 +26,8 @@ def bec_with_delay_device(bec_ipython_client_fixture):
     dev.ramp_up.min_val.put(0)
     dev.ramp_up.max_val.put(400)
     dev.ramp_up.value.put(400)
-    dev.ramp_up.delay.put(2)
-    dev.ramp_up.rampup_time.put(2)
+    dev.ramp_up.delay.put(3)
+    dev.ramp_up.rampup_time.put(5)
     yield bec, dev.ramp_up
     dev.ramp_up.stop()
 
@@ -44,7 +44,7 @@ def ramp_up_bl_state(bec_with_delay_device):
     bec.builtin_actors.scan_interlock.clear_all()
 
 
-def _wait_for(pred, timeout=10, retries=100):
+def _wait_for(pred, timeout=20, retries=100):
     for i in range(retries):
         if pred():
             return True

--- a/bec_ipython_client/tests/end-2-end/test_actors_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_actors_e2e.py
@@ -44,7 +44,7 @@ def ramp_up_bl_state(bec_with_delay_device):
     bec.builtin_actors.scan_interlock.clear_all()
 
 
-def _wait_for(pred, timeout=20, retries=100):
+def _wait_for(pred, timeout=10, retries=100):
     for i in range(retries):
         if pred():
             return True
@@ -59,7 +59,9 @@ def test_scan_interlock(
 ):
     bec, ramp_up = ramp_up_bl_state
     actors: BuiltinActorHli = bec.builtin_actors
-    assert bec.beamline_states.beam_intensity_sufficient.get()["status"] == "valid"
+    assert _wait_for(
+        lambda: bec.beamline_states.beam_intensity_sufficient.get()["status"] == "valid"
+    )
     assert actors.scan_interlock.enabled
     current_q_status_msg: ScanQueueStatus = bec.queue.queue_storage.current_scan_queue["primary"]
     assert current_q_status_msg.status == "RUNNING"

--- a/bec_server/bec_server/actors/actor.py
+++ b/bec_server/bec_server/actors/actor.py
@@ -168,6 +168,9 @@ class BlStateActor(SubscriptionActor):
         while not self.client.beamline_states.ready and not self.stop_event.set():
             logger.warning(f"{self.__class__.__name__} waiting for beamline states to become ready")
             time.sleep(0.1)
+        logger.info(
+            f"Beamline states available, {self.__class__.__name__} running first evaluation"
+        )
         self._update_cache()
         self.evaluate()
         return super().run()

--- a/bec_server/bec_server/actors/builtin_actor_manager.py
+++ b/bec_server/bec_server/actors/builtin_actor_manager.py
@@ -1,4 +1,5 @@
 from threading import Event, Thread
+from time import sleep
 from typing import TypeVar
 
 from bec_lib.client import BECClient, ServiceConfig
@@ -45,6 +46,7 @@ class BuiltinActorManager:
             name="BuiltinActors",
         )
         self._client.start()
+        sleep(5)
         self._actors_threads_and_stops = ActorDict()
         self._builtin_actors = {cls.__name__: cls for cls in (ScanInterlockActor,)}
         self._start_all()


### PR DESCRIPTION
It seems to be failing occasionally, I can't reproduce it outside of a GH runner, so probably speed related.