### PR TITLE
test: increase ramp-up time for delay device in test fixture

### DIFF
--- a/bec_ipython_client/tests/end-2-end/test_actors_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_actors_e2e.py
@@ -27,7 +27,7 @@ def bec_with_delay_device(bec_ipython_client_fixture):
     dev.ramp_up.max_val.put(400)
     dev.ramp_up.value.put(400)
     dev.ramp_up.delay.put(2)
-    dev.ramp_up.rampup_time.put(2)
+    dev.ramp_up.rampup_time.put(8)
     yield bec, dev.ramp_up
     dev.ramp_up.stop()
 

--- a/bec_lib/bec_lib/alarm_handler.py
+++ b/bec_lib/bec_lib/alarm_handler.py
@@ -116,7 +116,7 @@ class AlarmHandler:
         """
         severity = Alarms(msg.severity)
         alarm = AlarmBase(alarm=msg, severity=severity, handled=False)
-        if alarm in self.alarms_stack:
+        if alarm in self.alarms_stack or alarm in self._raised_alarms:
             logger.debug(f"Alarm already in stack: {alarm}")
             return
         if severity > Alarms.MINOR:

--- a/bec_lib/tests/test_alarm_handler.py
+++ b/bec_lib/tests/test_alarm_handler.py
@@ -66,3 +66,22 @@ def test_raise_alarms_marks_alarm_handled():
 
     assert exc_info.value.handled is True
     assert handler.get_unhandled_alarms() == []
+
+
+def test_add_alarm_ignores_duplicate_raised_alarm():
+    error_info = messages.ErrorInfo(
+        error_message="This is a test alarm message for testing purposes.",
+        compact_error_message="Compact alarm content",
+        exception_type="TestAlarmType",
+        device="TestDevice",
+    )
+    alarm_msg = messages.AlarmMessage(severity=Alarms.MAJOR, info=error_info)
+    handler = AlarmHandler(connector=None)
+    handler.add_alarm(alarm_msg)
+
+    with pytest.raises(AlarmBase):
+        handler.raise_alarms()
+
+    handler.add_alarm(alarm_msg)
+
+    assert handler.get_unhandled_alarms() == []


### PR DESCRIPTION
## Description

The backend logs suggest that everything is working correctly: The actor kicks in, locks the queue and the device recovers, leading to an unlock. The client in the e2e test seems to receive the data too late, i.e. when the device has already recovered. I suggest to increase the rampup time to give it more time. 

While testing, I also found and fixed a bug in the alarm handler. 


