### PR TITLE
feat(interlock): support multiple statuses

### DIFF
--- a/bec_lib/bec_lib/builtin_actor_hli.py
+++ b/bec_lib/bec_lib/builtin_actor_hli.py
@@ -4,6 +4,7 @@ from bec_lib.endpoints import MessageEndpoints
 from bec_lib.messages import (
     BlStateStatus,
     BuiltinActorStateChangeNotification,
+    InterlockTargetState,
     ScanInterlockModifyStateTableMessage,
 )
 
@@ -35,20 +36,29 @@ class ScanInterlockHli:
             self._parent.set_disabled(self._actor_name)
 
     @property
-    def states_watched(self) -> dict[str, BlStateStatus]:
+    def states_watched(self) -> dict[str, InterlockTargetState]:
         """Return the table of beamline states currently watched by the scan interlock actor"""
         if msg := self._client.connector.get(MessageEndpoints.scan_interlock_states()):
             return msg.states_watched
         return {}
 
-    def add_state_to_interlock(self, state_name: str, required_value: BlStateStatus = "valid"):
+    def add_state_to_interlock(
+        self, state_name: str, required_value: BlStateStatus | InterlockTargetState | None = None
+    ):
         """
         Add a beamline state and its status to watch to the ScanInterlockActor. If the state no
-        longer has this status, an interlock will be placed on the primary scan queue.
+        longer has one of these statuses, an interlock will be placed on the primary scan queue.
         Args:
             state_name (str): the state to watch
-            status (Literal["valid","invalid","warning","unknown"]): the status to watch for. Defaults to "valid".
+            required_value (Literal["valid","invalid","warning","unknown"] | list[...]):
+                the accepted status or statuses. Defaults to `["valid", "warning"]`.
         """
+        if required_value is None:
+            required_value = ["valid", "warning"]
+        elif isinstance(required_value, str):
+            required_value = [required_value]
+        elif isinstance(required_value, (tuple, set)):
+            required_value = list(required_value)
         self._client.connector.xadd(
             MessageEndpoints.modify_interlock_table(),
             {

--- a/bec_lib/bec_lib/messages.py
+++ b/bec_lib/bec_lib/messages.py
@@ -2009,6 +2009,7 @@ class GameLeaderboardMessage(BECMessage):
 
 
 BlStateStatus = Literal["valid", "invalid", "warning", "unknown"]
+InterlockTargetState = list[BlStateStatus]
 
 
 class BeamlineStateMessage(BECMessage):
@@ -2073,12 +2074,14 @@ class ScanInterlockModifyStateTableMessage(BECMessage):
     msg_type: ClassVar[str] = "scan_interlock_modify_state_table"
     action: Literal["add", "remove", "remove_all"]
     state_name: str | None = None
-    status: BlStateStatus | None = None
+    status: InterlockTargetState | None = None
 
     @model_validator(mode="after")
     def _validate(self):
         if self.action == "add" and (self.status is None or self.state_name is None):
             raise ValueError("Must specify a name and status when adding a state")
+        if self.status == []:
+            raise ValueError("Must specify at least one status when adding a state")
         if self.action in ["remove", "remove_all"] and self.status is not None:
             raise ValueError("May not specify a status when removing a state")
         if self.action == "remove_all" and self.state_name is not None:
@@ -2088,7 +2091,7 @@ class ScanInterlockModifyStateTableMessage(BECMessage):
 
 class ScanInterlockStateTableContent(BECMessage):
     msg_type: ClassVar[str] = "scan_interlock_state_table_content"
-    states_watched: dict[str, BlStateStatus]
+    states_watched: dict[str, InterlockTargetState]
 
 
 class ActorStartRequestMessage(BECMessage):

--- a/bec_server/bec_server/actors/actor.py
+++ b/bec_server/bec_server/actors/actor.py
@@ -9,7 +9,12 @@ from bec_lib.actors import ActorActionTable
 from bec_lib.client import BECClient
 from bec_lib.endpoints import EndpointInfo, MessageEndpoints
 from bec_lib.logger import bec_logger
-from bec_lib.messages import BeamlineStateMessage, BlStateStatus, ProcedureWorkerStatus
+from bec_lib.messages import (
+    BeamlineStateMessage,
+    BlStateStatus,
+    InterlockTargetState,
+    ProcedureWorkerStatus,
+)
 from bec_server.procedures.oop_worker_base import push_status
 
 logger = bec_logger.logger
@@ -120,7 +125,7 @@ class BlStateActor(SubscriptionActor):
     self.all_match_action() is called. If not, self.some_mismatch_action() is called.
     """
 
-    state_table: dict[str, BlStateStatus]
+    state_table: dict[str, InterlockTargetState]
 
     def __init__(self, client: BECClient, name: str, exec_id: str):
         self.state_table_lock = RLock()
@@ -149,9 +154,11 @@ class BlStateActor(SubscriptionActor):
 
     def all_states_match(self, client: BECClient):
         with self.state_table_lock:
-            for state, status in self.state_table.items():
-                if self.state_cache.get(state) != status:
-                    logger.info(f"Beamline state {state} out of bounds: expected={status}")
+            for state, allowed_statuses in self.state_table.items():
+                if self.state_cache.get(state) not in allowed_statuses:
+                    logger.info(
+                        f"Beamline state {state} out of bounds: expected one of {allowed_statuses}"
+                    )
                     return False
             return True
 

--- a/bec_server/bec_server/actors/builtin_actor_manager.py
+++ b/bec_server/bec_server/actors/builtin_actor_manager.py
@@ -7,9 +7,9 @@ from bec_lib.endpoints import MessageEndpoints
 from bec_lib.logger import bec_logger
 from bec_lib.messages import (
     AvailableBeamlineStatesMessage,
-    BlStateStatus,
     BuiltinActorStateChangeNotification,
     BuiltinActorStateUpdatedNotification,
+    InterlockTargetState,
     ScanInterlockModifyStateTableMessage,
     ScanInterlockStateTableContent,
 )
@@ -110,13 +110,13 @@ class BuiltinActorManager:
         self._client.shutdown()
 
     # Actor specific management methods:
-    def _set_interlock_states_in_redis(self, states: dict[str, BlStateStatus]):
+    def _set_interlock_states_in_redis(self, states: dict[str, InterlockTargetState]):
         self._client.connector.set(
             MessageEndpoints.scan_interlock_states(),
             ScanInterlockStateTableContent(states_watched=states),
         )
 
-    def _current_watched_states(self) -> dict[str, BlStateStatus]:
+    def _current_watched_states(self) -> dict[str, InterlockTargetState]:
         states: ScanInterlockStateTableContent | None = self._client.connector.get(
             MessageEndpoints.scan_interlock_states()
         )

--- a/bec_server/bec_server/actors/scan_interlock.py
+++ b/bec_server/bec_server/actors/scan_interlock.py
@@ -77,8 +77,7 @@ class ScanInterlockActor(BlStateActor):
             return [
                 state_name
                 for state_name, expected_state in self.state_table.items()
-                if (current_state := self.state_cache.get(state_name)) is not None
-                and current_state != expected_state
+                if self.state_cache.get(state_name) not in expected_state
             ]
 
     def some_mismatch_action(self, client: BECClient):

--- a/bec_server/tests/tests_actors/test_actors.py
+++ b/bec_server/tests/tests_actors/test_actors.py
@@ -176,7 +176,7 @@ def test_actor_procedure_logs_error_not_actor():
 
 
 class BlStateTestActor(BlStateActor):
-    state_table = {"test_state": "valid", "test_state_2": "valid"}
+    state_table = {"test_state": ["valid"], "test_state_2": ["valid"]}
 
 
 def test_blstateactor_init_table_and_cache():
@@ -191,7 +191,7 @@ def test_blstateactor_init_table_and_cache():
     actor.stop_event.set()
     actor.run()
 
-    assert actor.state_table == {"test_state": "valid"}
+    assert actor.state_table == {"test_state": ["valid"]}
     assert actor.state_cache == {"test_state": "valid"}
 
 

--- a/bec_server/tests/tests_scan_server/test_builtin_actor_manager.py
+++ b/bec_server/tests/tests_scan_server/test_builtin_actor_manager.py
@@ -5,6 +5,7 @@ import pytest
 
 from bec_lib.messages import (
     AvailableBeamlineStatesMessage,
+    InterlockTargetState,
     ScanInterlockModifyStateTableMessage,
     ScanInterlockStateTableContent,
 )
@@ -155,7 +156,7 @@ def test_shutdown_stops_all_and_shuts_down_client(mocked_manager):
     mock_client.shutdown.assert_called_once()
 
 
-def _req_msg(action, state_name, status):
+def _req_msg(action, state_name, status: InterlockTargetState | None):
     return {
         "data": ScanInterlockModifyStateTableMessage(
             action=action, state_name=state_name, status=status
@@ -163,14 +164,18 @@ def _req_msg(action, state_name, status):
     }
 
 
-INITIAL_STATES = {"initial_state_1": "valid", "initial_state_2": "valid"}
+INITIAL_STATES = {"initial_state_1": ["valid"], "initial_state_2": ["valid"]}
 
 
 @pytest.mark.parametrize(
     ["modification_request", "new_watched_states"],
     [
-        (_req_msg("add", "test_state", "valid"), {**INITIAL_STATES, "test_state": "valid"}),
-        (_req_msg("remove", "initial_state_1", None), {"initial_state_2": "valid"}),
+        (_req_msg("add", "test_state", ["valid"]), {**INITIAL_STATES, "test_state": ["valid"]}),
+        (
+            _req_msg("add", "test_state", ["valid", "warning"]),
+            {**INITIAL_STATES, "test_state": ["valid", "warning"]},
+        ),
+        (_req_msg("remove", "initial_state_1", None), {"initial_state_2": ["valid"]}),
         (_req_msg("remove_all", None, None), {}),
         (_req_msg("remove", "missing_state", None), INITIAL_STATES),
     ],

--- a/bec_server/tests/tests_scan_server/test_scan_interlock.py
+++ b/bec_server/tests/tests_scan_server/test_scan_interlock.py
@@ -62,9 +62,9 @@ class TestScanInterlockActor:
     def test_on_state_modification_add(self, actor, mock_client):
         actor._update_cache = MagicMock()
         mock_client.connector.register.reset_mock()
-        msg = MagicMock(action="add", state_name="beam_ok", status="valid")
+        msg = MagicMock(action="add", state_name="beam_ok", status=["valid"])
         actor._on_state_modification(msg)
-        assert actor.state_table["beam_ok"] == "valid"
+        assert actor.state_table["beam_ok"] == ["valid"]
         mock_client.connector.register.assert_called_once()
         actor._update_cache.assert_called_once()
 
@@ -91,6 +91,16 @@ class TestScanInterlockActor:
             actor._on_state_modification(msg)
 
         mock_client.connector.unregister.assert_not_called()
+
+    def test_all_states_match_accepts_list_of_statuses(self, actor):
+        actor.state_table["beam_ok"] = ["valid", "warning"]
+        actor.state_cache["beam_ok"] = "warning"
+        assert actor.all_states_match(actor.client) is True
+
+    def test_mismatched_states_handles_list_of_statuses(self, actor):
+        actor.state_table["beam_ok"] = ["valid", "warning"]
+        actor.state_cache["beam_ok"] = "invalid"
+        assert actor.mismatched_states == ["beam_ok"]
 
     def test_some_mismatch_action_adds_lock(self, actor, mock_client):
         actor.some_mismatch_action(mock_client)


### PR DESCRIPTION
## Description

This PR improves the interlock by supporting multiple "acceptable" states as safe to continue. Previously, the default target state was "valid", i.e. everything that was not on "valid" would trigger a scan interlock. With these changes, also "warning" is acceptable to continue.


