### PR TITLE
Add managed redis config value tool and use it for scan interlock settings

### DIFF
--- a/bec_ipython_client/tests/end-2-end/test_actors_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_actors_e2e.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:  # pragma: no cover
 def bec_with_delay_device(bec_ipython_client_fixture):
     bec = bec_ipython_client_fixture
     bec.builtin_actors.scan_interlock.enabled = True
+    bec.builtin_actors.scan_interlock.trigger_setting = "restart_scan"
     dev = bec.device_manager.devices
     dev.ramp_up.min_val.put(0)
     dev.ramp_up.max_val.put(400)
@@ -61,6 +62,7 @@ def test_scan_interlock(
     actors: BuiltinActorHli = bec.builtin_actors
     assert bec.beamline_states.beam_intensity_sufficient.get()["status"] == "valid"
     assert actors.scan_interlock.enabled
+    assert actors.scan_interlock.trigger_setting == "restart_scan"
     current_q_status_msg: ScanQueueStatus = bec.queue.queue_storage.current_scan_queue["primary"]
     assert current_q_status_msg.status == "RUNNING"
     actors.scan_interlock.add_state_to_interlock("beam_intensity_sufficient", "valid")

--- a/bec_lib/bec_lib/builtin_actor_hli.py
+++ b/bec_lib/bec_lib/builtin_actor_hli.py
@@ -12,14 +12,10 @@ from bec_lib.messages import (
 if TYPE_CHECKING:
     from bec_lib.client import BECClient
 
-VAR_PREFIX = "_BuiltinActors"
-
 
 class ScanInterlockHli:
     def __init__(self, client: "BECClient", parent: "BuiltinActorHli") -> None:
         self._client = client
-        self._parent = parent
-        self._actor_name = "ScanInterlockActor"
         self._enabled = RedisConfigValue(
             connector=self._client.connector, endpoint=MessageEndpoints.scan_interlock_enabled()
         )
@@ -102,8 +98,17 @@ class ScanInterlockHli:
             {"data": ScanInterlockModifyStateTableMessage(action="remove_all")},
         )
 
+    def shutdown(self):
+        """Unregister the config-value stream subscriptions from the connector."""
+        self._enabled.unregister_all()
+        self._trigger_setting.unregister_all()
+
 
 class BuiltinActorHli:
     def __init__(self, client: "BECClient") -> None:
         self._client = client
         self.scan_interlock = ScanInterlockHli(self._client, self)
+
+    def shutdown(self):
+        """Tear down builtin-actor client subscriptions (called on client shutdown)."""
+        self.scan_interlock.shutdown()

--- a/bec_lib/bec_lib/builtin_actor_hli.py
+++ b/bec_lib/bec_lib/builtin_actor_hli.py
@@ -26,6 +26,10 @@ class ScanInterlockHli:
         self._enabled = RedisConfigValue(
             connector=self._client.connector, endpoint=MessageEndpoints.scan_interlock_enabled()
         )
+        self._restart_scan_on_lock = RedisConfigValue(
+            connector=self._client.connector,
+            endpoint=MessageEndpoints.scan_interlock_restart_scan(),
+        )
 
     @property
     def enabled(self):
@@ -34,6 +38,14 @@ class ScanInterlockHli:
     @enabled.setter
     def enabled(self, enabled: bool):
         self._enabled.value = enabled
+
+    @property
+    def restart_scan_on_lock(self):
+        return self._restart_scan_on_lock.value
+
+    @restart_scan_on_lock.setter
+    def restart_scan_on_lock(self, restart_scan_on_lock: bool):
+        self._restart_scan_on_lock.value = restart_scan_on_lock
 
     @property
     def states_watched(self) -> dict[str, InterlockTargetState]:

--- a/bec_lib/bec_lib/builtin_actor_hli.py
+++ b/bec_lib/bec_lib/builtin_actor_hli.py
@@ -1,9 +1,9 @@
 from typing import TYPE_CHECKING
 
+from bec_lib.config_values import RedisConfigValue
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.messages import (
     BlStateStatus,
-    BuiltinActorStateChangeNotification,
     InterlockTargetState,
     ScanInterlockModifyStateTableMessage,
 )
@@ -23,17 +23,17 @@ class ScanInterlockHli:
         self._client = client
         self._parent = parent
         self._actor_name = "ScanInterlockActor"
+        self._enabled = RedisConfigValue(
+            connector=self._client.connector, endpoint=MessageEndpoints.scan_interlock_enabled()
+        )
 
     @property
     def enabled(self):
-        return self._parent.check_enabled(self._actor_name)
+        return self._enabled.value
 
     @enabled.setter
     def enabled(self, enabled: bool):
-        if enabled:
-            self._parent.set_enabled(self._actor_name)
-        else:
-            self._parent.set_disabled(self._actor_name)
+        self._enabled.value = enabled
 
     @property
     def states_watched(self) -> dict[str, InterlockTargetState]:
@@ -95,20 +95,3 @@ class BuiltinActorHli:
     def __init__(self, client: "BECClient") -> None:
         self._client = client
         self.scan_interlock = ScanInterlockHli(self._client, self)
-
-    def _notify(self, actor_name):
-        self._client.connector.send(
-            MessageEndpoints.builtin_actor_update_req_notif(),
-            BuiltinActorStateChangeNotification(actor_name=actor_name),
-        )
-
-    def check_enabled(self, actor_name: str):
-        return bool(self._client.get_global_var(builtin_actor_enabled_var(actor_name)))
-
-    def set_enabled(self, actor_name: str):
-        self._client.set_global_var(builtin_actor_enabled_var(actor_name), True)
-        self._notify(actor_name)
-
-    def set_disabled(self, actor_name: str):
-        self._client.set_global_var(builtin_actor_enabled_var(actor_name), False)
-        self._notify(actor_name)

--- a/bec_lib/bec_lib/builtin_actor_hli.py
+++ b/bec_lib/bec_lib/builtin_actor_hli.py
@@ -15,10 +15,6 @@ if TYPE_CHECKING:
 VAR_PREFIX = "_BuiltinActors"
 
 
-def builtin_actor_enabled_var(actor_name: str):
-    return f"{VAR_PREFIX}/enabled/{actor_name}"
-
-
 class ScanInterlockHli:
     def __init__(self, client: "BECClient", parent: "BuiltinActorHli") -> None:
         self._client = client
@@ -29,7 +25,7 @@ class ScanInterlockHli:
         )
         self._trigger_setting = RedisConfigValue(
             connector=self._client.connector,
-            endpoint=MessageEndpoints.scan_interlock_restart_scan(),
+            endpoint=MessageEndpoints.scan_interlock_trigger_setting(),
         )
 
     @property

--- a/bec_lib/bec_lib/builtin_actor_hli.py
+++ b/bec_lib/bec_lib/builtin_actor_hli.py
@@ -6,6 +6,7 @@ from bec_lib.messages import (
     BlStateStatus,
     InterlockTargetState,
     ScanInterlockModifyStateTableMessage,
+    ScanInterlockTriggerSetting,
 )
 
 if TYPE_CHECKING:
@@ -26,7 +27,7 @@ class ScanInterlockHli:
         self._enabled = RedisConfigValue(
             connector=self._client.connector, endpoint=MessageEndpoints.scan_interlock_enabled()
         )
-        self._restart_scan_on_lock = RedisConfigValue(
+        self._trigger_setting = RedisConfigValue(
             connector=self._client.connector,
             endpoint=MessageEndpoints.scan_interlock_restart_scan(),
         )
@@ -40,12 +41,15 @@ class ScanInterlockHli:
         self._enabled.value = enabled
 
     @property
-    def restart_scan_on_lock(self):
-        return self._restart_scan_on_lock.value
+    def trigger_setting(self):
+        return self._trigger_setting.value
 
-    @restart_scan_on_lock.setter
-    def restart_scan_on_lock(self, restart_scan_on_lock: bool):
-        self._restart_scan_on_lock.value = restart_scan_on_lock
+    @trigger_setting.setter
+    def trigger_setting(self, trigger_setting: str | ScanInterlockTriggerSetting):
+        accepted_values = [str(v) for v in ScanInterlockTriggerSetting]
+        if isinstance(trigger_setting, str) and trigger_setting not in accepted_values:
+            raise ValueError(f"Scan interlock trigger setting must be one of {accepted_values}!")
+        self._trigger_setting.value = ScanInterlockTriggerSetting(trigger_setting)
 
     @property
     def states_watched(self) -> dict[str, InterlockTargetState]:

--- a/bec_lib/bec_lib/client.py
+++ b/bec_lib/bec_lib/client.py
@@ -135,8 +135,8 @@ class BECClient(BECService):
         if self._initialized:
             return
         self.__init_params: _InitParams = {
-            "config": config if config is not None else ServiceConfig(config_name="client"),
-            "connector_cls": connector_cls if connector_cls is not None else RedisConnector,
+            "config": (config if config is not None else ServiceConfig(config_name="client")),
+            "connector_cls": (connector_cls if connector_cls is not None else RedisConnector),
             "wait_for_server": wait_for_server,
             "prompt_for_acl": prompt_for_acl,
         }
@@ -164,6 +164,7 @@ class BECClient(BECService):
         self._system_user = ""
         self.beamline_states = None
         self.messaging: MessagingContainer = None  # type: ignore
+        self.builtin_actors: BuiltinActorHli = None  # type: ignore
 
     def __new__(cls, *args, forced=False, **kwargs):
         if forced or BECClient._client is None:
@@ -336,6 +337,9 @@ class BECClient(BECService):
         if self.history is not None:
             # pylint: disable=protected-access
             self.history._shutdown()
+        if self.builtin_actors is not None:
+            self.builtin_actors.shutdown()
+            self.builtin_actors = None  # type: ignore
         bec_logger.logger.remove()
         self.started = False
 

--- a/bec_lib/bec_lib/client.py
+++ b/bec_lib/bec_lib/client.py
@@ -164,7 +164,6 @@ class BECClient(BECService):
         self._system_user = ""
         self.beamline_states = None
         self.messaging: MessagingContainer = None  # type: ignore
-        self.builtin_actors = BuiltinActorHli(self)
 
     def __new__(cls, *args, forced=False, **kwargs):
         if forced or BECClient._client is None:
@@ -217,6 +216,7 @@ class BECClient(BECService):
             )
             builtins.bec = self._parent
             self.macros = UserMacros(self)
+            self.builtin_actors = BuiltinActorHli(self)
             self._start_services()
             self.proc = ProcedureHli(self.connector) if self._init_procedure_hli else None
             default_namespace = {"dev": self.device_manager.devices, "scans": self.scans_namespace}

--- a/bec_lib/bec_lib/config_values.py
+++ b/bec_lib/bec_lib/config_values.py
@@ -1,0 +1,74 @@
+from typing import Any, Callable, Generic, TypeVar
+from weakref import ReferenceType
+
+from louie.saferef import BoundMethodWeakref, safe_ref
+
+from bec_lib.endpoints import EndpointInfo, MessageOp
+from bec_lib.logger import bec_logger
+from bec_lib.messages import ManagedConfigMessage
+from bec_lib.redis_connector import RedisConnector
+
+logger = bec_logger.logger
+ValueT = TypeVar("ValueT")
+
+
+class RedisConfigValue(property, Generic[ValueT]):
+    def __init__(
+        self, connector: RedisConnector, endpoint: EndpointInfo[type[ManagedConfigMessage[ValueT]]]
+    ) -> None:
+        """A config value bound to a value in Redis, which uses the ManagedConfigMessage and an associated endpoint,
+        and which can be subscribed to."""
+
+        if endpoint.message_op != MessageOp.STREAM or not issubclass(
+            endpoint.message_type, ManagedConfigMessage
+        ):
+            raise TypeError(
+                "RedisConfigManager needs a STREAM endpoint with a message type which is a subclass of ManagedConfigMessage"
+            )
+        self._ep = endpoint
+        self._connector = connector
+        self._cbs: set[ReferenceType[Callable[[ValueT]]] | BoundMethodWeakref] = set()
+        self._config = self._fetch()
+        self._connector.register(self._ep, cb=self._update_cb)
+
+    def __del__(self):
+        self.unregister_all()
+
+    def _fetch(self) -> ManagedConfigMessage[ValueT]:
+        existing = self._connector.xread(self._ep, from_start=True)
+        if existing is None:
+            config = self._ep.message_type()  # type: ignore # concrete classes must have a default
+            self._write(config)
+            return config
+        return existing[0]["config"]
+
+    def _write(self, updated: ManagedConfigMessage[ValueT]):
+        self._connector.xadd(self._ep, {"config": updated}, max_size=1)
+
+    def _update_cb(self, msg_dict: dict):
+        self._config = msg_dict["config"]
+        for cb_ref in self._cbs:
+            if cb := cb_ref():
+                try:
+                    cb(self._config.value)
+                except Exception as e:
+                    logger.error(f"Exception in managed config value callback {cb}: {e}")
+            else:
+                self._cbs.discard(cb_ref)
+
+    @property
+    def value(self) -> ValueT:
+        return self._config.value
+
+    @value.setter
+    def value(self, value: ValueT):
+        self._write(self._ep.message_type(value=value))
+
+    def subscribe(self, cb: Callable[[ValueT], Any]):
+        self._cbs.add(safe_ref(cb))
+
+    def unsubscribe(self, cb: Callable[[ValueT], Any]):
+        self._cbs.discard(safe_ref(cb))
+
+    def unregister_all(self):
+        self._connector.unregister(self._ep, cb=self._update_cb)

--- a/bec_lib/bec_lib/config_values.py
+++ b/bec_lib/bec_lib/config_values.py
@@ -34,8 +34,11 @@ class RedisConfigValue(property, Generic[ValueT]):
     def __del__(self):
         self.unregister_all()
 
+    def __bool__(self):
+        raise ValueError(f"Maybe you meant to check {self}.value?")
+
     def _fetch(self) -> ManagedConfigMessage[ValueT]:
-        existing = self._connector.xread(self._ep, from_start=True)
+        existing = self._connector.xread(self._ep, id="+", count=1)
         if existing is None:
             config = self._ep.message_type()  # type: ignore # concrete classes must have a default
             self._write(config)

--- a/bec_lib/bec_lib/config_values.py
+++ b/bec_lib/bec_lib/config_values.py
@@ -1,3 +1,4 @@
+from threading import Event
 from typing import Any, Callable, Generic, TypeVar
 from weakref import ReferenceType
 
@@ -12,17 +13,12 @@ logger = bec_logger.logger
 ValueT = TypeVar("ValueT")
 
 
-class UninitializedSentinel:
-    def __eq__(self, value: object, /) -> bool:
-        return False
-
-
-_UNINITIALIZED = UninitializedSentinel()
-
-
 class RedisConfigValue(property, Generic[ValueT]):
     def __init__(
-        self, connector: RedisConnector, endpoint: EndpointInfo[type[ManagedConfigMessage[ValueT]]]
+        self,
+        connector: RedisConnector,
+        endpoint: EndpointInfo[type[ManagedConfigMessage[ValueT]]],
+        wait_for_writes: bool = True,
     ) -> None:
         """A config value bound to a value in Redis, which uses the ManagedConfigMessage and an associated endpoint,
         and which can be subscribed to."""
@@ -38,6 +34,9 @@ class RedisConfigValue(property, Generic[ValueT]):
         self._cbs: set[ReferenceType[Callable[[ValueT]]] | BoundMethodWeakref] = set()
         self._config = self._fetch()
         self._connector.register(self._ep, cb=self._update_cb)
+        self._writing_wait_event = Event()
+        self._writing_wait_event.set()
+        self._wait_for_writes = wait_for_writes
 
     def __del__(self):
         if hasattr(self, "_connector"):
@@ -57,19 +56,29 @@ class RedisConfigValue(property, Generic[ValueT]):
             return config
         return existing[-1]["config"]
 
-    def _write(self, updated: ManagedConfigMessage[ValueT]):
+    def _write(self, updated: ManagedConfigMessage[ValueT], wait: bool = True):
+        if wait:
+            self._writing_wait_event.clear()
         self._connector.xadd(self._ep, {"config": updated}, max_size=1)
+        self._writing_wait_event.wait(timeout=2)
+        if not self._writing_wait_event.is_set():
+            logger.error(
+                f"Timed out waiting for config variable {self._ep.endpoint} to return from Redis"
+            )
 
     def _update_cb(self, msg_dict: dict):
-        self._config = msg_dict["config"]
-        for cb_ref in list(self._cbs):
-            if cb := cb_ref():
-                try:
-                    cb(self._config.value)
-                except Exception as e:
-                    logger.error(f"Exception in managed config value callback {cb}: {e}")
-            else:
-                self._cbs.discard(cb_ref)
+        try:
+            self._config = msg_dict["config"]
+            for cb_ref in list(self._cbs):
+                if cb := cb_ref():
+                    try:
+                        cb(self._config.value)
+                    except Exception as e:
+                        logger.error(f"Exception in managed config value callback {cb}: {e}")
+                else:
+                    self._cbs.discard(cb_ref)
+        finally:
+            self._writing_wait_event.set()
 
     @property
     def value(self) -> ValueT:
@@ -77,7 +86,7 @@ class RedisConfigValue(property, Generic[ValueT]):
 
     @value.setter
     def value(self, value: ValueT):
-        self._write(self._ep.message_type(value=value))
+        self._write(self._ep.message_type(value=value), self._wait_for_writes)
 
     def subscribe(self, cb: Callable[[ValueT], Any]):
         self._cbs.add(safe_ref(cb))

--- a/bec_lib/bec_lib/config_values.py
+++ b/bec_lib/bec_lib/config_values.py
@@ -12,6 +12,14 @@ logger = bec_logger.logger
 ValueT = TypeVar("ValueT")
 
 
+class UninitializedSentinel:
+    def __eq__(self, value: object, /) -> bool:
+        return False
+
+
+_UNINITIALIZED = UninitializedSentinel()
+
+
 class RedisConfigValue(property, Generic[ValueT]):
     def __init__(
         self, connector: RedisConnector, endpoint: EndpointInfo[type[ManagedConfigMessage[ValueT]]]
@@ -39,19 +47,22 @@ class RedisConfigValue(property, Generic[ValueT]):
         raise ValueError(f"Maybe you meant to check {self}.value?")
 
     def _fetch(self) -> ManagedConfigMessage[ValueT]:
-        existing = self._connector.xread(self._ep, id="+", count=1)
-        if existing is None:
+        existing = self._connector.xread(self._ep, from_start=True)
+        if existing is None or existing == []:
+            logger.warning(
+                f"No value found in redis for managed config var {self._ep.endpoint}, resetting to default."
+            )
             config = self._ep.message_type()  # type: ignore # concrete classes must have a default
             self._write(config)
             return config
-        return existing[0]["config"]
+        return existing[-1]["config"]
 
     def _write(self, updated: ManagedConfigMessage[ValueT]):
         self._connector.xadd(self._ep, {"config": updated}, max_size=1)
 
     def _update_cb(self, msg_dict: dict):
         self._config = msg_dict["config"]
-        for cb_ref in self._cbs:
+        for cb_ref in list(self._cbs):
             if cb := cb_ref():
                 try:
                     cb(self._config.value)

--- a/bec_lib/bec_lib/config_values.py
+++ b/bec_lib/bec_lib/config_values.py
@@ -32,7 +32,8 @@ class RedisConfigValue(property, Generic[ValueT]):
         self._connector.register(self._ep, cb=self._update_cb)
 
     def __del__(self):
-        self.unregister_all()
+        if hasattr(self, "_connector"):
+            self.unregister_all()
 
     def __bool__(self):
         raise ValueError(f"Maybe you meant to check {self}.value?")

--- a/bec_lib/bec_lib/config_values.py
+++ b/bec_lib/bec_lib/config_values.py
@@ -29,14 +29,18 @@ class RedisConfigValue(property, Generic[ValueT]):
             raise TypeError(
                 "RedisConfigManager needs a STREAM endpoint with a message type which is a subclass of ManagedConfigMessage"
             )
+
         self._ep = endpoint
         self._connector = connector
-        self._cbs: set[ReferenceType[Callable[[ValueT]]] | BoundMethodWeakref] = set()
-        self._config = self._fetch()
-        self._connector.register(self._ep, cb=self._update_cb)
+
         self._writing_wait_event = Event()
         self._writing_wait_event.set()
         self._wait_for_writes = wait_for_writes
+
+        self._cbs: set[ReferenceType[Callable[[ValueT]]] | BoundMethodWeakref] = set()
+
+        self._config = self._fetch()
+        self._connector.register(self._ep, cb=self._update_cb)
 
     def __del__(self):
         if hasattr(self, "_connector"):
@@ -52,11 +56,11 @@ class RedisConfigValue(property, Generic[ValueT]):
                 f"No value found in redis for managed config var {self._ep.endpoint}, resetting to default."
             )
             config = self._ep.message_type()  # type: ignore # concrete classes must have a default
-            self._write(config)
+            self._write(config, False)
             return config
         return existing[-1]["config"]
 
-    def _write(self, updated: ManagedConfigMessage[ValueT], wait: bool = True):
+    def _write(self, updated: ManagedConfigMessage[ValueT], wait):
         if wait:
             self._writing_wait_event.clear()
         self._connector.xadd(self._ep, {"config": updated}, max_size=1)

--- a/bec_lib/bec_lib/endpoints.py
+++ b/bec_lib/bec_lib/endpoints.py
@@ -1646,16 +1646,6 @@ class MessageEndpoints:
         )
 
     @staticmethod
-    def builtin_actor_update_req_notif():
-        """Endpoint to notify a builtin actor of a pending state change request."""
-        endpoint = f"{EndpointType.INTERNAL.value}/actor/builtin/state_change_request_notification"
-        return EndpointInfo(
-            endpoint=endpoint,
-            message_type=messages.BuiltinActorStateChangeNotification,
-            message_op=MessageOp.SEND,
-        )
-
-    @staticmethod
     def builtin_actor_update_notif(actor_name: str):
         """Endpoint to notify clients of builtin actor state changes."""
         endpoint = f"{EndpointType.INFO.value}/actor/builtin/{actor_name}/state_change_done"
@@ -1693,11 +1683,9 @@ class MessageEndpoints:
         )
 
     @staticmethod
-    def scan_interlock_restart_scan():
+    def scan_interlock_trigger_setting():
         """Whether to restart the scan when the interlock is triggered."""
-        endpoint = (
-            f"{EndpointType.INFO.value}/actor/builtin/scan_interlock/config/restart_scan_on_lock"
-        )
+        endpoint = f"{EndpointType.INFO.value}/actor/builtin/scan_interlock/config/trigger_setting"
         return EndpointInfo(
             endpoint=endpoint,
             message_type=messages.ScanInterlockTriggerSettingMessage,

--- a/bec_lib/bec_lib/endpoints.py
+++ b/bec_lib/bec_lib/endpoints.py
@@ -1700,7 +1700,7 @@ class MessageEndpoints:
         )
         return EndpointInfo(
             endpoint=endpoint,
-            message_type=messages.BoolConfigDefaultFalse,
+            message_type=messages.ScanInterlockTriggerSettingMessage,
             message_op=MessageOp.STREAM,
         )
 

--- a/bec_lib/bec_lib/endpoints.py
+++ b/bec_lib/bec_lib/endpoints.py
@@ -56,7 +56,7 @@ class MessageOp(list[str], enum.Enum):
     SET = ["remove_from_set", "get_set_members", "delete"]
 
 
-MessageType = TypeVar("MessageType", bound="type[messages.BECMessage]")
+MessageType = TypeVar("MessageType", bound="type[messages.BECMessage]", covariant=True)
 
 
 @dataclass
@@ -1417,7 +1417,7 @@ class MessageEndpoints:
     # Procedures
 
     @staticmethod
-    def available_procedures() -> EndpointInfo:
+    def available_procedures():
         """
         Endpoint for available procedures. This endpoint is used to publish the available procedures
         using an AvailableResourceMessage.
@@ -1433,7 +1433,7 @@ class MessageEndpoints:
         )
 
     @staticmethod
-    def procedure_request() -> EndpointInfo:
+    def procedure_request():
         """
         Endpoint for requesting new procedures.
         The request is sent using a messages.ProcedureRequestMessage message.
@@ -1449,7 +1449,7 @@ class MessageEndpoints:
         )
 
     @staticmethod
-    def procedure_request_response() -> EndpointInfo:
+    def procedure_request_response():
         """
         Endpoint for procedure request responses. This endpoint is used to publish the
         information on whether the procedure request was accepted or rejected. The response
@@ -1561,7 +1561,7 @@ class MessageEndpoints:
         )
 
     @staticmethod
-    def procedure_status_update() -> EndpointInfo:
+    def procedure_status_update():
         """
         Endpoint for individual procedure status updates. Mainly for use in updating procedure statuses in the helper.
         For general queue monitoring, use the procedure_queue_notif endpoint and read the queues instead.
@@ -1637,7 +1637,7 @@ class MessageEndpoints:
         )
 
     @staticmethod
-    def actor_request_response() -> EndpointInfo:
+    def actor_request_response():
         endpoint = f"{EndpointType.INFO.value}/actor/request_response"
         return EndpointInfo(
             endpoint=endpoint,
@@ -1646,7 +1646,7 @@ class MessageEndpoints:
         )
 
     @staticmethod
-    def builtin_actor_update_req_notif() -> EndpointInfo:
+    def builtin_actor_update_req_notif():
         """Endpoint to notify a builtin actor of a pending state change request."""
         endpoint = f"{EndpointType.INTERNAL.value}/actor/builtin/state_change_request_notification"
         return EndpointInfo(
@@ -1656,7 +1656,7 @@ class MessageEndpoints:
         )
 
     @staticmethod
-    def builtin_actor_update_notif(actor_name: str) -> EndpointInfo:
+    def builtin_actor_update_notif(actor_name: str):
         """Endpoint to notify clients of builtin actor state changes."""
         endpoint = f"{EndpointType.INFO.value}/actor/builtin/{actor_name}/state_change_done"
         return EndpointInfo(
@@ -1666,7 +1666,7 @@ class MessageEndpoints:
         )
 
     @staticmethod
-    def modify_interlock_table() -> EndpointInfo:
+    def modify_interlock_table():
         endpoint = f"{EndpointType.INTERNAL.value}/actor/builtin/scan_interlock/table_mod"
         return EndpointInfo(
             endpoint=endpoint,
@@ -1675,12 +1675,21 @@ class MessageEndpoints:
         )
 
     @staticmethod
-    def scan_interlock_states() -> EndpointInfo:
+    def scan_interlock_states():
         endpoint = f"{EndpointType.INFO.value}/actor/builtin/scan_interlock/current_states_watched"
         return EndpointInfo(
             endpoint=endpoint,
             message_type=messages.ScanInterlockStateTableContent,
             message_op=MessageOp.KEY_VALUE,
+        )
+
+    @staticmethod
+    def scan_interlock_enabled():
+        endpoint = f"{EndpointType.INFO.value}/actor/builtin/scan_interlock/config/enabled"
+        return EndpointInfo(
+            endpoint=endpoint,
+            message_type=messages.BoolConfigDefaultFalse,
+            message_op=MessageOp.STREAM,
         )
 
     @staticmethod

--- a/bec_lib/bec_lib/endpoints.py
+++ b/bec_lib/bec_lib/endpoints.py
@@ -1693,6 +1693,18 @@ class MessageEndpoints:
         )
 
     @staticmethod
+    def scan_interlock_restart_scan():
+        """Whether to restart the scan when the interlock is triggered."""
+        endpoint = (
+            f"{EndpointType.INFO.value}/actor/builtin/scan_interlock/config/restart_scan_on_lock"
+        )
+        return EndpointInfo(
+            endpoint=endpoint,
+            message_type=messages.BoolConfigDefaultFalse,
+            message_op=MessageOp.STREAM,
+        )
+
+    @staticmethod
     def gui_registry_state(gui_id: str):
         """
         Endpoint for GUI registry state. This endpoint is used to publish the GUI registry state

--- a/bec_lib/bec_lib/messages.py
+++ b/bec_lib/bec_lib/messages.py
@@ -9,7 +9,18 @@ from copy import deepcopy
 from enum import Enum, auto
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as importlib_version
-from typing import Annotated, Any, ClassVar, Literal, Mapping, Self, TypedDict, Union
+from typing import (
+    Annotated,
+    Any,
+    ClassVar,
+    Generic,
+    Literal,
+    Mapping,
+    Self,
+    TypedDict,
+    TypeVar,
+    Union,
+)
 from uuid import uuid4
 
 import numpy as np
@@ -93,6 +104,23 @@ class BECMessage(BaseModel):
 
     def __hash__(self) -> int:
         return self.model_dump_json().__hash__()
+
+
+T = TypeVar("T")
+
+
+class ManagedConfigMessage(BECMessage, Generic[T]):
+    """Type to hold managed config values for the RedisConfigManager. Subclasses should have only one
+    field, `value`, which must have a default. This type can in turn contain multiple values if they
+    must be updated together."""
+
+    model_config = ConfigDict(validate_assignment=True)
+    value: T
+
+
+class BoolConfigDefaultFalse(ManagedConfigMessage[bool]):
+    msg_type: ClassVar[str] = "bool_config_default_false"
+    value: bool = False
 
 
 class BundleMessage(BECMessage):
@@ -2140,6 +2168,25 @@ class ScanInterlockModifyStateTableMessage(BECMessage):
 class ScanInterlockStateTableContent(BECMessage):
     msg_type: ClassVar[str] = "scan_interlock_state_table_content"
     states_watched: dict[str, InterlockTargetState]
+
+
+class BuiltinActorManagerConfig(BECMessage):
+    """Config for the builtin actor manager"""
+
+    model_config = ConfigDict(validate_assignment=True)
+    interlock_enabled: bool = Field(
+        True,
+        description="Enable the scan interlock to lock the queue when watched beamline states become invalid.",
+    )
+
+
+class ScanInterlockConfig(BECMessage):
+    """Config for the scan interlock actor. All fields should have defaults."""
+
+    model_config = ConfigDict(validate_assignment=True)
+    restart_scan_on_lock: bool = Field(
+        False, description="Abort and re-queue the running scan when the interlock triggers."
+    )
 
 
 class ActorStartRequestMessage(BECMessage):

--- a/bec_lib/bec_lib/messages.py
+++ b/bec_lib/bec_lib/messages.py
@@ -2170,25 +2170,6 @@ class ScanInterlockStateTableContent(BECMessage):
     states_watched: dict[str, InterlockTargetState]
 
 
-class BuiltinActorManagerConfig(BECMessage):
-    """Config for the builtin actor manager"""
-
-    model_config = ConfigDict(validate_assignment=True)
-    interlock_enabled: bool = Field(
-        True,
-        description="Enable the scan interlock to lock the queue when watched beamline states become invalid.",
-    )
-
-
-class ScanInterlockConfig(BECMessage):
-    """Config for the scan interlock actor. All fields should have defaults."""
-
-    model_config = ConfigDict(validate_assignment=True)
-    restart_scan_on_lock: bool = Field(
-        False, description="Abort and re-queue the running scan when the interlock triggers."
-    )
-
-
 class ActorStartRequestMessage(BECMessage):
     """Specify an actor class by module and name, to be instantiated and started by the actor
     manager."""

--- a/bec_lib/bec_lib/messages.py
+++ b/bec_lib/bec_lib/messages.py
@@ -6,7 +6,7 @@ import time
 import uuid
 import warnings
 from copy import deepcopy
-from enum import Enum, auto
+from enum import Enum, StrEnum, auto
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as importlib_version
 from typing import (
@@ -2168,6 +2168,17 @@ class ScanInterlockModifyStateTableMessage(BECMessage):
 class ScanInterlockStateTableContent(BECMessage):
     msg_type: ClassVar[str] = "scan_interlock_state_table_content"
     states_watched: dict[str, InterlockTargetState]
+
+
+class ScanInterlockTriggerSetting(StrEnum):
+    DO_NOTHING = auto()
+    RESTART_SCAN = auto()
+    PAUSE_SCAN = auto()
+
+
+class ScanInterlockTriggerSettingMessage(ManagedConfigMessage[ScanInterlockTriggerSetting]):
+    msg_type: ClassVar[str] = "scan_interlock_trigger_setting"
+    value: ScanInterlockTriggerSetting = ScanInterlockTriggerSetting.DO_NOTHING
 
 
 class ActorStartRequestMessage(BECMessage):

--- a/bec_lib/bec_lib/redis_connector.py
+++ b/bec_lib/bec_lib/redis_connector.py
@@ -316,7 +316,7 @@ class StreamSubs:
 
     def add_direct_listener(self, topic: str, new_sub: DirectReadStreamSubInfo):
         self._check_registered(topic, new_sub)
-        if not topic in self._direct_read_subs:
+        if topic not in self._direct_read_subs:
             self._direct_read_subs[topic] = {}
         self._direct_read_subs[topic][new_sub] = new_sub
         new_sub.thread.start()

--- a/bec_lib/bec_lib/tests/utils.py
+++ b/bec_lib/bec_lib/tests/utils.py
@@ -4,7 +4,7 @@ import builtins
 import os
 import time
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Callable, Literal
 from unittest.mock import MagicMock
 
 import bec_lib
@@ -659,3 +659,14 @@ class ConnectorMock(RedisConnector):  # pragma: no cover
     ):
         if not isinstance(group_name, str) or not isinstance(metrics, dict):
             raise TypeError("invalid arguments to publish_metrics")
+
+
+def wait_until(predicate: Callable[[], bool], timeout_s: float = 0.1):
+    # Yes I know this is actually more like retries than a timeout,
+    # it's just to make sure the threads have plenty of chances to switch in the test
+    elapsed, step = 0.0, timeout_s / 10
+    while not predicate():
+        time.sleep(step)
+        elapsed += step
+        if elapsed > timeout_s:
+            raise TimeoutError()

--- a/bec_lib/tests/test_managed_config_values.py
+++ b/bec_lib/tests/test_managed_config_values.py
@@ -1,4 +1,3 @@
-import threading
 from unittest.mock import Mock
 
 import pytest

--- a/bec_lib/tests/test_managed_config_values.py
+++ b/bec_lib/tests/test_managed_config_values.py
@@ -1,0 +1,69 @@
+import threading
+from unittest.mock import Mock
+
+import pytest
+
+from bec_lib.config_values import RedisConfigValue
+from bec_lib.endpoints import EndpointInfo, MessageOp
+from bec_lib.messages import BoolConfigDefaultFalse
+from bec_lib.tests.utils import wait_until
+
+
+@pytest.fixture
+def endpoint():
+    return EndpointInfo(
+        endpoint="test/config", message_type=BoolConfigDefaultFalse, message_op=MessageOp.STREAM
+    )
+
+
+def test_fetch_existing_value(endpoint):
+    connector = Mock()
+
+    existing = BoolConfigDefaultFalse(value=True)
+    connector.xread.return_value = [{"config": existing}]
+
+    cfg = RedisConfigValue(connector, endpoint)
+
+    assert cfg.value is True
+
+    connector.register.assert_called_once_with(endpoint, cb=cfg._update_cb)
+
+
+def test_invalid_endpoint_op():
+    connector = Mock()
+
+    bad_endpoint = EndpointInfo(
+        endpoint="test/config", message_type=BoolConfigDefaultFalse, message_op=MessageOp.KEY_VALUE
+    )
+
+    with pytest.raises(TypeError):
+        RedisConfigValue(connector, bad_endpoint)
+
+
+class NotManagedMessage:
+    pass
+
+
+def test_invalid_endpoint_message_type():
+    connector = Mock()
+
+    bad_endpoint = EndpointInfo(
+        endpoint="test/config", message_type=NotManagedMessage, message_op=MessageOp.STREAM
+    )
+
+    with pytest.raises(TypeError):
+        RedisConfigValue(connector, bad_endpoint)
+
+
+def test_config_value_redis_roundtrip(connected_connector, endpoint):
+    recorder = Mock()
+
+    def cb(value: bool):
+        recorder(value)
+
+    managed_var = RedisConfigValue(connected_connector, endpoint)
+    managed_var.subscribe(cb)
+    assert managed_var.value is False
+    managed_var.value = True
+    wait_until(lambda: managed_var.value is True)
+    recorder.assert_called_once_with(True)

--- a/bec_lib/tests/test_managed_config_values.py
+++ b/bec_lib/tests/test_managed_config_values.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -15,16 +15,17 @@ def endpoint():
     )
 
 
-def test_fetch_existing_value(endpoint):
+@pytest.fixture
+def connector():
     connector = Mock()
-
     existing = BoolConfigDefaultFalse(value=True)
     connector.xread.return_value = [{"config": existing}]
+    return connector
 
+
+def test_fetch_existing_value(connector, endpoint):
     cfg = RedisConfigValue(connector, endpoint)
-
     assert cfg.value is True
-
     connector.register.assert_called_once_with(endpoint, cb=cfg._update_cb)
 
 
@@ -66,3 +67,17 @@ def test_config_value_redis_roundtrip(connected_connector, endpoint):
     managed_var.value = True
     wait_until(lambda: managed_var.value is True)
     recorder.assert_called_once_with(True)
+
+
+def test_wait_not_used_if_disabled(connector, endpoint):
+    with patch("bec_lib.config_values.Event") as event_mock:
+        cfg = RedisConfigValue(connector, endpoint, wait_for_writes=False)
+        cfg.value = False
+        event_mock().clear.assert_not_called()
+
+
+def test_wait_used_if_not_specified(connector, endpoint):
+    with patch("bec_lib.config_values.Event") as event_mock:
+        cfg = RedisConfigValue(connector, endpoint)
+        cfg.value = False
+        event_mock().clear.assert_called()

--- a/bec_server/bec_server/actors/actor.py
+++ b/bec_server/bec_server/actors/actor.py
@@ -66,13 +66,10 @@ class SubscriptionActor(ActorBase):
     """An actor which subscribes to a list of redis endpoints, and evaluates on any message to any
     of those endpoints."""
 
-    min_delay_s: float = 0.01
-
     def __init__(self, client: BECClient, name: str, exec_id: str):
         super().__init__(client, name, exec_id)
         self._endpoints = self.default_monitor_endpoints()
         self._stopped = False
-        self.last_evaluated = 0
 
         logger.info(f"Setting up {self.__class__.__name__}: {self._endpoints}.")
         for endpoint in self._endpoints:
@@ -89,10 +86,7 @@ class SubscriptionActor(ActorBase):
     def evaluate(self, *_, **__):
         if self._stopped:
             return
-        if (now := time.monotonic()) < self.last_evaluated + self.min_delay_s:
-            return
-        logger.debug(f"{self.__class__.__name__} evaluated")
-        self.last_evaluated = now
+        logger.debug(f"{self.__class__.__name__} evaluating")
         return super().evaluate(*_, **__)
 
     def run(self):

--- a/bec_server/bec_server/actors/builtin_actor_manager.py
+++ b/bec_server/bec_server/actors/builtin_actor_manager.py
@@ -21,6 +21,7 @@ ActorType = TypeVar("ActorType", bound=ActorBase)
 
 
 class ActorDict(dict):
+
     def __setitem__(self, key: type[ActorType], value: tuple[ActorType, Thread, Event], /) -> None:
         return super().__setitem__(key, value)
 
@@ -66,7 +67,7 @@ class BuiltinActorManager:
         )
 
     def _interlock_enabled_changed(self, enabled: bool):
-        self._start_actor(ScanInterlockActor) if enabled else self._stop_actor(ScanInterlockActor)
+        (self._start_actor(ScanInterlockActor) if enabled else self._stop_actor(ScanInterlockActor))
 
     def _start_all(self):
         if self._scan_interlock_enabled.value:
@@ -95,6 +96,7 @@ class BuiltinActorManager:
         del actor
 
     def shutdown(self):
+        self._scan_interlock_enabled.unregister_all()
         for actor in list(self._actors_threads_and_stops):
             self._stop_actor(actor)
         self._client.shutdown()

--- a/bec_server/bec_server/actors/builtin_actor_manager.py
+++ b/bec_server/bec_server/actors/builtin_actor_manager.py
@@ -2,6 +2,7 @@ from threading import Event, Thread
 from typing import TypeVar
 
 from bec_lib.client import BECClient, ServiceConfig
+from bec_lib.config_values import RedisConfigValue
 from bec_lib.connector import MessageObject
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.logger import bec_logger
@@ -46,11 +47,13 @@ class BuiltinActorManager:
         )
         self._client.start()
         self._actors_threads_and_stops = ActorDict()
-        self._builtin_actors = {cls.__name__: cls for cls in (ScanInterlockActor,)}
-        self._start_all()
-        self._client.connector.register(
-            MessageEndpoints.builtin_actor_update_req_notif(), cb=self._on_state_changed
+
+        self._scan_interlock_enabled = RedisConfigValue(
+            connector=self._client.connector, endpoint=MessageEndpoints.scan_interlock_enabled()
         )
+        self._scan_interlock_enabled.subscribe(self._interlock_enabled_changed)
+
+        self._start_all()
         self._client.connector.register(
             MessageEndpoints.modify_interlock_table(), cb=self._modify_interlock_table
         )
@@ -64,22 +67,12 @@ class BuiltinActorManager:
             BuiltinActorStateUpdatedNotification(actor_name=actor_name),
         )
 
-    def _on_state_changed(self, msg_obj: MessageObject):
-        msg: BuiltinActorStateChangeNotification = msg_obj.value  # type: ignore
-        logger.info(f"Received state change notification {msg.actor_name}")
-        if msg.actor_name not in self._builtin_actors:
-            logger.error(f"Actor {msg.actor_name} does not exist!")
-            return
-        if self._client.builtin_actors.check_enabled(msg.actor_name):
-            self._start_actor(self._builtin_actors[msg.actor_name])
-        else:
-            self._stop_actor(msg.actor_name)
-        self._ping_clients(msg.actor_name)
+    def _interlock_enabled_changed(self, enabled: bool):
+        self._start_actor(ScanInterlockActor) if enabled else self._stop_actor(ScanInterlockActor)
 
     def _start_all(self):
-        for actor_class_name in self._builtin_actors:
-            if self._client.builtin_actors.check_enabled(actor_class_name):
-                self._start_actor(self._builtin_actors[actor_class_name])
+        if self._scan_interlock_enabled.value:
+            self._start_actor(ScanInterlockActor)
 
     def _start_actor(self, actor_class: type[ActorBase]):
         name = actor_class.__name__
@@ -92,11 +85,10 @@ class BuiltinActorManager:
         self._actors_threads_and_stops[actor_class] = (actor, t, actor.stop_event)
         t.start()
 
-    def _stop_actor(self, actor_name: str):
-        logger.info(f"Stopping {actor_name}")
-        actor_class = self._builtin_actors.get(actor_name)
+    def _stop_actor(self, actor_class: type[ActorBase]):
+        logger.info(f"Stopping {actor_class.__name__}")
         if (entry := self._actors_threads_and_stops.get(actor_class)) is None:
-            logger.warning(f"Actor {actor_name} is not active!")
+            logger.warning(f"Actor {actor_class.__name__} is not active!")
             return
         actor, t, event = entry
         event.set()

--- a/bec_server/bec_server/actors/builtin_actor_manager.py
+++ b/bec_server/bec_server/actors/builtin_actor_manager.py
@@ -3,12 +3,10 @@ from typing import TypeVar
 
 from bec_lib.client import BECClient, ServiceConfig
 from bec_lib.config_values import RedisConfigValue
-from bec_lib.connector import MessageObject
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.logger import bec_logger
 from bec_lib.messages import (
     AvailableBeamlineStatesMessage,
-    BuiltinActorStateChangeNotification,
     BuiltinActorStateUpdatedNotification,
     InterlockTargetState,
     ScanInterlockModifyStateTableMessage,

--- a/bec_server/bec_server/actors/builtin_actor_manager.py
+++ b/bec_server/bec_server/actors/builtin_actor_manager.py
@@ -58,7 +58,7 @@ class BuiltinActorManager:
             MessageEndpoints.modify_interlock_table(), cb=self._modify_interlock_table
         )
         self._client.connector.register(
-            MessageEndpoints.available_beamline_states(), cb=self._handle_state_update
+            MessageEndpoints.available_beamline_states(), cb=self._handle_beamline_state_update
         )
 
     def _ping_clients(self, actor_name: str):
@@ -97,7 +97,7 @@ class BuiltinActorManager:
         del actor
 
     def shutdown(self):
-        for actor in self._actors_threads_and_stops:
+        for actor in list(self._actors_threads_and_stops):
             self._stop_actor(actor)
         self._client.shutdown()
 
@@ -114,7 +114,7 @@ class BuiltinActorManager:
         )
         return states.states_watched if states is not None else {}
 
-    def _handle_state_update(self, msg_dict: dict):
+    def _handle_beamline_state_update(self, msg_dict: dict):
         msg: AvailableBeamlineStatesMessage = msg_dict["data"]
         state_names = [state.name for state in msg.states]
         for watched_state in self._current_watched_states():

--- a/bec_server/bec_server/actors/scan_interlock.py
+++ b/bec_server/bec_server/actors/scan_interlock.py
@@ -6,6 +6,7 @@ from bec_lib.messages import (
     BuiltinActorStateUpdatedNotification,
     ScanInterlockModifyStateTableMessage,
     ScanInterlockStateTableContent,
+    ScanInterlockTriggerSetting,
 )
 from bec_lib.messaging_hooks import MessagingEvent
 from bec_lib.messaging_services import NotificationMessageObject
@@ -106,9 +107,12 @@ class ScanInterlockActor(BlStateActor):
             reason=f"Interlock for beamline states: {self.mismatched_states}",
             lock_id=self._LOCK_ID,
         )
-        if self._restart_scan_on_lock.value:
+        if self._restart_scan_on_lock.value == ScanInterlockTriggerSetting.RESTART_SCAN:
             logger.info("Scan interlock requesting scan restart.")
             self.client.queue.request_scan_restart()
+        elif self._restart_scan_on_lock.value == ScanInterlockTriggerSetting.PAUSE_SCAN:
+            # TODO: update when pause implemented
+            logger.warning("Pausing scans not yet implemented")
 
     def all_match_action(self, client: BECClient):
         self._unlock()

--- a/bec_server/bec_server/actors/scan_interlock.py
+++ b/bec_server/bec_server/actors/scan_interlock.py
@@ -1,4 +1,5 @@
 from bec_lib.client import BECClient
+from bec_lib.config_values import RedisConfigValue
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.logger import bec_logger
 from bec_lib.messages import (
@@ -28,6 +29,10 @@ class ScanInterlockActor(BlStateActor):
             self.state_table = {}
 
         super().__init__(client, name, exec_id)
+
+        self._restart_scan_on_lock = RedisConfigValue(
+            connector=self.client.connector, endpoint=MessageEndpoints.scan_interlock_restart_scan()
+        )
 
     def _ping_clients(self):
         logger.debug(f"{self.name} pinging clients that it was updated")
@@ -101,7 +106,9 @@ class ScanInterlockActor(BlStateActor):
             reason=f"Interlock for beamline states: {self.mismatched_states}",
             lock_id=self._LOCK_ID,
         )
-        self.client.queue.request_scan_restart()
+        if self._restart_scan_on_lock.value:
+            logger.info("Scan interlock requesting scan restart.")
+            self.client.queue.request_scan_restart()
 
     def all_match_action(self, client: BECClient):
         self._unlock()

--- a/bec_server/bec_server/actors/scan_interlock.py
+++ b/bec_server/bec_server/actors/scan_interlock.py
@@ -32,7 +32,8 @@ class ScanInterlockActor(BlStateActor):
         super().__init__(client, name, exec_id)
 
         self._restart_scan_on_lock = RedisConfigValue(
-            connector=self.client.connector, endpoint=MessageEndpoints.scan_interlock_restart_scan()
+            connector=self.client.connector,
+            endpoint=MessageEndpoints.scan_interlock_trigger_setting(),
         )
 
     def _ping_clients(self):

--- a/bec_server/bec_server/actors/scan_interlock.py
+++ b/bec_server/bec_server/actors/scan_interlock.py
@@ -139,5 +139,6 @@ class ScanInterlockActor(BlStateActor):
         self._unlock()
 
     def stop(self, *_):
+        self._restart_scan_on_lock.unregister_all()
         self._unlock()
         super().stop()

--- a/bec_server/tests/tests_scan_server/test_builtin_actor_manager.py
+++ b/bec_server/tests/tests_scan_server/test_builtin_actor_manager.py
@@ -9,6 +9,7 @@ from bec_lib.messages import (
     ScanInterlockModifyStateTableMessage,
     ScanInterlockStateTableContent,
 )
+from bec_lib.tests.utils import BECClient
 from bec_server.actors.builtin_actor_manager import BuiltinActorManager
 
 
@@ -27,6 +28,7 @@ class DummyActor:
 def mocked_manager():
     with (
         patch("bec_server.actors.builtin_actor_manager.BECClient") as mock_client_cls,
+        patch("bec_server.actors.builtin_actor_manager.ScanInterlockActor", DummyActor),
         patch.object(BuiltinActorManager, "_start_all"),
     ):
         mock_client = MagicMock()
@@ -35,8 +37,8 @@ def mocked_manager():
         mock_client_cls.return_value = mock_client
 
         manager = BuiltinActorManager("localhost:6379")
-        with patch.object(manager, "_builtin_actors", {"DummyActor": DummyActor}):
-            yield manager, mock_client
+        # with patch.object(manager, "_builtin_actors", {"DummyActor": DummyActor}):
+        yield manager, mock_client
 
 
 def test_init_registers_callback(mocked_manager):
@@ -48,7 +50,7 @@ def test_init_registers_callback(mocked_manager):
 
     kwargs = mock_client.connector.register.call_args_list[0].kwargs
     assert "cb" in kwargs
-    assert kwargs["cb"] == manager._on_state_changed
+    assert kwargs["cb"] == manager._scan_interlock_enabled._update_cb
 
     kwargs = mock_client.connector.register.call_args_list[1].kwargs
     assert "cb" in kwargs
@@ -93,7 +95,7 @@ def test_stop_actor_sets_event_and_joins(mocked_manager):
 
     manager._actors_threads_and_stops[DummyActor] = (actor, mock_thread, actor.stop_event)
 
-    manager._stop_actor("DummyActor")
+    manager._stop_actor(DummyActor)
 
     assert actor.stop_event.is_set()
     mock_thread.join.assert_called_once()
@@ -102,40 +104,21 @@ def test_stop_actor_sets_event_and_joins(mocked_manager):
 def test_stop_actor_missing_is_noop(mocked_manager):
     manager, _ = mocked_manager
 
+    class MissingActor(DummyActor): ...
+
     # Should not raise
-    manager._stop_actor("MissingActor")
+    manager._stop_actor(MissingActor)
 
 
-def test_on_state_changed_starts_enabled_actor(mocked_manager):
-    manager, mock_client = mocked_manager
-
-    manager._builtin_actors = {"DummyActor": DummyActor}
-
-    msg = MagicMock()
-    msg.value.actor_name = "DummyActor"
-
-    mock_client.builtin_actors.check_enabled.return_value = True
-
-    with patch.object(manager, "_start_actor") as mock_start:
-        manager._on_state_changed(msg)
-
-    mock_start.assert_called_once_with(DummyActor)
-
-
-def test_on_state_changed_unknown_actor(mocked_manager):
+def test_on_state_changed_starts_enabled_actor(
+    mocked_manager: tuple[BuiltinActorManager, BECClient],
+):
     manager, _ = mocked_manager
 
-    msg = MagicMock()
-    msg.value.actor_name = "UnknownActor"
+    with patch.object(manager, "_start_actor") as mock_start:
+        manager._interlock_enabled_changed(True)
 
-    with (
-        patch.object(manager, "_start_actor") as mock_start,
-        patch.object(manager, "_stop_actor") as mock_stop,
-    ):
-        manager._on_state_changed(msg)
-
-    mock_start.assert_not_called()
-    mock_stop.assert_not_called()
+    mock_start.assert_called_once_with(DummyActor)
 
 
 def test_shutdown_stops_all_and_shuts_down_client(mocked_manager):
@@ -193,7 +176,7 @@ def test_handle_state_update(mocked_manager):
     manager, _ = mocked_manager
     manager._current_watched_states = lambda: {"test_state": "valid"}
     manager._modify_interlock_table = MagicMock()
-    manager._handle_state_update({"data": AvailableBeamlineStatesMessage(states=[])})
+    manager._handle_beamline_state_update({"data": AvailableBeamlineStatesMessage(states=[])})
     manager._modify_interlock_table.assert_called_with(
         {"data": ScanInterlockModifyStateTableMessage(action="remove", state_name="test_state")}
     )

--- a/bec_server/tests/tests_scan_server/test_builtin_actor_manager.py
+++ b/bec_server/tests/tests_scan_server/test_builtin_actor_manager.py
@@ -37,7 +37,6 @@ def mocked_manager():
         mock_client_cls.return_value = mock_client
 
         manager = BuiltinActorManager("localhost:6379")
-        # with patch.object(manager, "_builtin_actors", {"DummyActor": DummyActor}):
         yield manager, mock_client
 
 


### PR DESCRIPTION
- Adds a `RedisConfigValue` which associates to a config value in Redis which can be subscribed to, and infers the type of the config value from the endpoint and message type
- Uses this for the interlock enabled config value
- Uses this to determine whether to restart a scan or not if the interlock triggers.