### PR TITLE
fix: implement request ID handling for scan abortion

### DIFF
--- a/bec_ipython_client/bec_ipython_client/callbacks/ipython_live_updates.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/ipython_live_updates.py
@@ -189,7 +189,7 @@ class IPythonLiveUpdates:
                 request_context.queue_status = queue.status
                 self._request_block_id = req_id = self._active_request.metadata.get("RID")
 
-                while queue.status not in ["COMPLETED", "ABORTED", "HALTED"]:
+                while queue.status not in ["COMPLETED", "ABORTED", "HALTED", "CANCELLED"]:
                     request_context.queue_status = queue.status
                     if self._process_queue(queue, request, req_id):
                         break
@@ -302,7 +302,7 @@ class IPythonLiveUpdates:
         if queue.scans:
             if queue.scans[-1] is not None and queue.scans[-1].status == "user_completed":
                 return True
-            if queue.scans[-1] is None and queue.status == "STOPPED":
+            if queue.scans[-1] is None and queue.status in ["STOPPED", "CANCELLED"]:
                 raise ScanInterruption("Scan was stopped by the user.")
 
         if queue.queue_position is None:

--- a/bec_ipython_client/bec_ipython_client/callbacks/ipython_live_updates.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/ipython_live_updates.py
@@ -209,6 +209,14 @@ class IPythonLiveUpdates:
                 self._wait_for_cleanup()
             self._reset(forced=True)
             raise scan_interr
+        except KeyboardInterrupt as exc:
+            self._stop_status_live()
+            if self.client._service_config.abort_on_ctrl_c and self._abort_pending_request():
+                self._wait_for_cleanup()
+                self._reset(forced=True)
+                raise ScanInterruption("User abort.") from exc
+            self._reset(forced=True)
+            raise
         finally:
             self._stop_status_live()
 
@@ -224,6 +232,24 @@ class IPythonLiveUpdates:
         except KeyboardInterrupt:
             self.client.queue.request_scan_halt()
 
+    def _abort_pending_request(self) -> bool:
+        """Abort the pending queue item currently being tracked by this live update."""
+        if self._current_queue is None or self.client.queue is None:
+            return False
+        if self._current_queue.status != "PENDING":
+            return False
+        scan_ids = [scan_id for scan_id in self._current_queue.scan_ids if scan_id is not None]
+        if scan_ids:
+            self.client.queue.request_scan_abortion(scan_id=scan_ids)
+            return True
+        if self._active_request is None:
+            return False
+        request_id = self._active_request.metadata.get("RID")
+        if request_id is None:
+            return False
+        self.client.queue.request_scan_abortion(request_id=request_id)
+        return True
+
     def _element_in_queue(self) -> bool:
         if self.client.queue is None:
             return False
@@ -237,7 +263,7 @@ class IPythonLiveUpdates:
             return False
         if self._current_queue is None:
             return False
-        return self._current_queue.queue_id == queue_info[0].queue_id
+        return any(queue_item.queue_id == self._current_queue.queue_id for queue_item in queue_info)
 
     def _process_queue(
         self, queue: QueueItem, request: messages.ScanQueueMessage, req_id: str

--- a/bec_ipython_client/bec_ipython_client/callbacks/ipython_live_updates.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/ipython_live_updates.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import collections
 import time
+from contextvars import Token
 from typing import TYPE_CHECKING, Any
 
 from rich.console import Console
@@ -11,6 +12,7 @@ from rich.panel import Panel
 from bec_ipython_client.callbacks.device_progress import LiveUpdatesDeviceProgress
 from bec_lib.bec_errors import ScanInterruption, ScanRestart
 from bec_lib.logger import bec_logger
+from bec_lib.request_context import ActiveRequestContext, active_request_context
 
 from .live_table import LiveUpdatesTable
 from .move_device import LiveUpdatesReadbackProgressbar
@@ -164,11 +166,15 @@ class IPythonLiveUpdates:
     def process_request(self, request: messages.ScanQueueMessage, callbacks: Any) -> None:
         """Process the request and report instructions."""
         # pylint: disable=protected-access
+        context_token: Token | None = None
         try:
             with self.client._sighandler:
                 # pylint: disable=protected-access
                 self._active_request = request
                 self._user_callback = callbacks
+                request_id = request.metadata["RID"]
+                request_context = ActiveRequestContext(request_id=request_id)
+                context_token = active_request_context.set(request_context)
                 scan_request = ScanRequestMixin(self.client, request.metadata["RID"])
                 scan_request.wait()
 
@@ -180,9 +186,11 @@ class IPythonLiveUpdates:
                     time.sleep(0.01)
 
                 self._current_queue = queue = scan_request.scan_queue_request.queue
+                request_context.queue_status = queue.status
                 self._request_block_id = req_id = self._active_request.metadata.get("RID")
 
                 while queue.status not in ["COMPLETED", "ABORTED", "HALTED"]:
+                    request_context.queue_status = queue.status
                     if self._process_queue(queue, request, req_id):
                         break
 
@@ -218,6 +226,8 @@ class IPythonLiveUpdates:
             self._reset(forced=True)
             raise
         finally:
+            if context_token is not None:
+                active_request_context.reset(context_token)
             self._stop_status_live()
 
     def _wait_for_cleanup(self):
@@ -230,7 +240,20 @@ class IPythonLiveUpdates:
             while self._element_in_queue():
                 time.sleep(0.1)
         except KeyboardInterrupt:
-            self.client.queue.request_scan_halt()
+            request_id = self._get_tracked_request_id()
+            if request_id is None:
+                self.client.queue.request_scan_halt()
+                return
+            self.client.queue.request_scan_halt(request_id=request_id)
+
+    def _get_tracked_request_id(self) -> str | None:
+        """Return the request id associated with the active live-updates request."""
+        request_context = active_request_context.get()
+        if request_context is not None:
+            return request_context.request_id
+        if self._active_request is None:
+            return None
+        return self._active_request.metadata.get("RID")
 
     def _abort_pending_request(self) -> bool:
         """Abort the pending queue item currently being tracked by this live update."""
@@ -238,13 +261,7 @@ class IPythonLiveUpdates:
             return False
         if self._current_queue.status != "PENDING":
             return False
-        scan_ids = [scan_id for scan_id in self._current_queue.scan_ids if scan_id is not None]
-        if scan_ids:
-            self.client.queue.request_scan_abortion(scan_id=scan_ids)
-            return True
-        if self._active_request is None:
-            return False
-        request_id = self._active_request.metadata.get("RID")
+        request_id = self._get_tracked_request_id()
         if request_id is None:
             return False
         self.client.queue.request_scan_abortion(request_id=request_id)
@@ -336,19 +353,20 @@ class IPythonLiveUpdates:
 
         if self.client.queue is None or self.client.queue.queue_storage.current_scan_queue is None:
             return
-        target_queue = self.client.queue.queue_storage.current_scan_queue.get(
-            self.client.queue.get_default_scan_queue()
-        )
-        if target_queue is None:
+        target_queue = self.client.queue.get_default_scan_queue()
+        target_queue_status = self.client.queue.queue_storage.current_scan_queue.get(target_queue)
+        if target_queue_status is None:
             return
 
         queue_position = queue.queue_position
         if queue_position is None:
             return
 
-        status = target_queue.status
+        status = target_queue_status.status
         if status == "LOCKED":
-            lock_info = [f"{lock.identifier}: {lock.reason}\n" for lock in target_queue.locks]
+            lock_info = [
+                f"{lock.identifier}: {lock.reason}\n" for lock in target_queue_status.locks
+            ]
             message = (
                 f"Scan is waiting for the lock to be released. Active locks: \n{''.join(lock_info)}"
             )

--- a/bec_ipython_client/bec_ipython_client/signals.py
+++ b/bec_ipython_client/bec_ipython_client/signals.py
@@ -6,6 +6,7 @@ import time
 from typing import TYPE_CHECKING
 
 from bec_lib.bec_errors import ScanInterruption
+from bec_lib.request_context import active_request_context
 
 if TYPE_CHECKING:  # pragma: no cover
     from bec_lib.client import BECClient
@@ -100,14 +101,28 @@ class SigintHandler(SignalHandler):
         else:
             raise ValueError(f"Mode {self._operation_mode} not handled by SigintHandler")
 
+    @staticmethod
+    def _get_active_request_id() -> str | None:
+        request_context = active_request_context.get()
+        if request_context is None:
+            return None
+        return request_context.request_id
+
     def _procedure_mode(self):
         # Catch it here to only kill scans which were started here
         print("SIGINT received in procedure mode. Sending scan abort request and exiting.")
-        self.bec.queue.request_scan_abortion()
+        self.bec.queue.request_scan_abortion(request_id=self._get_active_request_id())
         # Let the procedure worker shut itself down
         raise KeyboardInterrupt
 
     def _normal_mode(self):
+        request_context = active_request_context.get()
+        request_id = request_context.request_id if request_context is not None else None
+        if request_context is not None and request_context.queue_status == "PENDING":
+            # A locally tracked request is still queued behind someone else.
+            # Let IPythonLiveUpdates handle Ctrl-C so we only target that request.
+            raise KeyboardInterrupt
+
         current_scan = self.bec.queue.scan_storage.current_scan_info
         if not current_scan:
             raise KeyboardInterrupt
@@ -126,7 +141,9 @@ class SigintHandler(SignalHandler):
                 print("It has been 10 seconds since the last SIGINT. Resetting SIGINT handler.")
 
             threading.Thread(
-                target=self.bec.queue.request_scan_interruption, args=(True,), daemon=True
+                target=self.bec.queue.request_scan_interruption,
+                kwargs={"deferred_pause": True, "request_id": request_id},
+                daemon=True,
             ).start()
             print(
                 "A 'deferred pause' has been requested. The "
@@ -141,10 +158,16 @@ class SigintHandler(SignalHandler):
         # - Ctrl-C twice within 10 seconds or a direct command (e.g. mv) -> hard pause
         if self.bec._service_config.abort_on_ctrl_c:
             print("The scan will be aborted.")
-            threading.Thread(target=self.bec.queue.request_scan_abortion, daemon=True).start()
+            threading.Thread(
+                target=self.bec.queue.request_scan_abortion,
+                kwargs={"request_id": request_id},
+                daemon=True,
+            ).start()
             raise ScanInterruption("User abort.")
         print("A hard pause will be requested.")
         threading.Thread(
-            target=self.bec.queue.request_scan_interruption, args=(False,), daemon=True
+            target=self.bec.queue.request_scan_interruption,
+            kwargs={"deferred_pause": False, "request_id": request_id},
+            daemon=True,
         ).start()
         raise ScanInterruption(PAUSE_MSG)

--- a/bec_ipython_client/tests/client_tests/test_ipython_live_updates.py
+++ b/bec_ipython_client/tests/client_tests/test_ipython_live_updates.py
@@ -173,6 +173,155 @@ def test_process_request_repeats_on_ScanRestart_error(
         assert live_updates._stop_status_live.call_count == 5
 
 
+def test_abort_pending_request_requests_abortion_by_scan_ids(bec_client_mock):
+    live_updates = IPythonLiveUpdates(bec_client_mock)
+    live_updates._current_queue = mock.MagicMock(status="PENDING", scan_ids=["scan_id", None])
+
+    with mock.patch.object(live_updates.client.queue, "request_scan_abortion") as request_abort:
+        assert live_updates._abort_pending_request() is True
+        request_abort.assert_called_once_with(scan_id=["scan_id"])
+
+
+def test_abort_pending_request_falls_back_to_request_id(bec_client_mock, sample_request_msg):
+    live_updates = IPythonLiveUpdates(bec_client_mock)
+    live_updates._current_queue = mock.MagicMock(status="PENDING", scan_ids=[None])
+    live_updates._active_request = sample_request_msg
+
+    with mock.patch.object(live_updates.client.queue, "request_scan_abortion") as request_abort:
+        assert live_updates._abort_pending_request() is True
+        request_abort.assert_called_once_with(request_id="something")
+
+
+def test_abort_pending_request_returns_false_when_not_pending(bec_client_mock):
+    live_updates = IPythonLiveUpdates(bec_client_mock)
+    live_updates._current_queue = mock.MagicMock(status="RUNNING", scan_ids=["scan_id"])
+
+    with mock.patch.object(live_updates.client.queue, "request_scan_abortion") as request_abort:
+        assert live_updates._abort_pending_request() is False
+        request_abort.assert_not_called()
+
+
+def test_wait_for_cleanup_returns_immediately_when_queue_item_gone(bec_client_mock):
+    live_updates = IPythonLiveUpdates(bec_client_mock)
+
+    with (
+        mock.patch.object(live_updates, "_stop_status_live") as stop_status_live,
+        mock.patch.object(live_updates, "_element_in_queue", return_value=False) as in_queue,
+    ):
+        live_updates._wait_for_cleanup()
+
+    stop_status_live.assert_called_once()
+    in_queue.assert_called_once()
+
+
+def test_wait_for_cleanup_loops_until_queue_item_removed(bec_client_mock):
+    live_updates = IPythonLiveUpdates(bec_client_mock)
+
+    with (
+        mock.patch.object(
+            live_updates, "_element_in_queue", side_effect=[True, True, False]
+        ) as in_queue,
+        mock.patch("bec_ipython_client.callbacks.ipython_live_updates.time.sleep") as sleep,
+    ):
+        live_updates._wait_for_cleanup()
+
+    assert in_queue.call_count == 3
+    sleep.assert_called_once_with(0.1)
+
+
+def test_wait_for_cleanup_keyboard_interrupt_requests_halt(bec_client_mock):
+    live_updates = IPythonLiveUpdates(bec_client_mock)
+
+    with (
+        mock.patch.object(live_updates, "_element_in_queue", side_effect=KeyboardInterrupt),
+        mock.patch.object(live_updates.client.queue, "request_scan_halt") as request_halt,
+    ):
+        live_updates._wait_for_cleanup()
+
+    request_halt.assert_called_once()
+
+
+@pytest.fixture
+def process_request_keyboard_interrupt_setup(
+    ipython_live_updates_with_mocked_live, sample_request_msg
+):
+    live_updates, _ = ipython_live_updates_with_mocked_live
+    callbacks = mock.MagicMock()
+    live_updates.client._service_config = mock.MagicMock(abort_on_ctrl_c=True)
+
+    queue = mock.MagicMock()
+    queue.scan_ids = ["scan_id"]
+    queue.queue_id = "queue_id"
+
+    request_item = mock.MagicMock()
+    request_item.queue = queue
+    fake_scan_request = mock.MagicMock()
+    fake_scan_request.scan_queue_request = request_item
+    fake_scan_request.wait.return_value = None
+
+    live_updates.client._sighandler = mock.MagicMock()
+    live_updates.client._sighandler.__enter__.return_value = None
+    live_updates.client._sighandler.__exit__.return_value = None
+
+    return live_updates, callbacks, sample_request_msg, queue, fake_scan_request
+
+
+def test_process_request_keyboard_interrupt_pending_request_raises_scan_interruption(
+    process_request_keyboard_interrupt_setup,
+):
+    live_updates, callbacks, sample_request_msg, queue, fake_scan_request = (
+        process_request_keyboard_interrupt_setup
+    )
+    queue.status = "PENDING"
+
+    with (
+        mock.patch(
+            "bec_ipython_client.callbacks.ipython_live_updates.ScanRequestMixin",
+            return_value=fake_scan_request,
+        ),
+        mock.patch.object(live_updates, "_process_queue", side_effect=KeyboardInterrupt()),
+        mock.patch.object(
+            live_updates, "_abort_pending_request", return_value=True
+        ) as abort_pending,
+        mock.patch.object(live_updates, "_wait_for_cleanup") as wait_for_cleanup,
+        mock.patch.object(live_updates, "_reset") as reset,
+    ):
+        with pytest.raises(ScanInterruption, match="User abort."):
+            live_updates.process_request(sample_request_msg, callbacks)
+
+    abort_pending.assert_called_once()
+    wait_for_cleanup.assert_called_once()
+    reset.assert_called_once_with(forced=True)
+
+
+def test_process_request_keyboard_interrupt_non_pending_re_raises(
+    process_request_keyboard_interrupt_setup,
+):
+    live_updates, callbacks, sample_request_msg, queue, fake_scan_request = (
+        process_request_keyboard_interrupt_setup
+    )
+    queue.status = "RUNNING"
+
+    with (
+        mock.patch(
+            "bec_ipython_client.callbacks.ipython_live_updates.ScanRequestMixin",
+            return_value=fake_scan_request,
+        ),
+        mock.patch.object(live_updates, "_process_queue", side_effect=KeyboardInterrupt()),
+        mock.patch.object(
+            live_updates, "_abort_pending_request", return_value=False
+        ) as abort_pending,
+        mock.patch.object(live_updates, "_wait_for_cleanup") as wait_for_cleanup,
+        mock.patch.object(live_updates, "_reset") as reset,
+    ):
+        with pytest.raises(KeyboardInterrupt):
+            live_updates.process_request(sample_request_msg, callbacks)
+
+    abort_pending.assert_called_once()
+    wait_for_cleanup.assert_not_called()
+    reset.assert_called_once_with(forced=True)
+
+
 @pytest.mark.timeout(20)
 def test_live_updates_process_queue_without_status(bec_client_mock, queue_elements):
     client = bec_client_mock
@@ -379,6 +528,39 @@ def test_element_in_queue_queue_id_in_info(bec_client_mock, sample_request_block
     )
     scan_queue_status = messages.ScanQueueStatus(info=[queue_info_entry], status="RUNNING")
     client.queue.queue_storage.current_scan_queue = {"primary": scan_queue_status}
+    assert live_updates._element_in_queue() is True
+
+
+@pytest.mark.timeout(20)
+def test_element_in_queue_queue_id_in_later_position(bec_client_mock, sample_request_block):
+    client = bec_client_mock
+    live_updates = IPythonLiveUpdates(client)
+
+    current_queue = mock.MagicMock()
+    current_queue.queue_id = "my_queue_id"
+    live_updates._current_queue = current_queue
+
+    first_entry = messages.QueueInfoEntry(
+        queue_id="different_queue_id",
+        scan_id=["scan_id_1"],
+        is_scan=[True],
+        request_blocks=[sample_request_block],
+        scan_number=[1],
+        status="RUNNING",
+        active_request_block=None,
+    )
+    second_entry = messages.QueueInfoEntry(
+        queue_id="my_queue_id",
+        scan_id=["scan_id_2"],
+        is_scan=[True],
+        request_blocks=[sample_request_block],
+        scan_number=[2],
+        status="PENDING",
+        active_request_block=None,
+    )
+    scan_queue_status = messages.ScanQueueStatus(info=[first_entry, second_entry], status="LOCKED")
+    client.queue.queue_storage.current_scan_queue = {"primary": scan_queue_status}
+
     assert live_updates._element_in_queue() is True
 
 

--- a/bec_ipython_client/tests/client_tests/test_ipython_live_updates.py
+++ b/bec_ipython_client/tests/client_tests/test_ipython_live_updates.py
@@ -147,6 +147,41 @@ def test_live_updates_process_queue_running(ipython_live_updates_with_mocked_liv
                     assert res is True
 
 
+def test_live_updates_process_queue_cancelled_pending_request_raises_interruption(bec_client_mock):
+    client = bec_client_mock
+    live_updates = IPythonLiveUpdates(client)
+    request_msg = messages.ScanQueueMessage(
+        scan_type="grid_scan",
+        parameter={"args": {"samx": (-5, 5, 3)}, "kwargs": {}},
+        queue="primary",
+        metadata={"RID": "something"},
+    )
+    request_block = messages.RequestBlock(
+        msg=request_msg,
+        RID="something",
+        report_instructions=[],
+        readout_priority={"monitored": ["samx"]},
+        is_scan=True,
+        scan_number=1,
+        scan_id=None,
+    )
+    queue = QueueItem(
+        scan_manager=client.queue,
+        queue_id="queue_id",
+        request_blocks=[request_block],
+        status="CANCELLED",
+        active_request_block=None,
+        scan_id=[None],
+    )
+
+    with (
+        mock.patch.object(queue, "_update_with_buffer"),
+        mock.patch("bec_lib.queue_items.QueueItem.queue_position", new_callable=mock.PropertyMock),
+        pytest.raises(ScanInterruption, match="stopped by the user"),
+    ):
+        live_updates._process_queue(queue, request_msg, "something")
+
+
 def test_process_request_repeats_on_ScanRestart_error(
     ipython_live_updates_with_mocked_live, queue_elements
 ):

--- a/bec_ipython_client/tests/client_tests/test_ipython_live_updates.py
+++ b/bec_ipython_client/tests/client_tests/test_ipython_live_updates.py
@@ -6,6 +6,7 @@ from bec_ipython_client.callbacks.ipython_live_updates import IPythonLiveUpdates
 from bec_lib import messages
 from bec_lib.bec_errors import ScanInterruption, ScanRestart
 from bec_lib.queue_items import QueueItem
+from bec_lib.request_context import ActiveRequestContext, active_request_context
 
 
 @pytest.fixture
@@ -173,13 +174,32 @@ def test_process_request_repeats_on_ScanRestart_error(
         assert live_updates._stop_status_live.call_count == 5
 
 
-def test_abort_pending_request_requests_abortion_by_scan_ids(bec_client_mock):
+def test_abort_pending_request_requests_abortion_by_request_id(bec_client_mock, sample_request_msg):
     live_updates = IPythonLiveUpdates(bec_client_mock)
     live_updates._current_queue = mock.MagicMock(status="PENDING", scan_ids=["scan_id", None])
+    live_updates._active_request = sample_request_msg
 
     with mock.patch.object(live_updates.client.queue, "request_scan_abortion") as request_abort:
         assert live_updates._abort_pending_request() is True
-        request_abort.assert_called_once_with(scan_id=["scan_id"])
+        request_abort.assert_called_once_with(request_id="something")
+
+
+def test_get_tracked_request_id_uses_contextvar(bec_client_mock):
+    live_updates = IPythonLiveUpdates(bec_client_mock)
+    live_updates._active_request = messages.ScanQueueMessage(
+        scan_type="grid_scan",
+        parameter={"args": {"samx": (-5, 5, 3)}, "kwargs": {}},
+        queue="primary",
+        metadata={"RID": "fallback-request"},
+    )
+    token = active_request_context.set(
+        ActiveRequestContext(request_id="context-request", queue_status="PENDING")
+    )
+
+    try:
+        assert live_updates._get_tracked_request_id() == "context-request"
+    finally:
+        active_request_context.reset(token)
 
 
 def test_abort_pending_request_falls_back_to_request_id(bec_client_mock, sample_request_msg):
@@ -231,6 +251,12 @@ def test_wait_for_cleanup_loops_until_queue_item_removed(bec_client_mock):
 
 def test_wait_for_cleanup_keyboard_interrupt_requests_halt(bec_client_mock):
     live_updates = IPythonLiveUpdates(bec_client_mock)
+    live_updates._active_request = messages.ScanQueueMessage(
+        scan_type="grid_scan",
+        parameter={"args": {"samx": (-5, 5, 3)}, "kwargs": {}},
+        queue="primary",
+        metadata={"RID": "pending-request"},
+    )
 
     with (
         mock.patch.object(live_updates, "_element_in_queue", side_effect=KeyboardInterrupt),
@@ -238,7 +264,19 @@ def test_wait_for_cleanup_keyboard_interrupt_requests_halt(bec_client_mock):
     ):
         live_updates._wait_for_cleanup()
 
-    request_halt.assert_called_once()
+    request_halt.assert_called_once_with(request_id="pending-request")
+
+
+def test_wait_for_cleanup_keyboard_interrupt_requests_halt_without_request_id(bec_client_mock):
+    live_updates = IPythonLiveUpdates(bec_client_mock)
+
+    with (
+        mock.patch.object(live_updates, "_element_in_queue", side_effect=KeyboardInterrupt),
+        mock.patch.object(live_updates.client.queue, "request_scan_halt") as request_halt,
+    ):
+        live_updates._wait_for_cleanup()
+
+    request_halt.assert_called_once_with()
 
 
 @pytest.fixture
@@ -290,6 +328,36 @@ def test_process_request_keyboard_interrupt_pending_request_raises_scan_interrup
             live_updates.process_request(sample_request_msg, callbacks)
 
     abort_pending.assert_called_once()
+    wait_for_cleanup.assert_called_once()
+    reset.assert_called_once_with(forced=True)
+
+
+@pytest.mark.parametrize("queue_status", ["RUNNING", "LOCKED"])
+def test_process_request_keyboard_interrupt_pending_request_aborts_local_request_by_id(
+    process_request_keyboard_interrupt_setup, queue_status
+):
+    live_updates, callbacks, sample_request_msg, queue, fake_scan_request = (
+        process_request_keyboard_interrupt_setup
+    )
+    queue.status = "PENDING"
+    live_updates.client.queue.queue_storage.current_scan_queue = {
+        "primary": messages.ScanQueueStatus(info=[], status=queue_status)
+    }
+
+    with (
+        mock.patch(
+            "bec_ipython_client.callbacks.ipython_live_updates.ScanRequestMixin",
+            return_value=fake_scan_request,
+        ),
+        mock.patch.object(live_updates, "_process_queue", side_effect=KeyboardInterrupt()),
+        mock.patch.object(live_updates.client.queue, "request_scan_abortion") as request_abort,
+        mock.patch.object(live_updates, "_wait_for_cleanup") as wait_for_cleanup,
+        mock.patch.object(live_updates, "_reset") as reset,
+    ):
+        with pytest.raises(ScanInterruption, match="User abort."):
+            live_updates.process_request(sample_request_msg, callbacks)
+
+    request_abort.assert_called_once_with(request_id="something")
     wait_for_cleanup.assert_called_once()
     reset.assert_called_once_with(forced=True)
 

--- a/bec_ipython_client/tests/client_tests/test_signals.py
+++ b/bec_ipython_client/tests/client_tests/test_signals.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import threading
+from unittest import mock
+
+import pytest
+
+from bec_ipython_client.signals import SigintHandler
+from bec_lib.bec_errors import ScanInterruption
+from bec_lib.request_context import ActiveRequestContext, active_request_context
+
+
+@pytest.fixture
+def bec_with_pending_live_request():
+    bec = mock.MagicMock()
+    bec._service_config = mock.MagicMock(abort_on_ctrl_c=True)
+    return bec
+
+
+def test_sigint_handler_raises_keyboard_interrupt_for_pending_live_request(
+    bec_with_pending_live_request,
+):
+    handler = SigintHandler(bec_with_pending_live_request)
+    token = active_request_context.set(
+        ActiveRequestContext(request_id="pending-request", queue_status="PENDING")
+    )
+
+    try:
+        with pytest.raises(KeyboardInterrupt):
+            handler._normal_mode()
+    finally:
+        active_request_context.reset(token)
+
+    bec_with_pending_live_request.queue.request_scan_interruption.assert_not_called()
+    bec_with_pending_live_request.queue.request_scan_abortion.assert_not_called()
+
+
+def test_sigint_handler_pending_live_request_does_not_abort_running_scan_from_other_client():
+    bec = mock.MagicMock()
+    bec._service_config = mock.MagicMock(abort_on_ctrl_c=True)
+    bec.queue.scan_storage.current_scan_info = mock.MagicMock(
+        status="RUNNING",
+        is_scan=[True],
+        request_blocks=[mock.MagicMock(RID="other-client-request")],
+    )
+    handler = SigintHandler(bec)
+    token = active_request_context.set(
+        ActiveRequestContext(request_id="local-pending-request", queue_status="PENDING")
+    )
+
+    try:
+        with pytest.raises(KeyboardInterrupt):
+            handler._normal_mode()
+    finally:
+        active_request_context.reset(token)
+
+    bec.queue.request_scan_interruption.assert_not_called()
+    bec.queue.request_scan_abortion.assert_not_called()
+
+
+def test_sigint_handler_requests_deferred_pause_for_running_scan():
+    bec = mock.MagicMock()
+    bec._service_config = mock.MagicMock(abort_on_ctrl_c=True)
+    bec._live_updates = None
+    bec.queue.scan_storage.current_scan_info = mock.MagicMock(status="RUNNING", is_scan=[True])
+
+    handler = SigintHandler(bec)
+    token = active_request_context.set(
+        ActiveRequestContext(request_id="running-request", queue_status="RUNNING")
+    )
+
+    try:
+        with mock.patch.object(threading, "Thread") as thread_cls:
+            handler._normal_mode()
+    finally:
+        active_request_context.reset(token)
+
+    thread_cls.assert_called_once_with(
+        target=bec.queue.request_scan_interruption,
+        kwargs={"deferred_pause": True, "request_id": "running-request"},
+        daemon=True,
+    )
+    thread_cls.return_value.start.assert_called_once_with()
+
+
+def test_sigint_handler_requests_abort_for_running_scan_after_second_sigint():
+    bec = mock.MagicMock()
+    bec._service_config = mock.MagicMock(abort_on_ctrl_c=True)
+    bec._live_updates = None
+    bec.queue.scan_storage.current_scan_info = mock.MagicMock(
+        status="DEFERRED_PAUSE", is_scan=[True]
+    )
+
+    handler = SigintHandler(bec)
+    handler.last_sigint_time = 0
+    token = active_request_context.set(
+        ActiveRequestContext(request_id="running-request", queue_status="DEFERRED_PAUSE")
+    )
+
+    try:
+        with (
+            mock.patch("bec_ipython_client.signals.time.time", return_value=5),
+            mock.patch.object(threading, "Thread") as thread_cls,
+            pytest.raises(ScanInterruption, match="User abort."),
+        ):
+            handler._normal_mode()
+    finally:
+        active_request_context.reset(token)
+
+    thread_cls.assert_called_once_with(
+        target=bec.queue.request_scan_abortion,
+        kwargs={"request_id": "running-request"},
+        daemon=True,
+    )
+    thread_cls.return_value.start.assert_called_once_with()
+
+
+def test_sigint_handler_without_active_or_pending_scan_reraises_keyboard_interrupt():
+    bec = mock.MagicMock()
+    bec._service_config = mock.MagicMock(abort_on_ctrl_c=True)
+    bec.queue.scan_storage.current_scan_info = None
+    handler = SigintHandler(bec)
+
+    with pytest.raises(KeyboardInterrupt):
+        handler._normal_mode()
+
+    bec.queue.request_scan_interruption.assert_not_called()
+    bec.queue.request_scan_abortion.assert_not_called()
+
+
+def test_sigint_handler_without_request_context_passes_none_to_thread_target():
+    bec = mock.MagicMock()
+    bec._service_config = mock.MagicMock(abort_on_ctrl_c=True)
+    bec._live_updates = None
+    bec.queue.scan_storage.current_scan_info = mock.MagicMock(status="RUNNING", is_scan=[True])
+    handler = SigintHandler(bec)
+
+    with mock.patch.object(threading, "Thread") as thread_cls:
+        handler._normal_mode()
+
+    thread_cls.assert_called_once_with(
+        target=bec.queue.request_scan_interruption,
+        kwargs={"deferred_pause": True, "request_id": None},
+        daemon=True,
+    )

--- a/bec_lib/bec_lib/messages.py
+++ b/bec_lib/bec_lib/messages.py
@@ -14,6 +14,7 @@ from uuid import uuid4
 
 import numpy as np
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
+from typing_extensions import deprecated
 
 from bec_lib.metadata_schema import get_metadata_schema_for_scan
 
@@ -269,8 +270,8 @@ class ScanQueueModificationMessage(BECMessage):
     """Message type for sending scan queue modifications
 
     Args:
-        scan_id (str): Unique scan ID
-        request_id (str | None): Request ID to target when no scan ID is available yet
+        scan_id (str): Unique scan ID. Deprecated, use request_id instead.
+        request_id (str | None): Request ID to target for queue modifications
         action (str): One of the actions defined in ACTIONS:
                 "pause",
                 "deferred_pause",
@@ -288,11 +289,13 @@ class ScanQueueModificationMessage(BECMessage):
         metadata (dict, optional): Additional metadata to describe and identify the scan.
 
     Examples:
-        >>> ScanQueueModificationMessage(scan_id=scan_id, action="abort", parameter={})
+        >>> ScanQueueModificationMessage(request_id=request_id, action="abort", parameter={})
     """
 
     msg_type: ClassVar[str] = "scan_queue_modification"
-    scan_id: str | list[str] | None | list[None]
+    scan_id: str | list[str] | None | list[None] = Field(
+        None, deprecated=deprecated("scan_id is deprecated, use request_id instead")
+    )
     request_id: str | None = None
     action: Literal[
         "pause",

--- a/bec_lib/bec_lib/messages.py
+++ b/bec_lib/bec_lib/messages.py
@@ -270,6 +270,7 @@ class ScanQueueModificationMessage(BECMessage):
 
     Args:
         scan_id (str): Unique scan ID
+        request_id (str | None): Request ID to target when no scan ID is available yet
         action (str): One of the actions defined in ACTIONS:
                 "pause",
                 "deferred_pause",
@@ -292,6 +293,7 @@ class ScanQueueModificationMessage(BECMessage):
 
     msg_type: ClassVar[str] = "scan_queue_modification"
     scan_id: str | list[str] | None | list[None]
+    request_id: str | None = None
     action: Literal[
         "pause",
         "deferred_pause",

--- a/bec_lib/bec_lib/request_context.py
+++ b/bec_lib/bec_lib/request_context.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from contextvars import ContextVar
+from dataclasses import dataclass
+
+
+@dataclass
+class ActiveRequestContext:
+    request_id: str
+    queue_status: str | None = None
+
+
+active_request_context: ContextVar[ActiveRequestContext | None] = ContextVar(
+    "active_request_context", default=None
+)

--- a/bec_lib/bec_lib/scan_manager.py
+++ b/bec_lib/bec_lib/scan_manager.py
@@ -15,6 +15,7 @@ from bec_lib import messages  # typechecking doesn't work with lazy_import
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.logger import bec_logger
 from bec_lib.queue_items import QueueStorage
+from bec_lib.request_context import active_request_context
 from bec_lib.request_items import RequestStorage
 from bec_lib.scan_items import ScanStorage
 from bec_lib.scan_number_container import ScanNumberContainer
@@ -71,43 +72,44 @@ class ScanManager:
         self.queue_storage.update_with_status(queue)
         self.scan_storage.update_with_queue_status(queue)
 
-    def request_scan_interruption(self, deferred_pause=True, scan_id: str = None) -> None:
+    def request_scan_interruption(self, deferred_pause=True, request_id: str | None = None) -> None:
         """request a scan interruption
 
         Args:
             deferred_pause (bool, optional): Request a deferred pause. If False, a pause will be requested. Defaults to True.
-            scan_id (str, optional): ScanID. Defaults to None.
-
+            request_id (str, optional): Request ID. Used when no scan ID exists yet.
         """
-        if scan_id is None:
-            scan_id = self.scan_storage.current_scan_id
-        if not any(scan_id):
-            return self.request_scan_abortion()
+        request_id = self._resolve_request_id(request_id=request_id)
+        if not any(self.scan_storage.current_scan_id):
+            # If we don't have a scan to cancel, we abort
+            return self.request_scan_abortion(request_id=request_id)
 
         action = "deferred_pause" if deferred_pause else "pause"
         logger.info(f"Requesting {action}")
 
         return self.connector.send(
             MessageEndpoints.scan_queue_modification_request(),
-            messages.ScanQueueModificationMessage(scan_id=scan_id, action=action, parameter={}),
+            messages.ScanQueueModificationMessage(
+                scan_id=None, request_id=request_id, action=action, parameter={}
+            ),
         )
 
-    def request_scan_abortion(self, scan_id=None, request_id: str | None = None):
+    def request_scan_abortion(self, request_id: str | None = None, scan_id=None):
         """request a scan abortion
 
         Args:
-            scan_id (str, optional): ScanID. Defaults to None.
             request_id (str, optional): Request ID. Used when no scan ID exists yet.
+            scan_id (str, optional): ScanID. Deprecated, use request_id instead. Defaults to None.
 
         """
-        if scan_id is None and request_id is None:
-            scan_id = self.scan_storage.current_scan_id
-        logger.info("Requesting scan abortion")
+        request_id = self._resolve_request_id(request_id=request_id)
         target_queue = self.get_default_scan_queue()
+        logger.info("Requesting scan abortion")
+
         self.connector.send(
             MessageEndpoints.scan_queue_modification_request(),
             messages.ScanQueueModificationMessage(
-                scan_id=scan_id,
+                scan_id=None,
                 request_id=request_id,
                 action="abort",
                 parameter={},
@@ -115,45 +117,40 @@ class ScanManager:
             ),
         )
 
-    def request_scan_halt(self, scan_id=None, request_id: str | None = None):
-        """request a scan halt
+    def request_scan_halt(self, request_id: str | None = None):
+        """
+        Request a scan halt. This is an emergency stop without cleanup.
 
         Args:
-            scan_id (str, optional): ScanID. Defaults to None.
-            request_id (str, optional): Request ID. Used when no scan ID exists yet.
-
+            request_id (str, optional): Request ID.
         """
-        if scan_id is None and request_id is None:
-            scan_id = self.scan_storage.current_scan_id
+        request_id = self._resolve_request_id(request_id=request_id)
         target_queue = self.get_default_scan_queue()
         logger.info("Requesting scan halt")
+
         self.connector.send(
             MessageEndpoints.scan_queue_modification_request(),
             messages.ScanQueueModificationMessage(
-                scan_id=scan_id,
-                request_id=request_id,
-                action="halt",
-                parameter={},
-                queue=target_queue,
+                scan_id=None, request_id=request_id, action="halt", parameter={}, queue=target_queue
             ),
         )
 
-    def request_set_completed(self, scan_id=None, request_id: str | None = None):
+    def request_set_completed(self, request_id: str | None = None, scan_id=None):
         """request to set a scan as completed
 
         Args:
-            scan_id (str, optional): ScanID. Defaults to None.
             request_id (str, optional): Request ID. Used when no scan ID exists yet.
+            scan_id (str, optional): ScanID. Deprecated, use request_id instead. Defaults to None.
 
         """
-        if scan_id is None and request_id is None:
-            scan_id = self.scan_storage.current_scan_id
-        logger.info("Requesting to set scan as completed")
+        request_id = self._resolve_request_id(request_id=request_id)
         target_queue = self.get_default_scan_queue()
+        logger.info("Requesting to set scan as completed")
+
         self.connector.send(
             MessageEndpoints.scan_queue_modification_request(),
             messages.ScanQueueModificationMessage(
-                scan_id=scan_id,
+                scan_id=None,
                 request_id=request_id,
                 action="user_completed",
                 parameter={},
@@ -161,22 +158,21 @@ class ScanManager:
             ),
         )
 
-    def request_scan_continuation(self, scan_id=None, request_id: str | None = None):
+    def request_scan_continuation(self, request_id: str | None = None, scan_id=None):
         """request a scan continuation
 
         Args:
-            scan_id (str, optional): ScanID. Defaults to None.
             request_id (str, optional): Request ID. Used when no scan ID exists yet.
+            scan_id (str, optional): ScanID. Deprecated, use request_id instead. Defaults to None.
 
         """
-        if scan_id is None and request_id is None:
-            scan_id = self.scan_storage.current_scan_id
+        request_id = self._resolve_request_id(request_id=request_id)
         logger.info("Requesting scan continuation")
         target_queue = self.get_default_scan_queue()
         self.connector.send(
             MessageEndpoints.scan_queue_modification_request(),
             messages.ScanQueueModificationMessage(
-                scan_id=scan_id,
+                scan_id=None,
                 request_id=request_id,
                 action="continue",
                 parameter={},
@@ -192,26 +188,36 @@ class ScanManager:
             messages.ScanQueueModificationMessage(scan_id=None, action="clear", parameter={}),
         )
 
-    def request_scan_restart(self, scan_id=None, requestID=None, replace=True) -> str:
-        """request to restart a scan"""
-        if scan_id is None:
-            scan_id = self.scan_storage.current_scan_id
-        if requestID is None:
-            requestID = str(uuid.uuid4())
-        logger.info("Requesting to abort and repeat a scan")
+    def request_scan_restart(
+        self, request_id: str | None = None, new_request_id: str | None = None, replace=True
+    ) -> str:
+        """
+        Request to restart a scan
+
+        Args:
+            request_id (str, optional): Request ID for the existing scan. Used when no scan ID exists yet. Defaults to None.
+            new_request_id (str, optional): Request ID for the new scan. Used when no scan ID exists yet. Defaults to None.
+            replace (bool, optional): Whether to replace the scan in the queue or add a new entry. Defaults to True.
+        """
+        request_id = self._resolve_request_id(request_id=request_id)
+        if new_request_id is None:
+            new_request_id = str(uuid.uuid4())
+
         position = "replace" if replace else "append"
         target_queue = self.get_default_scan_queue()
+        logger.info("Requesting to abort and repeat a scan")
 
         self.connector.send(
             MessageEndpoints.scan_queue_modification_request(),
             messages.ScanQueueModificationMessage(
-                scan_id=scan_id,
+                scan_id=None,
+                request_id=request_id,
                 action="restart",
-                parameter={"position": position, "RID": requestID},
+                parameter={"position": position, "RID": new_request_id},
                 queue=target_queue,
             ),
         )
-        return requestID
+        return new_request_id
 
     def add_queue_lock(self, queue: str, reason: str, lock_id: str) -> None:
         """
@@ -299,6 +305,25 @@ class ScanManager:
                 cb=self._request_response_callback,
             )
             return update["response"]
+
+    def _get_request_id_from_storage(self) -> str | None:
+        """Helper method to get the request ID from the current queue storage."""
+        queue_info = self.scan_storage.current_scan_info
+        if queue_info is not None and queue_info.request_blocks:
+            # Note: It doesn't matter which request id we take if there
+            # are multiple as we can anyway only abort an entire queue item
+            # on the server side, so we just take the first one
+            return queue_info.request_blocks[0].RID
+        return None
+
+    def _resolve_request_id(self, request_id: str | None = None) -> str | None:
+        """Resolve a request id for queue modifications."""
+        if request_id is not None:
+            return request_id
+        context = active_request_context.get()
+        if context is not None:
+            return context.request_id
+        return self._get_request_id_from_storage()
 
     @staticmethod
     def _request_response_callback(msg, update):

--- a/bec_lib/bec_lib/scan_manager.py
+++ b/bec_lib/bec_lib/scan_manager.py
@@ -92,75 +92,95 @@ class ScanManager:
             messages.ScanQueueModificationMessage(scan_id=scan_id, action=action, parameter={}),
         )
 
-    def request_scan_abortion(self, scan_id=None):
+    def request_scan_abortion(self, scan_id=None, request_id: str | None = None):
         """request a scan abortion
 
         Args:
             scan_id (str, optional): ScanID. Defaults to None.
+            request_id (str, optional): Request ID. Used when no scan ID exists yet.
 
         """
-        if scan_id is None:
+        if scan_id is None and request_id is None:
             scan_id = self.scan_storage.current_scan_id
         logger.info("Requesting scan abortion")
         target_queue = self.get_default_scan_queue()
         self.connector.send(
             MessageEndpoints.scan_queue_modification_request(),
             messages.ScanQueueModificationMessage(
-                scan_id=scan_id, action="abort", parameter={}, queue=target_queue
+                scan_id=scan_id,
+                request_id=request_id,
+                action="abort",
+                parameter={},
+                queue=target_queue,
             ),
         )
 
-    def request_scan_halt(self, scan_id=None):
+    def request_scan_halt(self, scan_id=None, request_id: str | None = None):
         """request a scan halt
 
         Args:
             scan_id (str, optional): ScanID. Defaults to None.
+            request_id (str, optional): Request ID. Used when no scan ID exists yet.
 
         """
-        if scan_id is None:
+        if scan_id is None and request_id is None:
             scan_id = self.scan_storage.current_scan_id
         target_queue = self.get_default_scan_queue()
         logger.info("Requesting scan halt")
         self.connector.send(
             MessageEndpoints.scan_queue_modification_request(),
             messages.ScanQueueModificationMessage(
-                scan_id=scan_id, action="halt", parameter={}, queue=target_queue
+                scan_id=scan_id,
+                request_id=request_id,
+                action="halt",
+                parameter={},
+                queue=target_queue,
             ),
         )
 
-    def request_set_completed(self, scan_id=None):
+    def request_set_completed(self, scan_id=None, request_id: str | None = None):
         """request to set a scan as completed
 
         Args:
             scan_id (str, optional): ScanID. Defaults to None.
+            request_id (str, optional): Request ID. Used when no scan ID exists yet.
 
         """
-        if scan_id is None:
+        if scan_id is None and request_id is None:
             scan_id = self.scan_storage.current_scan_id
         logger.info("Requesting to set scan as completed")
         target_queue = self.get_default_scan_queue()
         self.connector.send(
             MessageEndpoints.scan_queue_modification_request(),
             messages.ScanQueueModificationMessage(
-                scan_id=scan_id, action="user_completed", parameter={}, queue=target_queue
+                scan_id=scan_id,
+                request_id=request_id,
+                action="user_completed",
+                parameter={},
+                queue=target_queue,
             ),
         )
 
-    def request_scan_continuation(self, scan_id=None):
+    def request_scan_continuation(self, scan_id=None, request_id: str | None = None):
         """request a scan continuation
 
         Args:
             scan_id (str, optional): ScanID. Defaults to None.
+            request_id (str, optional): Request ID. Used when no scan ID exists yet.
 
         """
-        if scan_id is None:
+        if scan_id is None and request_id is None:
             scan_id = self.scan_storage.current_scan_id
         logger.info("Requesting scan continuation")
         target_queue = self.get_default_scan_queue()
         self.connector.send(
             MessageEndpoints.scan_queue_modification_request(),
             messages.ScanQueueModificationMessage(
-                scan_id=scan_id, action="continue", parameter={}, queue=target_queue
+                scan_id=scan_id,
+                request_id=request_id,
+                action="continue",
+                parameter={},
+                queue=target_queue,
             ),
         )
 

--- a/bec_lib/bec_lib/scan_report.py
+++ b/bec_lib/bec_lib/scan_report.py
@@ -165,6 +165,8 @@ class ScanReport:
         """
         if self.request is None:
             raise ValueError("Request is not set. Cannot cancel the scan.")
+        if self._client is None:
+            raise ValueError("Client is not set. Cannot cancel the scan.")
         scan_type = self.request.request.content["scan_type"]
         if scan_type == "mv":
             motors = list(self.request.request.parameter["args"].keys())
@@ -179,11 +181,8 @@ class ScanReport:
                         f"Stopping error details: {''.join(traceback.format_exception(e, limit=5)[:-1])}"
                     )
         else:
-            if self.request.scan and self.request.scan.scan_id:
-                scan_id = self.request.scan.scan_id
-            else:
-                scan_id = None
-            self._client.queue.request_scan_abortion(scan_id)
+            request_id = self.request.requestID
+            self._client.queue.request_scan_abortion(request_id=request_id)
         return self
 
     def _check_timeout(self, timeout: float | None = None, elapsed_time: float = 0) -> None:

--- a/bec_lib/bec_lib/scan_report.py
+++ b/bec_lib/bec_lib/scan_report.py
@@ -249,7 +249,7 @@ class ScanReport:
         while True:
             if conditions_are_met():
                 break
-            if self.status == "STOPPED":
+            if self.status in ["STOPPED", "CANCELLED"]:
                 raise ScanAbortion
             self._client.callbacks.poll()
             time.sleep(sleep_time)

--- a/bec_lib/tests/test_bec_messages.py
+++ b/bec_lib/tests/test_bec_messages.py
@@ -73,7 +73,7 @@ def test_bundled_message():
 
 def test_ScanQueueModificationMessage():
     msg = messages.ScanQueueModificationMessage(
-        scan_id="1234", action="halt", parameter={"RID": "1234"}
+        request_id="1234", action="halt", parameter={"RID": "1234"}
     )
     res = MsgpackSerialization.dumps(msg)
     res_loaded = MsgpackSerialization.loads(res)
@@ -83,7 +83,7 @@ def test_ScanQueueModificationMessage():
 def test_ScanQueueModificationMessage_with_wrong_action_returns_None():
     with pytest.raises(pydantic.ValidationError):
         messages.ScanQueueModificationMessage(
-            scan_id="1234", action="wrong_action", parameter={"RID": "1234"}
+            request_id="1234", action="wrong_action", parameter={"RID": "1234"}
         )
 
 

--- a/bec_lib/tests/test_scan_manager.py
+++ b/bec_lib/tests/test_scan_manager.py
@@ -9,6 +9,7 @@ from typeguard import TypeCheckError
 from bec_lib import messages
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.redis_connector import MessageObject
+from bec_lib.request_context import ActiveRequestContext, active_request_context
 from bec_lib.scan_manager import ScanManager
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -80,31 +81,42 @@ def test_scan_manager_next_dataset_number_setter(scan_manager):
 
 
 def test_scan_manager_request_scan_abortion(scan_manager):
-    scan_manager.request_scan_abortion("scan_id")
+    scan_manager.request_scan_abortion("request-id")
     scan_manager.connector.send.assert_called_once_with(
         MessageEndpoints.scan_queue_modification_request(),
         messages.ScanQueueModificationMessage(
-            scan_id="scan_id", request_id=None, action="abort", parameter={}
+            scan_id=None, request_id="request-id", action="abort", parameter={}
         ),
     )
 
 
 @pytest.mark.parametrize("scan_id", [None, "scan_id", ["scan_id"], [None]])
 def test_scan_manager_request_scan_abortion_scan_id(scan_manager, scan_id):
-
     class ScanStorage:
-        current_scan_info = {"scan_id": scan_id}
-
-        @property
-        def current_scan_id(self):
-            return self.current_scan_info["scan_id"]
+        current_scan_info = messages.QueueInfoEntry(
+            queue_id="queue-id",
+            scan_id=["scan_id"],
+            is_scan=[True],
+            request_blocks=[
+                messages.RequestBlock(
+                    msg=messages.ScanQueueMessage(scan_type="mv", parameter={}),
+                    RID="request-id",
+                    readout_priority={},
+                    is_scan=True,
+                    scan_number=1,
+                    scan_id="scan_id",
+                )
+            ],
+            scan_number=[1],
+            status="RUNNING",
+        )
 
     scan_manager.scan_storage = ScanStorage()
-    scan_manager.request_scan_abortion()
+    scan_manager.request_scan_abortion(scan_id=scan_id)
     scan_manager.connector.send.assert_called_once_with(
         MessageEndpoints.scan_queue_modification_request(),
         messages.ScanQueueModificationMessage(
-            scan_id=scan_id, request_id=None, action="abort", parameter={}
+            scan_id=None, request_id="request-id", action="abort", parameter={}
         ),
     )
 
@@ -120,61 +132,146 @@ def test_scan_manager_request_scan_abortion_request_id(scan_manager):
 
 
 def test_scan_manager_request_scan_halt(scan_manager):
-    scan_manager.request_scan_halt("scan_id")
+    scan_manager.request_scan_halt("request-id")
     scan_manager.connector.send.assert_called_once_with(
         MessageEndpoints.scan_queue_modification_request(),
         messages.ScanQueueModificationMessage(
-            scan_id="scan_id", request_id=None, action="halt", parameter={}
+            scan_id=None, request_id="request-id", action="halt", parameter={}
         ),
     )
 
 
 @pytest.mark.parametrize("scan_id", [None, "scan_id", ["scan_id"], [None]])
 def test_scan_manager_request_scan_halt_scan_id(scan_manager, scan_id):
-
     class ScanStorage:
-        current_scan_info = {"scan_id": scan_id}
-
-        @property
-        def current_scan_id(self):
-            return self.current_scan_info["scan_id"]
+        current_scan_info = messages.QueueInfoEntry(
+            queue_id="queue-id",
+            scan_id=["scan_id"],
+            is_scan=[True],
+            request_blocks=[
+                messages.RequestBlock(
+                    msg=messages.ScanQueueMessage(scan_type="mv", parameter={}),
+                    RID="request-id",
+                    readout_priority={},
+                    is_scan=True,
+                    scan_number=1,
+                    scan_id="scan_id",
+                )
+            ],
+            scan_number=[1],
+            status="RUNNING",
+        )
 
     scan_manager.scan_storage = ScanStorage()
     scan_manager.request_scan_halt()
     scan_manager.connector.send.assert_called_once_with(
         MessageEndpoints.scan_queue_modification_request(),
         messages.ScanQueueModificationMessage(
-            scan_id=scan_id, request_id=None, action="halt", parameter={}
+            scan_id=None, request_id="request-id", action="halt", parameter={}
         ),
     )
 
 
 def test_scan_manager_request_scan_continuation(scan_manager):
-    scan_manager.request_scan_continuation("scan_id")
+    scan_manager.request_scan_continuation("request-id")
     scan_manager.connector.send.assert_called_once_with(
         MessageEndpoints.scan_queue_modification_request(),
         messages.ScanQueueModificationMessage(
-            scan_id="scan_id", request_id=None, action="continue", parameter={}
+            scan_id=None, request_id="request-id", action="continue", parameter={}
+        ),
+    )
+
+
+def test_scan_manager_request_scan_interruption_uses_request_id(scan_manager):
+    class ScanStorage:
+        current_scan_info = messages.QueueInfoEntry(
+            queue_id="queue-id",
+            scan_id=["scan_id"],
+            is_scan=[True],
+            request_blocks=[
+                messages.RequestBlock(
+                    msg=messages.ScanQueueMessage(scan_type="mv", parameter={}),
+                    RID="request-id",
+                    readout_priority={},
+                    is_scan=True,
+                    scan_number=1,
+                    scan_id="scan_id",
+                )
+            ],
+            scan_number=[1],
+            status="RUNNING",
+        )
+
+        @property
+        def current_scan_id(self):
+            return self.current_scan_info.scan_id
+
+    scan_manager.scan_storage = ScanStorage()
+    scan_manager.request_scan_interruption(deferred_pause=False)
+    scan_manager.connector.send.assert_called_once_with(
+        MessageEndpoints.scan_queue_modification_request(),
+        messages.ScanQueueModificationMessage(
+            scan_id=None, request_id="request-id", action="pause", parameter={}
+        ),
+    )
+
+
+def test_scan_manager_request_scan_restart_uses_request_id(scan_manager):
+    scan_manager.request_scan_restart(request_id="request-id", new_request_id="new-request-id")
+    scan_manager.connector.send.assert_called_once_with(
+        MessageEndpoints.scan_queue_modification_request(),
+        messages.ScanQueueModificationMessage(
+            scan_id=None,
+            request_id="request-id",
+            action="restart",
+            parameter={"position": "replace", "RID": "new-request-id"},
+            queue="primary",
+        ),
+    )
+
+
+def test_scan_manager_request_scan_abortion_uses_context_request_id(scan_manager):
+    token = active_request_context.set(ActiveRequestContext(request_id="request-id"))
+    try:
+        scan_manager.request_scan_abortion()
+    finally:
+        active_request_context.reset(token)
+
+    scan_manager.connector.send.assert_called_once_with(
+        MessageEndpoints.scan_queue_modification_request(),
+        messages.ScanQueueModificationMessage(
+            scan_id=None, request_id="request-id", action="abort", parameter={}, queue="primary"
         ),
     )
 
 
 @pytest.mark.parametrize("scan_id", [None, "scan_id", ["scan_id"], [None]])
 def test_scan_manager_request_scan_continuation_scan_id(scan_manager, scan_id):
-
     class ScanStorage:
-        current_scan_info = {"scan_id": scan_id}
-
-        @property
-        def current_scan_id(self):
-            return self.current_scan_info["scan_id"]
+        current_scan_info = messages.QueueInfoEntry(
+            queue_id="queue-id",
+            scan_id=["scan_id"],
+            is_scan=[True],
+            request_blocks=[
+                messages.RequestBlock(
+                    msg=messages.ScanQueueMessage(scan_type="mv", parameter={}),
+                    RID="request-id",
+                    readout_priority={},
+                    is_scan=True,
+                    scan_number=1,
+                    scan_id="scan_id",
+                )
+            ],
+            scan_number=[1],
+            status="RUNNING",
+        )
 
     scan_manager.scan_storage = ScanStorage()
-    scan_manager.request_scan_continuation()
+    scan_manager.request_scan_continuation(scan_id=scan_id)
     scan_manager.connector.send.assert_called_once_with(
         MessageEndpoints.scan_queue_modification_request(),
         messages.ScanQueueModificationMessage(
-            scan_id=scan_id, request_id=None, action="continue", parameter={}
+            scan_id=None, request_id="request-id", action="continue", parameter={}
         ),
     )
 
@@ -276,30 +373,41 @@ def test_scan_manager_add_scan_to_queue_schedule(scan_manager_with_fakeredis):
 
 
 def test_scan_manager_request_set_completed(scan_manager):
-    scan_manager.request_set_completed("scan_id")
+    scan_manager.request_set_completed("request-id")
     scan_manager.connector.send.assert_called_once_with(
         MessageEndpoints.scan_queue_modification_request(),
         messages.ScanQueueModificationMessage(
-            scan_id="scan_id", request_id=None, action="user_completed", parameter={}
+            scan_id=None, request_id="request-id", action="user_completed", parameter={}
         ),
     )
 
 
 def test_scan_manager_request_set_completed_scan_id(scan_manager):
-
     class ScanStorage:
-        current_scan_info = {"scan_id": "current_scan_id"}
-
-        @property
-        def current_scan_id(self):
-            return self.current_scan_info["scan_id"]
+        current_scan_info = messages.QueueInfoEntry(
+            queue_id="queue-id",
+            scan_id=["current_scan_id"],
+            is_scan=[True],
+            request_blocks=[
+                messages.RequestBlock(
+                    msg=messages.ScanQueueMessage(scan_type="mv", parameter={}),
+                    RID="request-id",
+                    readout_priority={},
+                    is_scan=True,
+                    scan_number=1,
+                    scan_id="current_scan_id",
+                )
+            ],
+            scan_number=[1],
+            status="RUNNING",
+        )
 
     scan_manager.scan_storage = ScanStorage()
     scan_manager.request_set_completed()
     scan_manager.connector.send.assert_called_once_with(
         MessageEndpoints.scan_queue_modification_request(),
         messages.ScanQueueModificationMessage(
-            scan_id="current_scan_id", request_id=None, action="user_completed", parameter={}
+            scan_id=None, request_id="request-id", action="user_completed", parameter={}
         ),
     )
 

--- a/bec_lib/tests/test_scan_manager.py
+++ b/bec_lib/tests/test_scan_manager.py
@@ -83,7 +83,9 @@ def test_scan_manager_request_scan_abortion(scan_manager):
     scan_manager.request_scan_abortion("scan_id")
     scan_manager.connector.send.assert_called_once_with(
         MessageEndpoints.scan_queue_modification_request(),
-        messages.ScanQueueModificationMessage(scan_id="scan_id", action="abort", parameter={}),
+        messages.ScanQueueModificationMessage(
+            scan_id="scan_id", request_id=None, action="abort", parameter={}
+        ),
     )
 
 
@@ -101,7 +103,19 @@ def test_scan_manager_request_scan_abortion_scan_id(scan_manager, scan_id):
     scan_manager.request_scan_abortion()
     scan_manager.connector.send.assert_called_once_with(
         MessageEndpoints.scan_queue_modification_request(),
-        messages.ScanQueueModificationMessage(scan_id=scan_id, action="abort", parameter={}),
+        messages.ScanQueueModificationMessage(
+            scan_id=scan_id, request_id=None, action="abort", parameter={}
+        ),
+    )
+
+
+def test_scan_manager_request_scan_abortion_request_id(scan_manager):
+    scan_manager.request_scan_abortion(request_id="request-id")
+    scan_manager.connector.send.assert_called_once_with(
+        MessageEndpoints.scan_queue_modification_request(),
+        messages.ScanQueueModificationMessage(
+            scan_id=None, request_id="request-id", action="abort", parameter={}
+        ),
     )
 
 
@@ -109,7 +123,9 @@ def test_scan_manager_request_scan_halt(scan_manager):
     scan_manager.request_scan_halt("scan_id")
     scan_manager.connector.send.assert_called_once_with(
         MessageEndpoints.scan_queue_modification_request(),
-        messages.ScanQueueModificationMessage(scan_id="scan_id", action="halt", parameter={}),
+        messages.ScanQueueModificationMessage(
+            scan_id="scan_id", request_id=None, action="halt", parameter={}
+        ),
     )
 
 
@@ -127,7 +143,9 @@ def test_scan_manager_request_scan_halt_scan_id(scan_manager, scan_id):
     scan_manager.request_scan_halt()
     scan_manager.connector.send.assert_called_once_with(
         MessageEndpoints.scan_queue_modification_request(),
-        messages.ScanQueueModificationMessage(scan_id=scan_id, action="halt", parameter={}),
+        messages.ScanQueueModificationMessage(
+            scan_id=scan_id, request_id=None, action="halt", parameter={}
+        ),
     )
 
 
@@ -135,7 +153,9 @@ def test_scan_manager_request_scan_continuation(scan_manager):
     scan_manager.request_scan_continuation("scan_id")
     scan_manager.connector.send.assert_called_once_with(
         MessageEndpoints.scan_queue_modification_request(),
-        messages.ScanQueueModificationMessage(scan_id="scan_id", action="continue", parameter={}),
+        messages.ScanQueueModificationMessage(
+            scan_id="scan_id", request_id=None, action="continue", parameter={}
+        ),
     )
 
 
@@ -153,7 +173,9 @@ def test_scan_manager_request_scan_continuation_scan_id(scan_manager, scan_id):
     scan_manager.request_scan_continuation()
     scan_manager.connector.send.assert_called_once_with(
         MessageEndpoints.scan_queue_modification_request(),
-        messages.ScanQueueModificationMessage(scan_id=scan_id, action="continue", parameter={}),
+        messages.ScanQueueModificationMessage(
+            scan_id=scan_id, request_id=None, action="continue", parameter={}
+        ),
     )
 
 
@@ -258,7 +280,7 @@ def test_scan_manager_request_set_completed(scan_manager):
     scan_manager.connector.send.assert_called_once_with(
         MessageEndpoints.scan_queue_modification_request(),
         messages.ScanQueueModificationMessage(
-            scan_id="scan_id", action="user_completed", parameter={}
+            scan_id="scan_id", request_id=None, action="user_completed", parameter={}
         ),
     )
 
@@ -277,7 +299,7 @@ def test_scan_manager_request_set_completed_scan_id(scan_manager):
     scan_manager.connector.send.assert_called_once_with(
         MessageEndpoints.scan_queue_modification_request(),
         messages.ScanQueueModificationMessage(
-            scan_id="current_scan_id", action="user_completed", parameter={}
+            scan_id="current_scan_id", request_id=None, action="user_completed", parameter={}
         ),
     )
 
@@ -291,6 +313,7 @@ def test_scan_manager_add_queue_lock(scan_manager):
         MessageEndpoints.scan_queue_modification_request(),
         messages.ScanQueueModificationMessage(
             scan_id=None,
+            request_id=None,
             action="lock",
             parameter={"reason": "Testing lock", "identifier": "test_lock"},
             queue="primary",
@@ -307,6 +330,7 @@ def test_scan_manager_remove_queue_lock(scan_manager):
         MessageEndpoints.scan_queue_modification_request(),
         messages.ScanQueueModificationMessage(
             scan_id=None,
+            request_id=None,
             action="release_lock",
             parameter={"identifier": "test_lock"},
             queue="primary",

--- a/bec_lib/tests/test_scan_report.py
+++ b/bec_lib/tests/test_scan_report.py
@@ -101,6 +101,13 @@ def test_scan_report_wait_for_scan_raises(scan_report):
             scan_report._wait_scan(None, 0.1)
 
 
+def test_scan_report_wait_for_scan_raises_when_request_is_cancelled(scan_report):
+    scan_report.request.request = messages.ScanQueueMessage(scan_type="line_scan", parameter={})
+    scan_report.queue_item.status = "CANCELLED"
+    with pytest.raises(ScanAbortion):
+        scan_report._wait_scan(None, 0.1)
+
+
 def test_scan_report_aborts_on_ctrl_c(scan_report):
     scan_report.request.request = messages.ScanQueueMessage(
         scan_type="mv", parameter={"args": {"samx": [5]}}

--- a/bec_server/bec_server/scan_server/scan_queue.py
+++ b/bec_server/bec_server/scan_server/scan_queue.py
@@ -293,11 +293,20 @@ class QueueManager:
             parameter = scan_mod_msg.parameter
             queue = scan_mod_msg.queue
             getattr(self, f"set_{action}")(
-                scan_id=scan_mod_msg.scan_id, queue=queue, parameter=parameter
+                scan_id=scan_mod_msg.scan_id,
+                request_id=scan_mod_msg.request_id,
+                queue=queue,
+                parameter=parameter,
             )
 
     @requires_queue
-    def set_pause(self, scan_id=None, queue="primary", parameter: dict | None = None) -> None:
+    def set_pause(
+        self,
+        scan_id=None,
+        request_id: str | None = None,
+        queue="primary",
+        parameter: dict | None = None,
+    ) -> None:
         # pylint: disable=unused-argument
         """pause the queue and the currently running instruction queue"""
         que = self.queues[queue]
@@ -307,7 +316,11 @@ class QueueManager:
 
     @requires_queue
     def set_deferred_pause(
-        self, scan_id=None, queue="primary", parameter: dict | None = None
+        self,
+        scan_id=None,
+        request_id: str | None = None,
+        queue="primary",
+        parameter: dict | None = None,
     ) -> None:
         # pylint: disable=unused-argument
         """pause the queue but continue with the currently running instruction queue until the next checkpoint"""
@@ -318,7 +331,13 @@ class QueueManager:
                 que.worker_status = InstructionQueueStatus.DEFERRED_PAUSE
 
     @requires_queue
-    def set_continue(self, scan_id=None, queue="primary", parameter: dict | None = None) -> None:
+    def set_continue(
+        self,
+        scan_id=None,
+        request_id: str | None = None,
+        queue="primary",
+        parameter: dict | None = None,
+    ) -> None:
         # pylint: disable=unused-argument
         """continue with the currently scheduled queue and instruction queue"""
         self.queues[queue].status = ScanQueueStatus.RUNNING
@@ -329,6 +348,7 @@ class QueueManager:
     def set_abort(
         self,
         scan_id=None,
+        request_id: str | None = None,
         queue="primary",
         parameter: dict | None = None,
         exit_info: ExitInfoType | None = None,
@@ -347,6 +367,15 @@ class QueueManager:
         if exit_info is None:
             exit_info = ("aborted", "user" if user_call else "alarm")
         que = self.queues[queue]
+        if request_id is not None:
+            target_queue_item = self._get_queue_item_by_request_id(queue, request_id)
+            if target_queue_item is None:
+                logger.warning(f"Request {request_id} not found in queue {queue}")
+                return
+            if target_queue_item is not que.active_instruction_queue:
+                que.remove_queue_item_by_request_id(request_id)
+                return
+            scan_id = target_queue_item.scan_id
         if scan_id:
             if not isinstance(scan_id, list):
                 scan_id = [scan_id]
@@ -382,7 +411,12 @@ class QueueManager:
 
     @requires_queue
     def set_halt(
-        self, scan_id=None, queue="primary", parameter: dict | None = None, user_call: bool = True
+        self,
+        scan_id=None,
+        request_id: str | None = None,
+        queue="primary",
+        parameter: dict | None = None,
+        user_call: bool = True,
     ) -> None:
         """abort the scan and do not perform any cleanup routines"""
         exit_info = ("halted", "user" if user_call else "alarm")
@@ -392,20 +426,31 @@ class QueueManager:
                 instruction_queue.run_on_exception_hook = False
             else:
                 instruction_queue.return_to_start = False
-        self.set_abort(scan_id=scan_id, queue=queue, exit_info=exit_info)
+        self.set_abort(scan_id=scan_id, request_id=request_id, queue=queue, exit_info=exit_info)
 
     @requires_queue
     def set_user_completed(
-        self, scan_id=None, queue="primary", parameter: dict | None = None, user_call: bool = True
+        self,
+        scan_id=None,
+        request_id: str | None = None,
+        queue="primary",
+        parameter: dict | None = None,
+        user_call: bool = True,
     ) -> None:
         """mark the scan as user completed and perform cleanup routines"""
         exit_info = ("user_completed", "user" if user_call else "alarm")
         queue_state_prior_abort = self.queues[queue].status
-        self.set_abort(scan_id=scan_id, queue=queue, exit_info=exit_info)
+        self.set_abort(scan_id=scan_id, request_id=request_id, queue=queue, exit_info=exit_info)
         self.queues[queue].status = queue_state_prior_abort
 
     @requires_queue
-    def set_clear(self, scan_id=None, queue="primary", parameter: dict | None = None) -> None:
+    def set_clear(
+        self,
+        scan_id=None,
+        request_id: str | None = None,
+        queue="primary",
+        parameter: dict | None = None,
+    ) -> None:
         # pylint: disable=unused-argument
         """pause the queue and clear all its elements"""
         logger.info("clearing queue")
@@ -416,7 +461,13 @@ class QueueManager:
             que.clear()
 
     @requires_queue
-    def set_restart(self, scan_id=None, queue="primary", parameter: dict | None = None) -> None:
+    def set_restart(
+        self,
+        scan_id=None,
+        request_id: str | None = None,
+        queue="primary",
+        parameter: dict | None = None,
+    ) -> None:
         """abort and restart the currently running scan. The active scan will be aborted."""
         if not scan_id:
             scan_id = self._get_active_scan_id(queue)
@@ -469,7 +520,13 @@ class QueueManager:
         self.queues[queue].status = original_queue_status
 
     @requires_queue
-    def set_lock(self, scan_id=None, queue="primary", parameter: dict | None = None) -> None:
+    def set_lock(
+        self,
+        scan_id=None,
+        request_id: str | None = None,
+        queue="primary",
+        parameter: dict | None = None,
+    ) -> None:
         """
         Add a lock to the queue. The queue will not proceed until the lock is removed.
         """
@@ -487,7 +544,11 @@ class QueueManager:
 
     @requires_queue
     def set_release_lock(
-        self, scan_id=None, queue="primary", parameter: dict | None = None
+        self,
+        scan_id=None,
+        request_id: str | None = None,
+        queue="primary",
+        parameter: dict | None = None,
     ) -> None:
         """
         Remove a lock from the queue. The queue will proceed if no more locks are present.
@@ -500,6 +561,15 @@ class QueueManager:
         self.remove_queue_lock(
             queue_name=queue, lock=messages.ScanQueueLock(reason="", identifier=identifier)
         )
+
+    def _get_queue_item_by_request_id(
+        self, queue: str, request_id: str
+    ) -> InstructionQueueItem | DirectInstructionQueueItem | None:
+        for instruction_queue in self.queues[queue].queue:
+            request_blocks = instruction_queue.describe().request_blocks
+            if any(request_block.RID == request_id for request_block in request_blocks):
+                return instruction_queue
+        return None
 
     def _get_active_scan_id(self, queue):
         if len(self.queues[queue].queue) == 0:
@@ -723,6 +793,19 @@ class ScanQueue:
         remove = []
         for queue in self.queue:
             if len(set(scan_id) & set(queue.scan_id)) > 0:
+                remove.append(queue)
+        if remove:
+            for rmv in remove:
+                self.queue.remove(rmv)
+
+    def remove_queue_item_by_request_id(self, request_id: str) -> None:
+        """remove a queue item from the queue by request ID"""
+        if not request_id:
+            return
+        remove = []
+        for queue in self.queue:
+            request_blocks = queue.describe().request_blocks
+            if any(request_block.RID == request_id for request_block in request_blocks):
                 remove.append(queue)
         if remove:
             for rmv in remove:

--- a/bec_server/bec_server/scan_server/scan_queue.py
+++ b/bec_server/bec_server/scan_server/scan_queue.py
@@ -55,6 +55,7 @@ class InstructionQueueStatus(Enum):
     DEFERRED_PAUSE = 3
     RUNNING = 4
     COMPLETED = 5
+    CANCELLED = 6
 
 
 class ScanQueueStatus(Enum):
@@ -373,6 +374,7 @@ class QueueManager:
                 logger.warning(f"Request {request_id} not found in queue {queue}")
                 return
             if target_queue_item is not que.active_instruction_queue:
+                self._cancel_queue_item(target_queue_item, queue=queue)
                 que.remove_queue_item_by_request_id(request_id)
                 return
             scan_id = target_queue_item.scan_id
@@ -384,6 +386,16 @@ class QueueManager:
                 current_scan_id = [current_scan_id]
             if len(set(scan_id) & set(current_scan_id)) == 0:
                 # The scan to abort is not the currently running scan, so we just remove it from the queue
+                target_queue_item = next(
+                    (
+                        instruction_queue
+                        for instruction_queue in self.queues[queue].queue
+                        if len(set(scan_id) & set(instruction_queue.scan_id)) > 0
+                    ),
+                    None,
+                )
+                if target_queue_item is not None:
+                    self._cancel_queue_item(target_queue_item, queue=queue)
                 self.queues[queue].remove_queue_item(scan_id)
                 return
 
@@ -408,6 +420,22 @@ class QueueManager:
             else:
                 stop_id = instruction_queue.scan_id
             self.stop_all_devices(stop_id=stop_id)
+
+    def _cancel_queue_item(
+        self, target_queue_item: InstructionQueueItem | DirectInstructionQueueItem, queue: str
+    ) -> None:
+        """
+        Mark a pending queue item as cancelled before removing it from the queue.
+        This is to allow clients to recognize that the scan was cancelled and did not just
+        disappear from the queue.
+
+        Args:
+            target_queue_item (InstructionQueueItem | DirectInstructionQueueItem): The queue item to cancel.
+            queue (str): The name of the queue the item is in, e.g. "primary".
+        """
+        del queue  # queue kept for signature symmetry with callers
+        target_queue_item._status = InstructionQueueStatus.CANCELLED
+        self.send_queue_status()
 
     @requires_queue
     def set_halt(

--- a/bec_server/tests/tests_scan_server/test_scan_server_queue.py
+++ b/bec_server/tests/tests_scan_server/test_scan_server_queue.py
@@ -653,6 +653,18 @@ def test_set_abort_with_request_id_not_active(queuemanager_mock):
     assert len(scan_queue.queue) == 1
     remaining = scan_queue.queue[0].describe().request_blocks[0]
     assert remaining.RID == "rid-1"
+    cancelled_snapshots = [
+        sent["msg"]
+        for sent in queue_manager.connector.message_sent
+        if sent.get("queue") == MessageEndpoints.scan_queue_status()
+    ]
+    assert any(
+        any(
+            queue_item.request_blocks[0].RID == "rid-2" and queue_item.status == "CANCELLED"
+            for queue_item in snapshot.queue["primary"].info
+        )
+        for snapshot in cancelled_snapshots
+    )
 
 
 @pytest.mark.timeout(5)

--- a/bec_server/tests/tests_scan_server/test_scan_server_queue.py
+++ b/bec_server/tests/tests_scan_server/test_scan_server_queue.py
@@ -209,7 +209,9 @@ def test_scan_interception_halt(queuemanager_mock):
     )
     with mock.patch.object(queue_manager, "set_halt") as set_halt:
         queue_manager.scan_interception(msg)
-        set_halt.assert_called_once_with(scan_id="dummy", queue="secondary", parameter={})
+        set_halt.assert_called_once_with(
+            scan_id="dummy", request_id=None, queue="secondary", parameter={}
+        )
 
 
 def test_set_halt(queuemanager_mock):
@@ -217,7 +219,7 @@ def test_set_halt(queuemanager_mock):
     with mock.patch.object(queue_manager, "set_abort") as set_abort:
         queue_manager.set_halt(scan_id="dummy", parameter={})
         set_abort.assert_called_once_with(
-            scan_id="dummy", queue="primary", exit_info=("halted", "user")
+            scan_id="dummy", request_id=None, queue="primary", exit_info=("halted", "user")
         )
 
 
@@ -231,7 +233,7 @@ def test_set_halt_disables_return_to_start(queuemanager_mock):
         queue = queue_manager.queues["primary"].active_instruction_queue
         queue_manager.set_halt(scan_id="dummy", parameter={})
         set_abort.assert_called_once_with(
-            scan_id="dummy", queue="primary", exit_info=("halted", "user")
+            scan_id="dummy", request_id=None, queue="primary", exit_info=("halted", "user")
         )
         assert queue.return_to_start is False
 
@@ -246,7 +248,7 @@ def test_set_halt_disables_return_to_start_for_direct_instruction_queue(queueman
         queue = queue_manager.queues["primary"].active_instruction_queue
         queue_manager.set_halt(scan_id="dummy", parameter={})
         set_abort.assert_called_once_with(
-            scan_id="dummy", queue="primary", exit_info=("halted", "user")
+            scan_id="dummy", request_id=None, queue="primary", exit_info=("halted", "user")
         )
         assert queue.run_on_exception_hook is False
 
@@ -624,6 +626,36 @@ def test_set_abort_with_scan_id_not_active(queuemanager_mock):
 
 
 @pytest.mark.timeout(5)
+def test_set_abort_with_request_id_not_active(queuemanager_mock):
+    queue_manager = queuemanager_mock()
+    queue_manager.connector.message_sent = []
+    msg1 = messages.ScanQueueMessage(
+        scan_type="mv",
+        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        queue="primary",
+        metadata={"RID": "rid-1"},
+    )
+    msg2 = messages.ScanQueueMessage(
+        scan_type="mv",
+        parameter={"args": {"samx": (2,)}, "kwargs": {}},
+        queue="primary",
+        metadata={"RID": "rid-2"},
+    )
+    queue_manager.add_to_queue(scan_queue="primary", msg=msg1)
+    queue_manager.add_to_queue(scan_queue="primary", msg=msg2)
+    scan_queue = queue_manager.queues["primary"]
+    while scan_queue.scan_worker.current_instruction_queue_item is None:
+        time.sleep(0.1)
+
+    queue_manager.set_abort(request_id="rid-2", queue="primary")
+
+    assert queue_manager.queues["primary"].status == ScanQueueStatus.RUNNING
+    assert len(scan_queue.queue) == 1
+    remaining = scan_queue.queue[0].describe().request_blocks[0]
+    assert remaining.RID == "rid-1"
+
+
+@pytest.mark.timeout(5)
 def test_set_abort_with_wrong_scan_id(queuemanager_mock):
     queue_manager = queuemanager_mock()
     queue_manager.connector.message_sent = []
@@ -864,6 +896,30 @@ def test_remove_queue_item(queuemanager_mock):
     queue_manager.queues["primary"].queue[0].queue.request_blocks[0].scan_id = "random"
     queue_manager.queues["primary"].remove_queue_item(scan_id=["random"])
     assert len(queue_manager.queues["primary"].queue) == 0
+
+
+def test_remove_queue_item_by_request_id(queuemanager_mock):
+    queue_manager = queuemanager_mock()
+    msg1 = messages.ScanQueueMessage(
+        scan_type="mv",
+        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        queue="primary",
+        metadata={"RID": "rid-1"},
+    )
+    msg2 = messages.ScanQueueMessage(
+        scan_type="mv",
+        parameter={"args": {"samx": (2,)}, "kwargs": {}},
+        queue="primary",
+        metadata={"RID": "rid-2"},
+    )
+    queue_manager.add_to_queue(scan_queue="primary", msg=msg1)
+    queue_manager.add_to_queue(scan_queue="primary", msg=msg2)
+
+    queue_manager.queues["primary"].remove_queue_item_by_request_id("rid-2")
+
+    assert len(queue_manager.queues["primary"].queue) == 1
+    remaining = queue_manager.queues["primary"].queue[0].describe().request_blocks[0]
+    assert remaining.RID == "rid-1"
 
 
 def test_invalid_scan_specified_in_message(queuemanager_mock):


### PR DESCRIPTION
## Description

Pending requests were not properly removed from the queue. This PR fixes it by adding support for aborting element through their request ID. While this would normally not happen, or is at least very unlikely to ever be encountered by a user, the scan interlock exposed this faulty behavior: If the scan interlock is active, any request will remain pending. Therefore, if a user submits a new request and notices that the interlock is active and aborts it e.g with ctrl-c, the request would remain in the queue. 

## Type of Change

- Add support for scan modifications with request ID
- Extend ScanModificationMessage to support request ID
- Trigger aborts for pending requests on KeyboardInterrupt

## How to test

- Run unit tests
- Enable the scan interlock and move it to locked state. Submit a umv command through the cli and ctrl-c it. Check bec.queue to ensure that the element is properly removed from the queue.

## Additional Comments

The scan queue widget in BW is still only using the scan id so it will have the same problem. We should fix it asap.

