### PR TITLE
feat(scans): add scan hooks as abstractmethods

### DIFF
--- a/bec_server/bec_server/scan_server/scans/scan_base.py
+++ b/bec_server/bec_server/scan_server/scans/scan_base.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import enum
 import threading
+from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Annotated, Type
 
@@ -21,7 +22,7 @@ from bec_lib.redis_connector import RedisConnector
 from bec_server.scan_server.instruction_handler import InstructionHandler
 from bec_server.scan_server.scans.scan_actions import ScanActions
 from bec_server.scan_server.scans.scan_components import ScanComponents
-from bec_server.scan_server.scans.scan_modifier import ScanModifier, get_scan_hooks_impl
+from bec_server.scan_server.scans.scan_modifier import ScanModifier, get_scan_hooks_impl, scan_hook
 
 Units = pint.UnitRegistry()
 
@@ -150,7 +151,7 @@ class ScanInfo(BaseModel):
     model_config = ConfigDict(validate_assignment=True, arbitrary_types_allowed=True)
 
 
-class ScanBase:
+class ScanBase(ABC):
     scan_type = ScanType.SOFTWARE_TRIGGERED
     scan_name = "_v4_base_scan"
     arg_input = {}
@@ -263,3 +264,53 @@ class ScanBase:
                 setattr(self.scan_info, key, value)
             else:
                 self.scan_info.additional_scan_parameters[key] = value
+
+    @scan_hook
+    @abstractmethod
+    def prepare_scan(self):
+        """Prepare scan metadata and state before opening the scan."""
+
+    @scan_hook
+    @abstractmethod
+    def open_scan(self):
+        """Open the scan and publish the initial scan state."""
+
+    @scan_hook
+    @abstractmethod
+    def stage(self):
+        """Stage devices before the scan starts."""
+
+    @scan_hook
+    @abstractmethod
+    def pre_scan(self):
+        """Run pre-scan device preparation immediately before scan execution."""
+
+    @scan_hook
+    @abstractmethod
+    def scan_core(self):
+        """Execute the main scan procedure."""
+
+    @scan_hook
+    @abstractmethod
+    def at_each_point(self, *args, **kwargs):
+        """Run per-point scan logic when the scan iterates over points."""
+
+    @scan_hook
+    @abstractmethod
+    def post_scan(self):
+        """Run completion logic after the scan core finishes."""
+
+    @scan_hook
+    @abstractmethod
+    def unstage(self):
+        """Unstage devices after scan completion."""
+
+    @scan_hook
+    @abstractmethod
+    def close_scan(self):
+        """Close the scan and finalize scan bookkeeping."""
+
+    @scan_hook
+    @abstractmethod
+    def on_exception(self, exception: Exception):
+        """Handle scan exceptions and perform emergency cleanup."""

--- a/bec_server/bec_server/scan_server/tests/utils.py
+++ b/bec_server/bec_server/scan_server/tests/utils.py
@@ -1,13 +1,47 @@
 from bec_lib.messages import BECStatus
-from bec_lib.redis_connector import RedisConnector
 from bec_lib.service_config import ServiceConfig
 from bec_lib.tests.utils import ConnectorMock
 from bec_server.device_server.tests.utils import DMMock
 from bec_server.scan_server.scan_server import ScanServer
 from bec_server.scan_server.scan_worker import InstructionQueueStatus
+from bec_server.scan_server.scans.scan_base import ScanBase
 
 # pylint: disable=missing-function-docstring
 # pylint: disable=protected-access
+
+
+class NoopScan(ScanBase):
+    __doc__ = None
+
+    def prepare_scan(self):
+        pass
+
+    def open_scan(self):
+        pass
+
+    def stage(self):
+        pass
+
+    def pre_scan(self):
+        pass
+
+    def scan_core(self):
+        pass
+
+    def at_each_point(self, *args, **kwargs):
+        pass
+
+    def post_scan(self):
+        pass
+
+    def unstage(self):
+        pass
+
+    def close_scan(self):
+        pass
+
+    def on_exception(self, exception: Exception):
+        pass
 
 
 class WorkerMock:

--- a/bec_server/tests/tests_scan_server/scans_v4/test_scan_actions.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_scan_actions.py
@@ -13,9 +13,10 @@ from bec_lib.tests.utils import ConnectorMock
 from bec_server.scan_server.instruction_handler import InstructionHandler
 from bec_server.scan_server.scan_stubs import ScanStubStatus
 from bec_server.scan_server.scans.scan_base import ScanBase, ScanInfo
+from bec_server.scan_server.tests.utils import NoopScan
 
 
-class _TestScan(ScanBase):
+class _TestScan(NoopScan):
     scan_name = "_v4_test_scan"
     scan_type = None
 

--- a/bec_server/tests/tests_scan_server/test_scan_argument_modifier.py
+++ b/bec_server/tests/tests_scan_server/test_scan_argument_modifier.py
@@ -15,6 +15,7 @@ from bec_server.scan_server.scans.scan_argument_modifier import (
     scan_signature_with_modifiers,
 )
 from bec_server.scan_server.scans.scan_base import ScanBase
+from bec_server.scan_server.tests.utils import NoopScan
 
 
 def test_convert_annotation_wraps_plain_type_with_scan_argument():
@@ -43,7 +44,7 @@ def test_convert_annotation_returns_none_for_empty_annotation():
     assert _convert_annotation("_empty") is None
 
 
-class DummyScan(ScanBase):
+class DummyScan(NoopScan):
     scan_name = "dummy_scan"
 
     def __init__(self, value: float, relative: bool = True, **kwargs):
@@ -55,7 +56,7 @@ class DummyScan(ScanBase):
         self.relative = relative
 
 
-class GenericClassDocScan(ScanBase):
+class GenericClassDocScan(NoopScan):
     scan_name = "generic_class_doc_scan"
     __doc__ = ScanBase.__init__.__doc__
 

--- a/bec_server/tests/tests_scan_server/test_scan_assembler.py
+++ b/bec_server/tests/tests_scan_server/test_scan_assembler.py
@@ -12,7 +12,7 @@ from bec_server.scan_server.scan_assembler import ScanAssembler
 from bec_server.scan_server.scans import ScanArgType
 from bec_server.scan_server.scans.acquire import Acquire
 from bec_server.scan_server.scans.legacy_scans import FermatSpiralScan, LineScan, RequestBase
-from bec_server.scan_server.scans.scan_base import ScanBase as ScanBaseV4
+from bec_server.scan_server.tests.utils import NoopScan
 
 
 @pytest.fixture
@@ -40,7 +40,7 @@ class CustomScan2(RequestBase):
         pass
 
 
-class CustomDirectScan(ScanBaseV4):
+class CustomDirectScan(NoopScan):
     scan_name = "custom_direct_scan"
     arg_input = {"device": ScanArgType.DEVICE, "target": ScanArgType.FLOAT}
     arg_bundle_size = {"bundle": len(arg_input), "min": 1, "max": None}
@@ -51,7 +51,7 @@ class CustomDirectScan(ScanBaseV4):
         self.received_args = args
 
 
-class CustomFixedDirectScan(ScanBaseV4):
+class CustomFixedDirectScan(NoopScan):
     scan_name = "custom_fixed_direct_scan"
     is_scan = False
 
@@ -61,7 +61,7 @@ class CustomFixedDirectScan(ScanBaseV4):
         self.target = target
 
 
-class CustomBoundedDirectScan(ScanBaseV4):
+class CustomBoundedDirectScan(NoopScan):
     scan_name = "custom_bounded_direct_scan"
     is_scan = False
 
@@ -74,7 +74,7 @@ class CustomBoundedDirectScan(ScanBaseV4):
         self.value = value
 
 
-class CustomBundledBoundedDirectScan(ScanBaseV4):
+class CustomBundledBoundedDirectScan(NoopScan):
     scan_name = "custom_bundled_bounded_direct_scan"
     arg_input = {
         "device": ScanArgType.DEVICE,
@@ -94,7 +94,7 @@ class CustomBundledBoundedDirectScan(ScanBaseV4):
         self.scale = scale
 
 
-class CustomBundledScanWithDeviceKwarg(ScanBaseV4):
+class CustomBundledScanWithDeviceKwarg(NoopScan):
     scan_name = "custom_bundled_scan_with_device_kwarg"
     arg_input = {"device": ScanArgType.DEVICE, "target": ScanArgType.FLOAT}
     arg_bundle_size = {"bundle": len(arg_input), "min": 1, "max": None}
@@ -106,7 +106,7 @@ class CustomBundledScanWithDeviceKwarg(ScanBaseV4):
         self.monitor = monitor
 
 
-class DefaultOverrideDirectScan(ScanBaseV4):
+class DefaultOverrideDirectScan(NoopScan):
     scan_name = "default_override_direct_scan"
     is_scan = False
 
@@ -124,7 +124,7 @@ class DefaultOverrideModifier:
         return arguments, defaults
 
 
-class RelativeHiddenDirectScan(ScanBaseV4):
+class RelativeHiddenDirectScan(NoopScan):
     scan_name = "relative_hidden_direct_scan"
     is_scan = False
 
@@ -143,7 +143,7 @@ class RelativeHiddenModifier:
         return arguments, defaults
 
 
-class AdditionalParamsDirectScan(ScanBaseV4):
+class AdditionalParamsDirectScan(NoopScan):
     scan_name = "additional_params_direct_scan"
     is_scan = False
 

--- a/bec_server/tests/tests_scan_server/test_scan_server_queue.py
+++ b/bec_server/tests/tests_scan_server/test_scan_server_queue.py
@@ -22,9 +22,9 @@ from bec_server.scan_server.scan_queue import (
     ScanQueueStatus,
 )
 from bec_server.scan_server.scan_worker import ScanWorker
-from bec_server.scan_server.scans.scan_base import ScanBase as ScanBaseV4
 from bec_server.scan_server.scans.scan_base import ScanType
 from bec_server.scan_server.tests.fixtures import scan_server_mock
+from bec_server.scan_server.tests.utils import NoopScan
 
 # pylint: disable=missing-function-docstring
 # pylint: disable=protected-access
@@ -72,7 +72,7 @@ class InstructionQueueMock(InstructionQueueItem):
         self.queue.append(msg)
 
 
-class _DummyV4Scan(ScanBaseV4):
+class _DummyV4Scan(NoopScan):
     scan_name = "_v4_dummy_scan"
 
 

--- a/bec_server/tests/tests_scan_server/test_scan_server_scan_manager.py
+++ b/bec_server/tests/tests_scan_server/test_scan_server_scan_manager.py
@@ -10,7 +10,7 @@ from bec_lib.redis_connector import MessageObject
 from bec_lib.scan_args import ScanArgument
 from bec_server.scan_server.scan_manager import ScanManager
 from bec_server.scan_server.scans import ScanArgType
-from bec_server.scan_server.scans.scan_base import ScanBase
+from bec_server.scan_server.tests.utils import NoopScan
 
 
 @pytest.fixture
@@ -54,7 +54,7 @@ def test_scan_manager_convert_arg_input_does_not_mutate(scan_manager):
     assert arg_input == {"a": ScanArgType.FLOAT}
 
 
-class _GuiConfigScan(ScanBase):
+class _GuiConfigScan(NoopScan):
     scan_name = "gui_config_scan"
     arg_input = {}
     arg_bundle_size = {"bundle": 0, "min": None, "max": None}


### PR DESCRIPTION
## Description

This PR adds the scan hooks as abstractmethods to ScanBase (v4) to give us a better defined interface. There is no change of functionality. To simplify the test writing, I also added a Noop scan. 

## Definition of Done
- [x] Documentation is up-to-date.

