### PR TITLE
fix(config): get_device_config skips uninitialized devices

### DIFF
--- a/bec_lib/bec_lib/devicemanager.py
+++ b/bec_lib/bec_lib/devicemanager.py
@@ -865,14 +865,17 @@ class DeviceManagerBase:
                 continue
             if update_signals:
                 # If the device config specifies start values for signals, update them
-                available_signal = self.devices[dev_name]._info.get("signals", {})
+                device_obj = self.devices.get(dev_name)
+                if not device_obj:
+                    continue
+                available_signal = device_obj._info.get("signals", {})
                 device_config = dev_conf.get("deviceConfig", {})
                 if not device_config:
                     continue
                 for signal_name in device_config:
                     if signal_name in available_signal:
                         signal_obj_name = available_signal[signal_name].get("obj_name")
-                        signal_obj = getattr(self.devices[dev_name], signal_name, None)
+                        signal_obj = getattr(device_obj, signal_name, None)
                         if not signal_obj or not signal_obj_name:
                             continue
                         sig_read = signal_obj.read(cached=True)

--- a/bec_lib/tests/test_device_manager.py
+++ b/bec_lib/tests/test_device_manager.py
@@ -446,6 +446,22 @@ def test_get_device_config_returns_empty_dict_on_none(dm_with_devices):
     assert config == {}
 
 
+def test_get_device_config_skips_missing_loaded_device(dm_with_devices, session_from_test_config):
+    device_manager = dm_with_devices
+    config_with_missing_device = copy.deepcopy(session_from_test_config.get("devices"))
+    missing_device = next(dev for dev in config_with_missing_device if dev["name"] == "samx")
+    missing_device["deviceConfig"] = {"velocity": 0.0}
+    device_manager.devices.pop("samx")
+
+    with mock.patch.object(device_manager.connector, "get") as mock_get:
+        mock_get.return_value = messages.AvailableResourceMessage(
+            resource=config_with_missing_device
+        )
+        config = device_manager.get_device_config(update_signals=True)
+
+    assert "samx" not in config
+
+
 def test_get_device_config_with_signal_update(dm_with_devices, session_from_test_config):
     device_manager = dm_with_devices
     # Mock a device signal that can be read


### PR DESCRIPTION
## Description

If a device config load fails, it may happen that the client and device config in redis diverged during the config validation. 


## Screenshots / GIFs (if applicable)

<img width="1815" height="2420" alt="image" src="https://github.com/user-attachments/assets/81365823-f5dd-4fa3-a10c-832cfe91c9e3" />


