### PR TITLE
fix: initialize ready state in BeamlineStateManager

### DIFF
--- a/bec_lib/bec_lib/bl_state_manager.py
+++ b/bec_lib/bec_lib/bl_state_manager.py
@@ -111,10 +111,15 @@ class BeamlineStateManager:
         self._client = client
         self._connector = client.connector
         self._states: dict[str, BeamlineStateConfig] = {}
-        self._connector.register(
-            MessageEndpoints.available_beamline_states(), cb=self._on_state_update, from_start=True
-        )
         self._ready = False
+        if msg := self._connector.get_last(MessageEndpoints.available_beamline_states()):
+            self._on_state_update(msg)
+        else:
+            # No beamline-state stream exists yet: treat that as "ready with zero states".
+            self._ready = True
+        self._connector.register(
+            MessageEndpoints.available_beamline_states(), cb=self._on_state_update
+        )
 
     @property
     def ready(self) -> bool:

--- a/bec_lib/tests/test_beamline_states.py
+++ b/bec_lib/tests/test_beamline_states.py
@@ -205,9 +205,37 @@ class TestBeamlineStateManager:
         with mock.patch.object(connected_connector, "register") as register:
             BeamlineStateManager(client)
 
-        register.assert_called_once_with(
-            MessageEndpoints.available_beamline_states(), cb=mock.ANY, from_start=True
+        register.assert_called_once_with(MessageEndpoints.available_beamline_states(), cb=mock.ANY)
+
+    def test_manager_is_ready_when_no_state_update_exists(self, connected_connector):
+        client = mock.MagicMock()
+        client.connector = connected_connector
+
+        manager = BeamlineStateManager(client)
+
+        assert manager.ready is True
+        assert manager._states == {}
+
+    def test_manager_loads_existing_state_update_on_init(self, connected_connector):
+        config = messages.BeamlineStateConfig(
+            name="shutter_open",
+            title="Shutter Open",
+            state_type="ShutterState",
+            parameters={"name": "shutter_open", "title": "Shutter Open", "device": "samy"},
         )
+        connected_connector.xadd(
+            MessageEndpoints.available_beamline_states(),
+            {"data": messages.AvailableBeamlineStatesMessage(states=[config])},
+            max_size=1,
+        )
+        client = mock.MagicMock()
+        client.connector = connected_connector
+
+        manager = BeamlineStateManager(client)
+
+        assert manager.ready is True
+        assert "shutter_open" in manager._states
+        assert isinstance(getattr(manager, "shutter_open"), BeamlineStateClientBase)
 
     def test_on_state_update_creates_client_attribute(self, state_manager):
         config = messages.BeamlineStateConfig(

--- a/bec_server/bec_server/actors/builtin_actor_manager.py
+++ b/bec_server/bec_server/actors/builtin_actor_manager.py
@@ -127,6 +127,10 @@ class BuiltinActorManager:
         state_names = [state.name for state in msg.states]
         for watched_state in self._current_watched_states():
             if watched_state not in state_names:
+                logger.info(
+                    "Removing watched interlock state because it is not in available beamline "
+                    f"states: {watched_state}"
+                )
                 self._modify_interlock_table(
                     {
                         "data": ScanInterlockModifyStateTableMessage(

--- a/bec_server/bec_server/actors/scan_interlock.py
+++ b/bec_server/bec_server/actors/scan_interlock.py
@@ -84,6 +84,10 @@ class ScanInterlockActor(BlStateActor):
     def some_mismatch_action(self, client: BECClient):
         if self.client.queue is None:
             return
+        logger.info(
+            f"{self.name} placing queue lock due to mismatched states: "
+            f"{self.mismatched_states}; cache={self.state_cache}; table={self.state_table}"
+        )
         self.client.queue.add_queue_lock(
             queue="primary",
             reason=f"Interlock for beamline states: {self.mismatched_states}",
@@ -100,6 +104,10 @@ class ScanInterlockActor(BlStateActor):
         if (q := self.client.queue) is not None:
             if (curr_q := q.queue_storage.current_scan_queue) is not None:
                 if (primary := curr_q.get("primary")) is not None and primary.locks != []:
+                    logger.info(
+                        f"{self.name} removing queue lock if present; "
+                        f"queue_locks={primary.locks}; cache={self.state_cache}; table={self.state_table}"
+                    )
                     self.client.queue.remove_queue_lock(queue="primary", lock_id=self._LOCK_ID)
 
     def run(self):

--- a/bec_server/bec_server/scan_server/scan_server.py
+++ b/bec_server/bec_server/scan_server/scan_server.py
@@ -43,9 +43,9 @@ class ScanServer(BECService):
             use_subprocess_proc_worker=config.model.procedures.use_subprocess_worker
         )
         self._start_actor_managers()
-        self.status = messages.BECStatus.RUNNING
         self.beamline_states = None
         self._start_beamline_state_manager()
+        self.status = messages.BECStatus.RUNNING
 
     def _start_device_manager(self):
         self.wait_for_service("DeviceServer")


### PR DESCRIPTION
## Description

* Fix a small bug in the beamline state manager that would leave the manager in a "not ready" state. 
* Add some more logging around the actors.
* Fix startup state handling: The scan server was reporting "ready" before the states were set up. 

