### PR TITLE
feat(redis): support expire and trim on rpush

### DIFF
--- a/bec_lib/bec_lib/redis_connector.py
+++ b/bec_lib/bec_lib/redis_connector.py
@@ -1202,30 +1202,45 @@ class RedisConnector:
             msg = MsgpackSerialization.dumps(msg)
         client.lpush(topic, msg)
         if max_size:
-            client.ltrim(topic, 0, max_size)
+            client.ltrim(topic, 0, max_size - 1)
         if expire:
             client.expire(topic, expire)
         if not pipe:
             client.execute()
 
     @validate_endpoint("topic")
-    def lset(self, topic: str, index: int, msg: str, pipe: Pipeline | None = None) -> str:
+    def lset(
+        self, topic: str, index: int, msg: str | BECMessage, pipe: Pipeline | None = None
+    ) -> str | Pipeline:
         client = pipe if pipe is not None else self._redis_conn
         if isinstance(msg, BECMessage):
             msg = MsgpackSerialization.dumps(msg)
         return client.lset(topic, index, msg)  # type: ignore # using sync client
 
     @validate_endpoint("topic")
-    def rpush(self, topic: str, msg: str | BECMessage, pipe: Pipeline | None = None) -> int:
+    def rpush(
+        self,
+        topic: str,
+        msg: str | BECMessage,
+        pipe: Pipeline | None = None,
+        max_size: int | None = None,
+        expire: int | None = None,
+    ) -> None:
         """O(1) for each element added, so O(N) to add N elements when the
         command is called with multiple arguments. Insert all the specified
         values at the tail of the list stored at key. If key does not exist,
         it is created as empty list before performing the push operation. When
         key holds a value that is not a list, an error is returned."""
-        client = pipe if pipe is not None else self._redis_conn
+        client = pipe if pipe is not None else self.pipeline()
         if isinstance(msg, BECMessage):
             msg = MsgpackSerialization.dumps(msg)
-        return client.rpush(topic, msg)  # type: ignore # using sync client
+        client.rpush(topic, msg)
+        if max_size:
+            client.ltrim(topic, -max_size, -1)
+        if expire:
+            client.expire(topic, expire)
+        if not pipe:
+            client.execute()
 
     @validate_endpoint("topic")
     def lrange(self, topic: str, start: int, end: int, pipe: Pipeline | None = None):

--- a/bec_lib/tests/test_redis_connector.py
+++ b/bec_lib/tests/test_redis_connector.py
@@ -117,7 +117,7 @@ def test_redis_connector_lpush(connector, topic, msgs, max_size, expire):
     connector._redis_conn.pipeline().lpush.assert_called_once_with(topic, msgs)
 
     if max_size:
-        connector._redis_conn.pipeline().ltrim.assert_called_once_with(topic, 0, max_size)
+        connector._redis_conn.pipeline().ltrim.assert_called_once_with(topic, 0, max_size - 1)
     if expire:
         connector._redis_conn.pipeline().expire.assert_called_once_with(topic, expire)
     if not pipe:
@@ -141,7 +141,7 @@ def test_redis_connector_lpush_BECMessage(connector, topic, msgs, max_size, expi
     )
 
     if max_size:
-        connector._redis_conn.pipeline().ltrim.assert_called_once_with(topic, 0, max_size)
+        connector._redis_conn.pipeline().ltrim.assert_called_once_with(topic, 0, max_size - 1)
     if expire:
         connector._redis_conn.pipeline().expire.assert_called_once_with(topic, expire)
     if not pipe:
@@ -186,38 +186,50 @@ def test_redis_connector_lset_BECMessage(connector, topic, index, msgs, use_pipe
 
 
 @pytest.mark.parametrize(
-    "topic, msgs, use_pipe", [["topic1", "msg1", True], ["topic2", "msg2", False]]
+    "topic, msgs, use_pipe, max_size, expire",
+    [["topic1", "msg1", True, None, None], ["topic2", "msg2", False, 10, 100]],
 )
-def test_redis_connector_rpush(connector, topic, msgs, use_pipe):
+def test_redis_connector_rpush(connector, topic, msgs, use_pipe, max_size, expire):
     pipe = use_pipe_fcn(connector, use_pipe)
 
-    ret = connector.rpush(topic, msgs, pipe)
+    ret = connector.rpush(topic, msgs, pipe, max_size=max_size, expire=expire)
 
+    connector._redis_conn.pipeline().rpush.assert_called_once_with(topic, msgs)
+    if max_size:
+        connector._redis_conn.pipeline().ltrim.assert_called_once_with(topic, -max_size, -1)
+    if expire:
+        connector._redis_conn.pipeline().expire.assert_called_once_with(topic, expire)
     if pipe:
-        connector._redis_conn.pipeline().rpush.assert_called_once_with(topic, msgs)
-        assert ret == connector._redis_conn.pipeline().rpush()
+        connector._redis_conn.pipeline().execute.assert_not_called()
     else:
-        connector._redis_conn.rpush.assert_called_once_with(topic, msgs)
-        assert ret == connector._redis_conn.rpush()
+        connector._redis_conn.pipeline().execute.assert_called_once()
+    assert ret is None
 
 
 @pytest.mark.parametrize(
-    "topic, msgs, use_pipe",
-    [["topic1", TestMessage(msg="msg1"), True], ["topic2", TestMessage(msg="msg2"), False]],
+    "topic, msgs, use_pipe, max_size, expire",
+    [
+        ["topic1", TestMessage(msg="msg1"), True, None, None],
+        ["topic2", TestMessage(msg="msg2"), False, 10, 100],
+    ],
 )
-def test_redis_connector_rpush_BECMessage(connector, topic, msgs, use_pipe):
+def test_redis_connector_rpush_BECMessage(connector, topic, msgs, use_pipe, max_size, expire):
     pipe = use_pipe_fcn(connector, use_pipe)
 
-    ret = connector.rpush(topic, msgs, pipe)
+    ret = connector.rpush(topic, msgs, pipe, max_size=max_size, expire=expire)
 
+    connector._redis_conn.pipeline().rpush.assert_called_once_with(
+        topic, MsgpackSerialization.dumps(msgs)
+    )
+    if max_size:
+        connector._redis_conn.pipeline().ltrim.assert_called_once_with(topic, -max_size, -1)
+    if expire:
+        connector._redis_conn.pipeline().expire.assert_called_once_with(topic, expire)
     if pipe:
-        connector._redis_conn.pipeline().rpush.assert_called_once_with(
-            topic, MsgpackSerialization.dumps(msgs)
-        )
-        assert ret == connector._redis_conn.pipeline().rpush()
+        connector._redis_conn.pipeline().execute.assert_not_called()
     else:
-        connector._redis_conn.rpush.assert_called_once_with(topic, MsgpackSerialization.dumps(msgs))
-        assert ret == connector._redis_conn.rpush()
+        connector._redis_conn.pipeline().execute.assert_called_once()
+    assert ret is None
 
 
 @pytest.mark.parametrize(

--- a/bec_lib/tests/test_redis_connector_fakeredis.py
+++ b/bec_lib/tests/test_redis_connector_fakeredis.py
@@ -286,6 +286,21 @@ def test_redis_connector_lpush(connected_connector):
     assert connector._redis_conn.lrange("test", 0, -1) == [b"test_msg"]
 
 
+def test_redis_connector_rpush(connected_connector):
+    connector = connected_connector
+    connector.rpush("test", "test_msg")
+    assert connector._redis_conn.lrange("test", 0, -1) == [b"test_msg"]
+
+
+def test_redis_connector_rpush_with_max_size_and_expire(connected_connector):
+    connector = connected_connector
+    connector.rpush("test", "test_msg1", max_size=2, expire=100)
+    connector.rpush("test", "test_msg2", max_size=2, expire=100)
+    connector.rpush("test", "test_msg3", max_size=2, expire=100)
+    assert connector._redis_conn.lrange("test", 0, -1) == [b"test_msg2", b"test_msg3"]
+    assert 0 < connector._redis_conn.ttl("test") <= 100
+
+
 def test_redis_connector_lset(connected_connector):
     connector = connected_connector
     connector.lpush("test", "test_msg")


### PR DESCRIPTION
## Description

The redis connector had different implementations for rpush and lpush. This PR unifies them. 
These changes are needed for the support for async indices. 

