### PR TITLE
feat: add friendly errors to device server

### DIFF
--- a/bec_lib/bec_lib/messages.py
+++ b/bec_lib/bec_lib/messages.py
@@ -498,6 +498,28 @@ class RequestResponseMessage(BECMessage):
     message: str | dict | None = Field(default=None)
 
 
+DeviceInstructionAction = Literal[
+    "rpc",
+    "set",
+    "read",
+    "kickoff",
+    "complete",
+    "trigger",
+    "stage",
+    "unstage",
+    "pre_scan",
+    "wait",
+    "scan_report_instruction",
+    "open_scan",
+    "baseline_reading",
+    "close_scan",
+    "open_scan_def",
+    "close_scan_def",
+    "publish_data_as_read",
+    "close_scan_group",
+]
+
+
 class DeviceInstructionMessage(BECMessage):
     """Message type for sending device instructions to the device server
 
@@ -531,26 +553,7 @@ class DeviceInstructionMessage(BECMessage):
 
     msg_type: ClassVar[str] = "device_instruction"
     device: str | list[str] | None
-    action: Literal[
-        "rpc",
-        "set",
-        "read",
-        "kickoff",
-        "complete",
-        "trigger",
-        "stage",
-        "unstage",
-        "pre_scan",
-        "wait",
-        "scan_report_instruction",
-        "open_scan",
-        "baseline_reading",
-        "close_scan",
-        "open_scan_def",
-        "close_scan_def",
-        "publish_data_as_read",
-        "close_scan_group",
-    ]
+    action: DeviceInstructionAction
     parameter: dict
 
 

--- a/bec_server/bec_server/device_server/device_server.py
+++ b/bec_server/bec_server/device_server/device_server.py
@@ -23,6 +23,7 @@ from bec_lib.messages import BECStatus
 from bec_lib.serialization import json_ext
 from bec_lib.utils.rpc_utils import rgetattr
 from bec_server.device_server.devices.devicemanager import DeviceManagerDS
+from bec_server.device_server.friendly_device_exceptions import reformat_known_device_exceptions
 from bec_server.device_server.rpc_handler import RPCHandler
 
 if TYPE_CHECKING:
@@ -717,6 +718,9 @@ class DeviceServer(BECService):
         try:
             status = obj.set(val)
         except Exception as exc:  # pylint: disable=broad-except
+            exc = reformat_known_device_exceptions(
+                exc, "set", f"Device: {device_name}, value: {val}."
+            )
             status = DeviceStatus(device=obj)
             status.set_exception(exc)
         self._add_status_object_info(status, instr, obj)
@@ -866,7 +870,7 @@ class DeviceServer(BECService):
             )
         pipe.execute()
         logger.trace(
-            f"Elapsed time for reading and updating status info: {(time.time()-start)*1000} ms"
+            f"Elapsed time for reading and updating status info: {(time.time() - start) * 1000} ms"
         )
         return signal_container
 
@@ -891,7 +895,7 @@ class DeviceServer(BECService):
             )
         pipe.execute()
         logger.trace(
-            f"Elapsed time for reading and updating status info: {(time.time()-start)*1000} ms"
+            f"Elapsed time for reading and updating status info: {(time.time() - start) * 1000} ms"
         )
         return signal_container
 
@@ -964,7 +968,7 @@ class DeviceServer(BECService):
                             break
                         except ophyd_errors.WaitTimeoutError:
                             logger.warning(
-                                f"Unstaging device {dev} still running, {timeout_on_unstage*(ii+1)} seconds passed."
+                                f"Unstaging device {dev} still running, {timeout_on_unstage * (ii + 1)} seconds passed."
                             )
                     if status is not None:
                         raise ValueError(f"Unstaging device {dev} failed to finish in 30 seconds")

--- a/bec_server/bec_server/device_server/friendly_device_exceptions.py
+++ b/bec_server/bec_server/device_server/friendly_device_exceptions.py
@@ -1,0 +1,45 @@
+"""This module helps to reformat known exceptions raised from ophyd into less cryptic ones."""
+
+import re
+
+from bec_lib.messages import DeviceInstructionAction
+
+
+class DeviceInstructionError(Exception):
+    """An error encountered during execution of a device instruction."""
+
+
+def matches(p: re.Pattern[str], e: Exception) -> bool:
+    if not isinstance(msg := e.args[0], str):
+        return False
+    return bool(re.match(p, msg))
+
+
+def create(new_msg: str, cause: Exception) -> DeviceInstructionError:
+    new = DeviceInstructionError(new_msg)
+    new.__cause__ = cause
+    return new
+
+
+def reformat_known_device_exceptions(
+    e: Exception, action: DeviceInstructionAction, extra: str = ""
+) -> Exception:
+    """If the encountered exception is known, returns a clearer error with `extra` appended to the message.
+    Otherwise, returns the original exception unchanged."""
+
+    if action == "set":
+        return _handle_set(e, extra)
+    return e
+
+
+INCORRECT_VALUE_FOR_TUPLE = re.compile(r"tuple indices must be integers or slices, not float")
+
+
+def _handle_set(e: Exception, extra: str) -> Exception:
+    if isinstance(e, TypeError) and matches(INCORRECT_VALUE_FOR_TUPLE, e):
+        return create(
+            "An incorrect value was provided to a .set() command. This could be, for example, providing a float rather than an int to an enum PV. "
+            + extra,
+            e,
+        )
+    return e

--- a/bec_server/tests/tests_device_server/test_device_server.py
+++ b/bec_server/tests/tests_device_server/test_device_server.py
@@ -772,6 +772,39 @@ def test_set_device(device_server_mock, instr):
             )
 
 
+@pytest.mark.timeout(30)
+@pytest.mark.parametrize(
+    "instr",
+    [
+        messages.DeviceInstructionMessage(
+            device="samx",
+            action="set",
+            parameter={"value": 5},
+            metadata={"stream": "primary", "device_instr_id": "diid", "RID": "test"},
+        )
+    ],
+)
+@pytest.mark.parametrize("device_manager_class", [DeviceManagerDS])
+def test_set_device_error_formatted_nicely(device_server_mock, instr):
+    """Test that if set() raises an exception, and the exception is known,
+    a better-formated response is returned."""
+    with (
+        mock.patch.object(
+            device_server_mock.device_manager.devices.samx.obj,
+            "set",
+            side_effect=TypeError("tuple indices must be integers or slices, not float"),
+        ),
+        mock.patch.object(
+            device_server_mock.requests_handler, "send_device_instruction_response"
+        ) as mock_send_response,
+    ):
+        device_server_mock._set_device(instr)
+        assert (
+            """DeviceInstructionError: An incorrect value was provided to a .set() command. This could be, for example, providing a float rather than an int to an enum PV. Device: samx, value: 5."""
+            in mock_send_response.call_args.kwargs["error_info"].compact_error_message
+        )
+
+
 @pytest.mark.parametrize(
     "instr",
     [


### PR DESCRIPTION
The error returned when setting an enum PV with a float value is quite cryptic.

This change adds a module where we can put encountered errors raised by ophyd to format them a bit more nicely.