### PR TITLE
fix: migrate extra fields in pydantic models to json_schema_extra

### DIFF
--- a/bec_lib/bec_lib/bl_states.py
+++ b/bec_lib/bec_lib/bl_states.py
@@ -58,7 +58,7 @@ class BeamlineStateConfig(BaseModel):
     state_type: ClassVar[str] = "BeamlineState"
 
     name: str = Field(
-        **ScanArgument(
+        json_schema_extra=ScanArgument(
             display_name="State name",
             description=(
                 "Unique name for the beamline state. Must be a valid Python identifier and cannot be a reserved keyword. This name is used to identify the state in the system and should be descriptive of the state being monitored."
@@ -91,7 +91,7 @@ class DeviceStateConfig(BeamlineStateConfig):
 
     device: DeviceBase | str = Field(
         ...,
-        **ScanArgument(
+        json_schema_extra=ScanArgument(
             display_name="Device",
             description=(
                 "The device this state depends on. Can be specified as the device's dotted name or as the Device object itself. If the device has hints configured, the state will use the first hinted signal of the device by default. Otherwise, a signal must be specified explicitly for the state to function."
@@ -100,7 +100,7 @@ class DeviceStateConfig(BeamlineStateConfig):
     )
     signal: Signal | str | None = Field(
         default=None,
-        **ScanArgument(
+        json_schema_extra=ScanArgument(
             display_name="Signal",
             description=(
                 "The signal of the device to monitor for this state. Can be specified as the signal's dotted name, the signal object itself, or the obj_name of the signal as defined in the device's read dictionary. If not specified, the state will attempt to use the first hinted signal of the device. If the device has no hints and no signal is specified, the state will raise an error."
@@ -155,7 +155,7 @@ class DeviceWithinLimitsStateConfig(DeviceStateConfig):
 
     low_limit: float | None = Field(
         default=None,
-        **ScanArgument(
+        json_schema_extra=ScanArgument(
             display_name="Low limit",
             description="Optional lower allowed value. Leave disabled for no lower limit.",
             reference_units="device",
@@ -163,7 +163,7 @@ class DeviceWithinLimitsStateConfig(DeviceStateConfig):
     )
     high_limit: float | None = Field(
         default=None,
-        **ScanArgument(
+        json_schema_extra=ScanArgument(
             display_name="High limit",
             description="Optional upper allowed value. Leave disabled for no upper limit.",
             reference_units="device",
@@ -171,7 +171,7 @@ class DeviceWithinLimitsStateConfig(DeviceStateConfig):
     )
     tolerance: float = Field(
         default=0.1,
-        **ScanArgument(
+        json_schema_extra=ScanArgument(
             display_name="Tolerance",
             description="Warning margin applied inside the configured limits.",
             reference_units="device",


### PR DESCRIPTION
## Description

Pydantic marks additional kwargs in Field as deprecated and recommends to migrate to `json_schema_extra`. 


