### PR TITLE
Feature/async signal index

### DIFF
--- a/bec_lib/bec_lib/endpoints.py
+++ b/bec_lib/bec_lib/endpoints.py
@@ -425,6 +425,31 @@ class MessageEndpoints:
         )
 
     @staticmethod
+    def device_async_signal_index(scan_id: str, device: str, signal: str):
+        """
+        Endpoint for async device signal index updates.
+        This endpoint is used by the device server to publish per-message index
+        information for async signals using a messages.DeviceAsyncSignalIndexMessage
+        message. Index data is scoped to the async signal stream.
+
+        Args:
+            scan_id (str): unique scan identifier
+            device (str): Device name, e.g. "mcs".
+            signal (str): Signal name, e.g. "image".
+
+        Returns:
+            EndpointInfo: Endpoint for device async signal index updates.
+        """
+        endpoint = (
+            f"{EndpointType.INFO.value}/devices/async_signal_index/{scan_id}/{device}/{signal}"
+        )
+        return EndpointInfo(
+            endpoint=endpoint,
+            message_type=messages.DeviceAsyncSignalIndexMessage,
+            message_op=MessageOp.LIST,
+        )
+
+    @staticmethod
     def device_monitor_2d(device: str):
         """
         Endpoint for device monitoring of 2D detectors.

--- a/bec_lib/bec_lib/messages.py
+++ b/bec_lib/bec_lib/messages.py
@@ -689,6 +689,36 @@ class DeviceMessage(BECMessage):
         return v
 
 
+class DeviceAsyncSignalIndexMessage(BECMessage):
+    """Message type for sending device async signal index information from the device server
+
+    This message is used to send index information for async signals emitted by the device server. It is published to a
+    separate Redis list and is meant as a companion message to the DeviceMessage that contains the async signal data.
+    The DeviceAsyncSignalIndexMessage contains information about the shapes of the async signals
+    that are being emitted and can be used to keep track of offsets, even after the raw data stream has already been
+    evicted from Redis. The indices are managed on the device server side and are incremented for each new async signal emitted.
+
+    Args:
+        scan_id (str): Unique scan ID
+        device (str): Name of the device emitting the async signals
+        signal (str): Name of the async signal being emitted
+        shapes (dict[str, list[int]]): Dictionary containing the shapes of the async signals being emitted, keyed by signal name
+        indices (dict[str, int]): Dictionary containing the current indices of the async signals being emitted, keyed by signal name.
+                                    The index starts at 0 and is incremented for each new async signal emitted and can be used to
+                                    keep track of offsets in the raw data stream.
+        async_update (DeviceAsyncUpdate): Metadata controlling how data is aggregated into datasets during a scan. See DeviceAsyncUpdate for details.
+    """
+
+    msg_type: ClassVar[str] = "device_async_signal_index"
+
+    scan_id: str
+    device: str
+    signal: str
+    shapes: dict[str, list[int]]
+    indices: dict[str, int]
+    async_update: DeviceAsyncUpdate
+
+
 class DeviceAsyncUpdate(BaseModel):
     """Model for validating async update metadata sent with device data.
 

--- a/bec_lib/bec_lib/tests/utils.py
+++ b/bec_lib/bec_lib/tests/utils.py
@@ -583,9 +583,9 @@ class ConnectorMock(RedisConnector):  # pragma: no cover
             pipe._pipe_buffer.append(("lpush", (topic, msg), {}))
             return
 
-    def rpush(self, topic, msg, pipe=None):
+    def rpush(self, topic, msg, pipe=None, expire: int = None):
         if pipe:
-            pipe._pipe_buffer.append(("rpush", (topic, msg), {}))
+            pipe._pipe_buffer.append(("rpush", (topic, msg), {"expire": expire}))
             return
         pass
 

--- a/bec_lib/tests/test_bec_messages.py
+++ b/bec_lib/tests/test_bec_messages.py
@@ -62,6 +62,21 @@ def test_device_message_with_invalid_async_update():
         )
 
 
+def test_device_async_signal_index_message():
+    msg = messages.DeviceAsyncSignalIndexMessage(
+        scan_id="scan-1",
+        device="waveform",
+        signal="waveform_data",
+        shapes={"waveform_a": [2], "waveform_b": []},
+        indices={"waveform_a": 0, "waveform_b": 3},
+        async_update=messages.DeviceAsyncUpdate(type="add", max_shape=[None]),
+    )
+    res = MsgpackSerialization.dumps(msg)
+    res_loaded = MsgpackSerialization.loads(res)
+
+    assert res_loaded == msg
+
+
 def test_bundled_message():
     sub_msg = messages.DeviceMessage(signals={"samx": {"value": 5.2}}, metadata={"RID": "1234"})
     msg = messages.BundleMessage()

--- a/bec_server/bec_server/device_server/bec_message_handler.py
+++ b/bec_server/bec_server/device_server/bec_message_handler.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterable, TypedDict
 
+import numpy as np
 from ophyd import OphydObject
 from ophyd_devices.utils import bec_signals as bms
 
@@ -14,6 +15,11 @@ logger = bec_logger.logger
 
 if TYPE_CHECKING:  # pragma: no cover
     from bec_server.device_server.devices.devicemanager import DeviceManagerDS
+
+
+class _AsyncSignalIndexState(TypedDict):
+    scan_id: str
+    indices: dict[str, int]
 
 
 class BECMessageHandler:
@@ -32,6 +38,7 @@ class BECMessageHandler:
         self.device_manager = device_manager
         self.connector: RedisConnector = device_manager.connector
         self.devices = device_manager.devices
+        self._async_signal_index_state: dict[tuple[str, str], _AsyncSignalIndexState] = {}
 
     def emit(self, obj: OphydObject, message: messages.BECMessage):
         """
@@ -156,14 +163,70 @@ class BECMessageHandler:
                 f"Signal metadata is None for device {device_name} and signal {signal_name}."
             )
             return
+
+        indices = self._get_async_signal_indices(
+            obj=obj, scan_id=scan_id, signal_names=message.signals.keys()
+        )
+
+        # we augment the message metadata with the async signal indices so that
+        # downstream consumers can know which message corresponds to which async signal update
+        message.metadata["async_indices"] = indices
+
+        pipe = self.connector.pipeline()
         self.connector.xadd(
             MessageEndpoints.device_async_signal(
                 scan_id=scan_id, device=device_name, signal=signal_name
             ),
             {"data": message},
             max_size=obj.signal_metadata.get("max_size", 1000),
+            pipe=pipe,
             expire=obj.signal_metadata.get("expire", 600),  # default to 10 minutes (600 seconds)
         )
+
+        # NOTE: We are storing the shape information. This means that
+        # - a single value update will have shape [] (scalar)
+        # - an empty array will have shape [0]
+        # - a 1D array of length N will have shape [N]
+        # - a 2D array of shape (M, N) will have shape [M, N]
+        index_message = messages.DeviceAsyncSignalIndexMessage(
+            scan_id=scan_id,
+            device=device_name,
+            signal=signal_name,
+            shapes={
+                current_signal_name: list(np.shape(signal_data["value"]))
+                for current_signal_name, signal_data in message.signals.items()
+            },
+            indices=indices,
+            async_update=messages.DeviceAsyncUpdate.model_validate(
+                message.metadata["async_update"]
+            ),
+        )
+        self.connector.rpush(
+            MessageEndpoints.device_async_signal_index(
+                scan_id=scan_id, device=device_name, signal=signal_name
+            ),
+            index_message,
+            pipe=pipe,
+            expire=3600,  # expire after 1 hour; note that this is longer than the async signal message itself
+        )
+        pipe.execute()
+
+    def _get_async_signal_indices(
+        self, obj: bms.DynamicSignal, scan_id: str, signal_names: Iterable[str]
+    ) -> dict[str, int]:
+        state_key = (obj.root.name, obj.name)
+        state = self._async_signal_index_state.get(state_key)
+        if state is None or state["scan_id"] != scan_id:
+            state = _AsyncSignalIndexState(scan_id=scan_id, indices={})
+            self._async_signal_index_state[state_key] = state
+
+        out = {}
+        indices = state["indices"]
+        for signal_name in signal_names:
+            current_index = indices.get(signal_name, -1) + 1
+            indices[signal_name] = current_index
+            out[signal_name] = current_index
+        return out
 
     def _get_scan_status_message(self) -> messages.ScanStatusMessage | None:
         """

--- a/bec_server/tests/tests_device_server/test_device_manager_ds.py
+++ b/bec_server/tests/tests_device_server/test_device_manager_ds.py
@@ -24,13 +24,10 @@ def dm_with_devices_and_status(dm_with_devices):
     Fixture that adds the scan_info message to the device manager
     """
     device_manager = dm_with_devices
-    with mock.patch.object(
-        device_manager.scan_info, "msg", new_callable=mock.PropertyMock
-    ) as mock_scan_info_msg:
-        mock_scan_info_msg.return_value = messages.ScanStatusMessage(
-            scan_id="12345", status="open", info={"num_points": 10, "RID": "RID123"}
-        )
-        yield device_manager
+    device_manager.scan_info.msg = messages.ScanStatusMessage(
+        scan_id="12345", status="open", info={"num_points": 10, "RID": "RID123"}
+    )
+    yield device_manager
 
 
 class ControllerMock:

--- a/bec_server/tests/tests_device_server/test_device_manager_ds.py
+++ b/bec_server/tests/tests_device_server/test_device_manager_ds.py
@@ -418,7 +418,8 @@ def test_device_manager_ds_obj_callback_progress_signal_disabled_device(dm_with_
     [
         None,
         messages.DeviceMessage(
-            signals={"async_signal": {"value": np.random.rand(10), "timestamp": time.time()}}
+            signals={"async_signal": {"value": np.random.rand(10), "timestamp": time.time()}},
+            metadata={"async_update": {"type": "add", "max_shape": [None]}},
         ),
         "some string",
     ],
@@ -443,7 +444,8 @@ def test_device_manager_ds_obj_callback_async_signal_incomplete_info(dm_with_dev
     dm_with_devices.devices.bec_signals_device.metadata = metadata
 
     msg = messages.DeviceMessage(
-        signals={"async_signal": {"value": np.random.rand(10), "timestamp": time.time()}}
+        signals={"async_signal": {"value": np.random.rand(10), "timestamp": time.time()}},
+        metadata={"async_update": {"type": "add", "max_shape": [None]}},
     )
     with mock.patch.object(device_manager.connector, "xadd") as mock_xadd:
         device_manager._obj_callback_bec_message_signal(obj=device.async_signal, value=msg)


### PR DESCRIPTION
## Description

This PR introduces async signal indices for keeping track of individual updates of async signal events. This will become useful once we have the data api and try to match async and monitored signals. 

## Related Issues

closes #755

## Type of Change

- new endpoint `device_async_signal_index`
- new message type `DeviceAsyncSignalIndexMessage`
- bec message handler calculates the index and pushes the data to a list in redis

## How to test

- Run unit tests
- Check redis for the new endpoint 

