### PR TITLE
Fix/device progress lock

### DIFF
--- a/bec_ipython_client/bec_ipython_client/callbacks/device_progress.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/device_progress.py
@@ -34,9 +34,12 @@ class LiveUpdatesDeviceProgress(LiveUpdatesTable):
 
         status_message = getattr(self.scan_item, "status_message", None)
         if status_message and getattr(status_message, "reason", None) == "user":
-            raise ScanInterruption(
-                f"Scan {getattr(self.scan_item, 'scan_number', None)} was aborted by user."
-            )
+            scan_number = getattr(self.scan_item, "scan_number", None)
+            if scan_number is None:
+                msg = "Scan was aborted by user."
+            else:
+                msg = f"Scan {scan_number} was aborted by user."
+            raise ScanInterruption(msg)
 
         return False
 
@@ -49,7 +52,7 @@ class LiveUpdatesDeviceProgress(LiveUpdatesTable):
         """Run the update loop for the progress bar.
 
         Args:
-            device_names (list[str]): The name of the device to monitor.
+            device_names (list[str]): The names of the devices to monitor.
         """
         with ScanProgressBar(
             scan_number=self.scan_item.scan_number, clear_on_exit=False
@@ -65,7 +68,7 @@ class LiveUpdatesDeviceProgress(LiveUpdatesTable):
 
         Args:
             progressbar (ScanProgressBar): The progressbar to update.
-            device_names (str): The name of the device to monitor.
+            device_names (list[str]): The names of the devices to monitor.
         Returns:
             bool: True if the scan is finished.
         """

--- a/bec_ipython_client/bec_ipython_client/callbacks/device_progress.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/device_progress.py
@@ -1,6 +1,7 @@
 import time
 
 from bec_ipython_client.progressbar import ScanProgressBar
+from bec_lib.bec_errors import ScanInterruption, ScanRestart
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.logger import bec_logger
 
@@ -13,6 +14,31 @@ class LiveUpdatesDeviceProgress(LiveUpdatesTable):
     """Live updates for scans using a progress bar based on the progress of one or more devices"""
 
     REPORT_TYPE = "device_progress"
+
+    def _check_scan_state(self) -> bool:
+        """Check whether the scan has reached a terminal or exceptional state.
+
+        Returns:
+            bool: True if the scan should stop without error.
+        """
+        if not self.scan_item:
+            return False
+
+        restarted_msg = getattr(self.scan_item, "restarted_msg", None)
+        if restarted_msg:
+            raise ScanRestart(new_scan_msg=restarted_msg)
+
+        if getattr(self.scan_item, "status", None) == "user_completed":
+            print("Scan was set to 'completed' by user.")
+            return True
+
+        status_message = getattr(self.scan_item, "status_message", None)
+        if status_message and getattr(status_message, "reason", None) == "user":
+            raise ScanInterruption(
+                f"Scan {getattr(self.scan_item, 'scan_number', None)} was aborted by user."
+            )
+
+        return False
 
     def core(self):
         """core function to run the live updates for the table"""
@@ -44,6 +70,8 @@ class LiveUpdatesDeviceProgress(LiveUpdatesTable):
             bool: True if the scan is finished.
         """
         self.check_alarms()
+        if self._check_scan_state():
+            return True
         status = self.bec.connector.get(MessageEndpoints.device_progress(device_names[0]))
         if not status:
             logger.trace("waiting for new data point")
@@ -68,6 +96,8 @@ class LiveUpdatesDeviceProgress(LiveUpdatesTable):
         # process sync callbacks
         self.bec.callbacks.poll()
         self.scan_item.poll_callbacks()
+        if self._check_scan_state():
+            return True
 
         done = status.content.get("done")
         if point_id == max_value or done:

--- a/bec_ipython_client/bec_ipython_client/callbacks/ipython_live_updates.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/ipython_live_updates.py
@@ -363,7 +363,7 @@ class IPythonLiveUpdates:
             return
 
         status = target_queue_status.status
-        if status == "LOCKED":
+        if status == "LOCKED" and any(queue.scan_ids):
             lock_info = [
                 f"{lock.identifier}: {lock.reason}\n" for lock in target_queue_status.locks
             ]

--- a/bec_ipython_client/tests/client_tests/test_device_progress.py
+++ b/bec_ipython_client/tests/client_tests/test_device_progress.py
@@ -14,7 +14,7 @@ def test_update_progressbar_continues_without_device_data():
     progressbar = mock.MagicMock()
 
     bec.connector.get.return_value = None
-    res = live_update._update_progressbar(progressbar, "async_dev1")
+    res = live_update._update_progressbar(progressbar, ["async_dev1"])
     assert res is False
 
 
@@ -32,7 +32,7 @@ def test_update_progressbar_continues_when_scan_id_doesnt_match():
     bec.connector.get.return_value = messages.ProgressMessage(
         value=1, max_value=10, done=False, metadata={"scan_id": "scan_id"}
     )
-    res = live_update._update_progressbar(progressbar, "async_dev1")
+    res = live_update._update_progressbar(progressbar, ["async_dev1"])
     assert res is False
 
 
@@ -50,7 +50,7 @@ def test_update_progressbar_updates_max_value():
     bec.connector.get.return_value = messages.ProgressMessage(
         value=10, max_value=20, done=False, metadata={"scan_id": "scan_id"}
     )
-    res = live_update._update_progressbar(progressbar, "async_dev1")
+    res = live_update._update_progressbar(progressbar, ["async_dev1"])
     assert res is False
     assert progressbar.max_points == 20
     progressbar.update.assert_called_once_with(10)
@@ -70,7 +70,7 @@ def test_update_progressbar_returns_true_when_max_value_is_reached():
     bec.connector.get.return_value = messages.ProgressMessage(
         value=10, max_value=10, done=True, metadata={"scan_id": "scan_id"}
     )
-    res = live_update._update_progressbar(progressbar, "async_dev1")
+    res = live_update._update_progressbar(progressbar, ["async_dev1"])
     assert res is True
 
 
@@ -81,15 +81,12 @@ def test_update_progressbar_raises_scan_restart_when_scan_restarted():
     progressbar = mock.MagicMock()
     restart_msg = messages.ScanQueueMessage(scan_type="grid_scan", parameter={"args": {}})
     live_update.scan_item = mock.MagicMock(
-        scan_id="scan_id",
-        restarted_msg=restart_msg,
-        status="open",
-        status_message=None,
+        scan_id="scan_id", restarted_msg=restart_msg, status="open", status_message=None
     )
 
     with mock.patch("bec_ipython_client.callbacks.device_progress.print") as mock_print:
         with pytest.raises(ScanRestart) as exc_info:
-            live_update._update_progressbar(progressbar, "async_dev1")
+            live_update._update_progressbar(progressbar, ["async_dev1"])
 
     assert exc_info.value.new_scan_msg == restart_msg
     mock_print.assert_not_called()
@@ -101,14 +98,11 @@ def test_update_progressbar_returns_true_when_scan_completed_by_user():
     live_update = LiveUpdatesDeviceProgress(bec=bec, report_instruction={}, request=request)
     progressbar = mock.MagicMock()
     live_update.scan_item = mock.MagicMock(
-        scan_id="scan_id",
-        restarted_msg=None,
-        status="user_completed",
-        status_message=None,
+        scan_id="scan_id", restarted_msg=None, status="user_completed", status_message=None
     )
 
     with mock.patch("bec_ipython_client.callbacks.device_progress.print") as mock_print:
-        res = live_update._update_progressbar(progressbar, "async_dev1")
+        res = live_update._update_progressbar(progressbar, ["async_dev1"])
 
     assert res is True
     mock_print.assert_called_once_with("Scan was set to 'completed' by user.")
@@ -128,4 +122,4 @@ def test_update_progressbar_raises_scan_interruption_when_aborted_by_user():
     )
 
     with pytest.raises(ScanInterruption, match="Scan 5 was aborted by user."):
-        live_update._update_progressbar(progressbar, "async_dev1")
+        live_update._update_progressbar(progressbar, ["async_dev1"])

--- a/bec_ipython_client/tests/client_tests/test_device_progress.py
+++ b/bec_ipython_client/tests/client_tests/test_device_progress.py
@@ -1,7 +1,10 @@
 from unittest import mock
 
+import pytest
+
 from bec_ipython_client.callbacks.device_progress import LiveUpdatesDeviceProgress
 from bec_lib import messages
+from bec_lib.bec_errors import ScanInterruption, ScanRestart
 
 
 def test_update_progressbar_continues_without_device_data():
@@ -22,6 +25,9 @@ def test_update_progressbar_continues_when_scan_id_doesnt_match():
     progressbar = mock.MagicMock()
     live_update.scan_item = mock.MagicMock()
     live_update.scan_item.scan_id = "scan_id2"
+    live_update.scan_item.restarted_msg = None
+    live_update.scan_item.status = "open"
+    live_update.scan_item.status_message = None
 
     bec.connector.get.return_value = messages.ProgressMessage(
         value=1, max_value=10, done=False, metadata={"scan_id": "scan_id"}
@@ -37,6 +43,9 @@ def test_update_progressbar_updates_max_value():
     progressbar = mock.MagicMock()
     live_update.scan_item = mock.MagicMock()
     live_update.scan_item.scan_id = "scan_id"
+    live_update.scan_item.restarted_msg = None
+    live_update.scan_item.status = "open"
+    live_update.scan_item.status_message = None
 
     bec.connector.get.return_value = messages.ProgressMessage(
         value=10, max_value=20, done=False, metadata={"scan_id": "scan_id"}
@@ -54,9 +63,69 @@ def test_update_progressbar_returns_true_when_max_value_is_reached():
     progressbar = mock.MagicMock()
     live_update.scan_item = mock.MagicMock()
     live_update.scan_item.scan_id = "scan_id"
+    live_update.scan_item.restarted_msg = None
+    live_update.scan_item.status = "open"
+    live_update.scan_item.status_message = None
 
     bec.connector.get.return_value = messages.ProgressMessage(
         value=10, max_value=10, done=True, metadata={"scan_id": "scan_id"}
     )
     res = live_update._update_progressbar(progressbar, "async_dev1")
     assert res is True
+
+
+def test_update_progressbar_raises_scan_restart_when_scan_restarted():
+    bec = mock.MagicMock()
+    request = mock.MagicMock()
+    live_update = LiveUpdatesDeviceProgress(bec=bec, report_instruction={}, request=request)
+    progressbar = mock.MagicMock()
+    restart_msg = messages.ScanQueueMessage(scan_type="grid_scan", parameter={"args": {}})
+    live_update.scan_item = mock.MagicMock(
+        scan_id="scan_id",
+        restarted_msg=restart_msg,
+        status="open",
+        status_message=None,
+    )
+
+    with mock.patch("bec_ipython_client.callbacks.device_progress.print") as mock_print:
+        with pytest.raises(ScanRestart) as exc_info:
+            live_update._update_progressbar(progressbar, "async_dev1")
+
+    assert exc_info.value.new_scan_msg == restart_msg
+    mock_print.assert_not_called()
+
+
+def test_update_progressbar_returns_true_when_scan_completed_by_user():
+    bec = mock.MagicMock()
+    request = mock.MagicMock()
+    live_update = LiveUpdatesDeviceProgress(bec=bec, report_instruction={}, request=request)
+    progressbar = mock.MagicMock()
+    live_update.scan_item = mock.MagicMock(
+        scan_id="scan_id",
+        restarted_msg=None,
+        status="user_completed",
+        status_message=None,
+    )
+
+    with mock.patch("bec_ipython_client.callbacks.device_progress.print") as mock_print:
+        res = live_update._update_progressbar(progressbar, "async_dev1")
+
+    assert res is True
+    mock_print.assert_called_once_with("Scan was set to 'completed' by user.")
+
+
+def test_update_progressbar_raises_scan_interruption_when_aborted_by_user():
+    bec = mock.MagicMock()
+    request = mock.MagicMock()
+    live_update = LiveUpdatesDeviceProgress(bec=bec, report_instruction={}, request=request)
+    progressbar = mock.MagicMock()
+    live_update.scan_item = mock.MagicMock(
+        scan_id="scan_id",
+        scan_number=5,
+        restarted_msg=None,
+        status="open",
+        status_message=mock.MagicMock(reason="user"),
+    )
+
+    with pytest.raises(ScanInterruption, match="Scan 5 was aborted by user."):
+        live_update._update_progressbar(progressbar, "async_dev1")

--- a/bec_lib/bec_lib/messages.py
+++ b/bec_lib/bec_lib/messages.py
@@ -422,6 +422,7 @@ class ScanQueueLock(BaseModel):
 
     reason: str
     identifier: str
+    allow_device_instructions: bool = True
 
 
 class ScanQueueStatus(BaseModel):

--- a/bec_lib/bec_lib/scan_manager.py
+++ b/bec_lib/bec_lib/scan_manager.py
@@ -219,7 +219,9 @@ class ScanManager:
         )
         return new_request_id
 
-    def add_queue_lock(self, queue: str, reason: str, lock_id: str) -> None:
+    def add_queue_lock(
+        self, queue: str, reason: str, lock_id: str, allow_device_instructions: bool = True
+    ) -> None:
         """
         Add a lock to the specified scan queue.
 
@@ -227,6 +229,7 @@ class ScanManager:
             queue (str): The name of the scan queue to lock.
             reason (str): The reason for locking the queue.
             lock_id (str): The unique identifier for the lock.
+            allow_device_instructions (bool, optional): Whether to allow device instructions while the lock is active. Defaults to True.
         """
         logger.info(f"Adding lock to queue '{queue}' with reason: {reason}")
         self.connector.send(
@@ -234,7 +237,11 @@ class ScanManager:
             messages.ScanQueueModificationMessage(
                 scan_id=None,
                 action="lock",
-                parameter={"reason": reason, "identifier": lock_id},
+                parameter={
+                    "reason": reason,
+                    "identifier": lock_id,
+                    "allow_device_instructions": allow_device_instructions,
+                },
                 queue=queue,
             ),
         )

--- a/bec_lib/tests/test_scan_manager.py
+++ b/bec_lib/tests/test_scan_manager.py
@@ -423,7 +423,11 @@ def test_scan_manager_add_queue_lock(scan_manager):
             scan_id=None,
             request_id=None,
             action="lock",
-            parameter={"reason": "Testing lock", "identifier": "test_lock"},
+            parameter={
+                "reason": "Testing lock",
+                "identifier": "test_lock",
+                "allow_device_instructions": True,
+            },
             queue="primary",
         ),
     )

--- a/bec_server/bec_server/scan_server/scan_queue.py
+++ b/bec_server/bec_server/scan_server/scan_queue.py
@@ -556,7 +556,11 @@ class QueueManager:
         parameter: dict | None = None,
     ) -> None:
         """
-        Add a lock to the queue. The queue will not proceed until the lock is removed.
+        Add a lock to the queue. Whether the queue will proceed depends on the
+        allow_device_instructions flag in the lock parameter. If
+        allow_device_instructions is False, the queue will not proceed until
+        the lock is released. If allow_device_instructions is True, the
+        queue will proceed if the next queue item is not a scan.
         """
         if not parameter:
             raise ValueError("Missing parameter for lock action")
@@ -566,8 +570,14 @@ class QueueManager:
         identifier = parameter.get("identifier")
         if not identifier:
             raise ValueError("Missing lock identifier in lock parameter")
+        allow_device_instructions = parameter.get("allow_device_instructions", True)
         self.add_queue_lock(
-            queue_name=queue, lock=messages.ScanQueueLock(reason=lock_reason, identifier=identifier)
+            queue_name=queue,
+            lock=messages.ScanQueueLock(
+                reason=lock_reason,
+                identifier=identifier,
+                allow_device_instructions=allow_device_instructions,
+            ),
         )
 
     @requires_queue
@@ -882,6 +892,19 @@ class ScanQueue:
                     self._auto_shutdown_timer.join()
                 self._auto_shutdown_timer = None
 
+    def _queue_should_continue(self) -> bool:
+        """check if the queue should continue to the next instruction queue"""
+        if self.status not in [ScanQueueStatus.PAUSED, ScanQueueStatus.LOCKED]:
+            return True
+        if self.status == ScanQueueStatus.LOCKED:
+            if any(not lock.allow_device_instructions for lock in self.locks.values()):
+                # if any of the locks forbid device instructions, we should not continue
+                return False
+            # We allow the queue to continue if the next queue item is not a scan
+            if len(self.queue) > 0 and not any(self.queue[0].is_scan):
+                return True
+        return False
+
     def _next_instruction_queue(self) -> bool:
         """get the next instruction queue from the queue. If no update is available, it will return False."""
         with self._lock:
@@ -896,7 +919,7 @@ class ScanQueue:
                     self.queue.popleft()
                     self.queue_manager.send_queue_status()
 
-                if self.status not in [ScanQueueStatus.PAUSED, ScanQueueStatus.LOCKED]:
+                if self._queue_should_continue():
                     if len(self.queue) == 0:
                         if aiq is None:
                             self.signal_event.wait(0.1)
@@ -911,6 +934,8 @@ class ScanQueue:
 
                 while self.status == ScanQueueStatus.LOCKED and not self.signal_event.is_set():
                     self.signal_event.wait(0.1)
+                    if self._queue_should_continue():
+                        break
 
                 while self.status == ScanQueueStatus.PAUSED and not self.signal_event.is_set():
                     if len(self.queue) == 0 and self.auto_reset_enabled:

--- a/bec_server/tests/tests_scan_server/test_scan_server_queue.py
+++ b/bec_server/tests/tests_scan_server/test_scan_server_queue.py
@@ -1740,7 +1740,9 @@ def test_queue_waits_when_locked_and_resumes_after_release(queuemanager_mock):
     assert len(queue.queue) == 2
 
     # Set the queue locked
-    lock = messages.ScanQueueLock(identifier="hold_test", reason="Testing hold behavior")
+    lock = messages.ScanQueueLock(
+        identifier="hold_test", reason="Testing hold behavior", allow_device_instructions=False
+    )
     queue.add_lock(lock)
     assert queue.status == ScanQueueStatus.LOCKED
     assert len(queue.locks) == 1


### PR DESCRIPTION
## Description
This pull request aligns device-progress live updates with the existing live-table scan-state handling and introduces more explicit queue-lock behavior for device instructions.

On the client side, LiveUpdatesDeviceProgress now reacts to scan restarts, user-completed scans, and user-triggered aborts in the same way as LiveUpdatesTable, so progress-based callbacks no longer miss those terminal states.

On the server side, queue locks now carry allow_device_instructions explicitly, and queue continuation logic respects that flag: locks can block scans while still allowing device instructions when intended. The `ScanQueueLock` model and the `bec.queue.add_queue_lock` method have been extended accordingly. 

## Type of Change
- Bug fix for device-progress live update handling
- Behavioral refinement for scan queue locks and related test updates

## How to test
 - Run a move command or device rpc while the scan interlock is active

## Potential side effects
Device-progress callbacks may now exit earlier than before when a scan is restarted, user-completed, or aborted by the user, which is intended but changes observable behavior.

Queue locks now distinguish between “fully block queue progress” and “allow device instructions while locked,” so any code or workflows that previously assumed all locks were blocking should be reviewed against the new default semantics.


