### PR TITLE
fix: add a reason to scan queue messages to ensure that restarts are …

### DIFF
--- a/bec_ipython_client/bec_ipython_client/callbacks/device_progress.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/device_progress.py
@@ -95,4 +95,5 @@ class LiveUpdatesDeviceProgress(LiveUpdatesTable):
         done = status.content.get("done")
         if point_id == max_value or done:
             return True
+        time.sleep(0.05)  # small sleep to avoid busy waiting
         return False

--- a/bec_ipython_client/bec_ipython_client/callbacks/device_progress.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/device_progress.py
@@ -1,11 +1,11 @@
 import time
 
 from bec_ipython_client.progressbar import ScanProgressBar
-from bec_lib.bec_errors import ScanInterruption, ScanRestart
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.logger import bec_logger
 
 from .live_table import LiveUpdatesTable
+from .utils import ScanState, evaluate_scan_state
 
 logger = bec_logger.logger
 
@@ -15,33 +15,14 @@ class LiveUpdatesDeviceProgress(LiveUpdatesTable):
 
     REPORT_TYPE = "device_progress"
 
-    def _check_scan_state(self) -> bool:
+    def _check_scan_state(self) -> ScanState:
         """Check whether the scan has reached a terminal or exceptional state.
 
         Returns:
-            bool: True if the scan should stop without error.
+            The current scan state outcome for the callback loop.
         """
-        if not self.scan_item:
-            return False
-
-        restarted_msg = getattr(self.scan_item, "restarted_msg", None)
-        if restarted_msg:
-            raise ScanRestart(new_scan_msg=restarted_msg)
-
-        if getattr(self.scan_item, "status", None) == "user_completed":
-            print("Scan was set to 'completed' by user.")
-            return True
-
-        status_message = getattr(self.scan_item, "status_message", None)
-        if status_message and getattr(status_message, "reason", None) == "user":
-            scan_number = getattr(self.scan_item, "scan_number", None)
-            if scan_number is None:
-                msg = "Scan was aborted by user."
-            else:
-                msg = f"Scan {scan_number} was aborted by user."
-            raise ScanInterruption(msg)
-
-        return False
+        queue = self.scan_item.queue if self.scan_item else None
+        return evaluate_scan_state(scan_item=self.scan_item, queue=queue)
 
     def core(self):
         """core function to run the live updates for the table"""
@@ -73,8 +54,13 @@ class LiveUpdatesDeviceProgress(LiveUpdatesTable):
             bool: True if the scan is finished.
         """
         self.check_alarms()
-        if self._check_scan_state():
+        scan_state = self._check_scan_state()
+        if scan_state == ScanState.DONE:
+            print("Scan was set to 'completed' by user.")
             return True
+        if scan_state == ScanState.WAIT:
+            time.sleep(0.05)
+            return False
         status = self.bec.connector.get(MessageEndpoints.device_progress(device_names[0]))
         if not status:
             logger.trace("waiting for new data point")
@@ -99,8 +85,12 @@ class LiveUpdatesDeviceProgress(LiveUpdatesTable):
         # process sync callbacks
         self.bec.callbacks.poll()
         self.scan_item.poll_callbacks()
-        if self._check_scan_state():
+        scan_state = self._check_scan_state()
+        if scan_state == ScanState.DONE:
+            print("Scan was set to 'completed' by user.")
             return True
+        if scan_state == ScanState.WAIT:
+            return False
 
         done = status.content.get("done")
         if point_id == max_value or done:

--- a/bec_ipython_client/bec_ipython_client/callbacks/ipython_live_updates.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/ipython_live_updates.py
@@ -299,11 +299,16 @@ class IPythonLiveUpdates:
         check_alarms(self.client)
         if not queue.request_blocks or not queue.status:
             return False
-        if queue.scans:
-            if queue.scans[-1] is not None and queue.scans[-1].status == "user_completed":
-                return True
-            if queue.scans[-1] is None and queue.status in ["STOPPED", "CANCELLED"]:
-                raise ScanInterruption("Scan was stopped by the user.")
+        latest_scan = queue.scans[-1] if queue.scans else None
+        if latest_scan is not None and latest_scan.status == "user_completed":
+            return True
+        if queue.status in ["STOPPED", "CANCELLED"]:
+            restart_msg = self._restart_signal(queue)
+            if restart_msg is not None:
+                raise ScanRestart(new_scan_msg=restart_msg)
+            if queue.status == "STOPPED" and queue.reason == "restart":
+                return False
+            raise ScanInterruption(self._interruption_message(queue.status, latest_scan))
 
         if queue.queue_position is None:
             return False
@@ -341,6 +346,26 @@ class IPythonLiveUpdates:
             return True
 
         return False
+
+    def _restart_signal(self, queue: QueueItem) -> messages.ScanQueueMessage | None:
+        """Return the restart message if it has already reached the client."""
+        latest_scan = queue.scans[-1] if queue.scans else None
+        if latest_scan is not None and latest_scan.restarted_msg is not None:
+            return latest_scan.restarted_msg
+        return None
+
+    @staticmethod
+    def _interruption_message(queue_status: str, latest_scan) -> str:
+        """Build a user-facing interruption message for a stopped queue item."""
+        if queue_status == "CANCELLED":
+            return "Scan was cancelled."
+        status_message = getattr(latest_scan, "status_message", None)
+        if status_message is not None and getattr(status_message, "reason", None) == "user":
+            return "Scan was stopped by the user."
+        scan_number = getattr(latest_scan, "scan_number", None)
+        if scan_number is None:
+            return "Scan was interrupted."
+        return f"Scan {scan_number} was interrupted."
 
     def _process_pending_queue_element(self, queue: QueueItem) -> None:
         """

--- a/bec_ipython_client/bec_ipython_client/callbacks/ipython_live_updates.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/ipython_live_updates.py
@@ -16,7 +16,7 @@ from bec_lib.request_context import ActiveRequestContext, active_request_context
 
 from .live_table import LiveUpdatesTable
 from .move_device import LiveUpdatesReadbackProgressbar
-from .utils import ScanRequestMixin, check_alarms
+from .utils import ScanRequestMixin, ScanState, check_alarms, evaluate_scan_state
 
 if TYPE_CHECKING:
     from bec_lib import messages
@@ -202,7 +202,7 @@ class IPythonLiveUpdates:
             self._reset()
 
         except ScanRestart as scan_restart:
-            self._stop_status_live()
+            self._reset()
             Console().print("[yellow]Scan restarted[/yellow]")
             request = scan_restart.new_scan_msg
             if request.allow_restart:
@@ -299,16 +299,11 @@ class IPythonLiveUpdates:
         check_alarms(self.client)
         if not queue.request_blocks or not queue.status:
             return False
-        latest_scan = queue.scans[-1] if queue.scans else None
-        if latest_scan is not None and latest_scan.status == "user_completed":
+        queue_state = evaluate_scan_state(queue=queue)
+        if queue_state == ScanState.DONE:
             return True
-        if queue.status in ["STOPPED", "CANCELLED"]:
-            restart_msg = self._restart_signal(queue)
-            if restart_msg is not None:
-                raise ScanRestart(new_scan_msg=restart_msg)
-            if queue.status == "STOPPED" and queue.reason == "restart":
-                return False
-            raise ScanInterruption(self._interruption_message(queue.status, latest_scan))
+        if queue_state == ScanState.WAIT:
+            return False
 
         if queue.queue_position is None:
             return False
@@ -346,26 +341,6 @@ class IPythonLiveUpdates:
             return True
 
         return False
-
-    def _restart_signal(self, queue: QueueItem) -> messages.ScanQueueMessage | None:
-        """Return the restart message if it has already reached the client."""
-        latest_scan = queue.scans[-1] if queue.scans else None
-        if latest_scan is not None and latest_scan.restarted_msg is not None:
-            return latest_scan.restarted_msg
-        return None
-
-    @staticmethod
-    def _interruption_message(queue_status: str, latest_scan) -> str:
-        """Build a user-facing interruption message for a stopped queue item."""
-        if queue_status == "CANCELLED":
-            return "Scan was cancelled."
-        status_message = getattr(latest_scan, "status_message", None)
-        if status_message is not None and getattr(status_message, "reason", None) == "user":
-            return "Scan was stopped by the user."
-        scan_number = getattr(latest_scan, "scan_number", None)
-        if scan_number is None:
-            return "Scan was interrupted."
-        return f"Scan {scan_number} was interrupted."
 
     def _process_pending_queue_element(self, queue: QueueItem) -> None:
         """

--- a/bec_ipython_client/bec_ipython_client/callbacks/move_device.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/move_device.py
@@ -9,11 +9,10 @@ import numpy as np
 
 from bec_ipython_client.progressbar import DeviceProgressBar
 from bec_lib import messages
-from bec_lib.bec_errors import ScanInterruption, ScanRestart
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.redis_connector import MessageObject
 
-from .utils import LiveUpdatesBase, check_alarms
+from .utils import LiveUpdatesBase, ScanState, check_alarms, evaluate_scan_state
 
 if TYPE_CHECKING:
     from bec_lib.client import BECClient
@@ -201,9 +200,14 @@ class LiveUpdatesReadbackProgressbar(LiveUpdatesBase):
         with DeviceProgressBar(
             self.devices, start_values=start_values, target_values=target_values
         ) as progress:
-            while not progress.finished or not data_source.done():
+            while True:
                 check_alarms(self.bec)
-                self._check_scan_state()
+                scan_state = self._check_scan_state()
+                if scan_state == ScanState.WAIT:
+                    time.sleep(0.05)
+                    continue
+                if progress.finished and data_source.done():
+                    break
 
                 values = data_source.get_device_values()
                 progress.update(values=values)
@@ -222,39 +226,8 @@ class LiveUpdatesReadbackProgressbar(LiveUpdatesBase):
         """run the progressbar."""
         self.core()
 
-    def _check_scan_state(self) -> None:
+    def _check_scan_state(self) -> ScanState:
         """Check whether the tracked queue item has entered a terminal stop state."""
         if self.scan_queue_request is None or self.scan_queue_request.queue is None:
-            return
-        queue = self.scan_queue_request.queue
-        if queue.status not in ["STOPPED", "CANCELLED"]:
-            return
-
-        restart_msg = self._restart_signal(queue)
-        if restart_msg is not None:
-            raise ScanRestart(new_scan_msg=restart_msg)
-        if queue.status == "STOPPED" and queue.reason == "restart":
-            return
-        raise ScanInterruption(
-            self._interruption_message(queue.status, queue.scans[-1] if queue.scans else None)
-        )
-
-    def _restart_signal(self, queue) -> messages.ScanQueueMessage | None:
-        """Return the restart message if it has already reached the client."""
-        latest_scan = queue.scans[-1] if queue.scans else None
-        if latest_scan is not None and latest_scan.restarted_msg is not None:
-            return latest_scan.restarted_msg
-        return None
-
-    @staticmethod
-    def _interruption_message(queue_status: str, latest_scan) -> str:
-        """Build a user-facing interruption message for stopped readback updates."""
-        if queue_status == "CANCELLED":
-            return "Scan was cancelled."
-        status_message = getattr(latest_scan, "status_message", None)
-        if status_message is not None and getattr(status_message, "reason", None) == "user":
-            return "Scan was stopped by the user."
-        scan_number = getattr(latest_scan, "scan_number", None)
-        if scan_number is None:
-            return "Scan was interrupted."
-        return f"Scan {scan_number} was interrupted."
+            return ScanState.CONTINUE
+        return evaluate_scan_state(queue=self.scan_queue_request.queue)

--- a/bec_ipython_client/bec_ipython_client/callbacks/move_device.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/move_device.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import threading
+import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, cast
 
@@ -8,7 +9,7 @@ import numpy as np
 
 from bec_ipython_client.progressbar import DeviceProgressBar
 from bec_lib import messages
-from bec_lib.bec_errors import ScanInterruption
+from bec_lib.bec_errors import ScanInterruption, ScanRestart
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.redis_connector import MessageObject
 
@@ -202,8 +203,7 @@ class LiveUpdatesReadbackProgressbar(LiveUpdatesBase):
         ) as progress:
             while not progress.finished or not data_source.done():
                 check_alarms(self.bec)
-                if self.scan_queue_request and self.scan_queue_request.queue.status == "STOPPED":
-                    raise ScanInterruption("Scan was stopped by the user.")
+                self._check_scan_state()
 
                 values = data_source.get_device_values()
                 progress.update(values=values)
@@ -221,3 +221,40 @@ class LiveUpdatesReadbackProgressbar(LiveUpdatesBase):
     def run(self):
         """run the progressbar."""
         self.core()
+
+    def _check_scan_state(self) -> None:
+        """Check whether the tracked queue item has entered a terminal stop state."""
+        if self.scan_queue_request is None or self.scan_queue_request.queue is None:
+            return
+        queue = self.scan_queue_request.queue
+        if queue.status not in ["STOPPED", "CANCELLED"]:
+            return
+
+        restart_msg = self._restart_signal(queue)
+        if restart_msg is not None:
+            raise ScanRestart(new_scan_msg=restart_msg)
+        if queue.status == "STOPPED" and queue.reason == "restart":
+            return
+        raise ScanInterruption(
+            self._interruption_message(queue.status, queue.scans[-1] if queue.scans else None)
+        )
+
+    def _restart_signal(self, queue) -> messages.ScanQueueMessage | None:
+        """Return the restart message if it has already reached the client."""
+        latest_scan = queue.scans[-1] if queue.scans else None
+        if latest_scan is not None and latest_scan.restarted_msg is not None:
+            return latest_scan.restarted_msg
+        return None
+
+    @staticmethod
+    def _interruption_message(queue_status: str, latest_scan) -> str:
+        """Build a user-facing interruption message for stopped readback updates."""
+        if queue_status == "CANCELLED":
+            return "Scan was cancelled."
+        status_message = getattr(latest_scan, "status_message", None)
+        if status_message is not None and getattr(status_message, "reason", None) == "user":
+            return "Scan was stopped by the user."
+        scan_number = getattr(latest_scan, "scan_number", None)
+        if scan_number is None:
+            return "Scan was interrupted."
+        return f"Scan {scan_number} was interrupted."

--- a/bec_ipython_client/bec_ipython_client/callbacks/utils.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/utils.py
@@ -4,42 +4,149 @@ import abc
 import time
 import traceback
 from collections.abc import Callable
-from typing import TYPE_CHECKING
+from enum import Enum
+from typing import TYPE_CHECKING, Any
 
+from bec_lib.bec_errors import ScanInterruption, ScanRestart
 from bec_lib.logger import bec_logger
 from bec_lib.request_items import RequestItem
 
 if TYPE_CHECKING:
     from bec_lib import messages
     from bec_lib.client import BECClient
+    from bec_lib.queue_items import QueueItem
+    from bec_lib.scan_items import ScanItem
 
 logger = bec_logger.logger
 
 
 class ScanRequestError(Exception):
-    """Error raised when a scan request is rejected"""
+    """Raised when the server rejects a scan request."""
 
 
-def check_alarms(bec):
-    """check for alarms and raise them if needed"""
+class ScanState(Enum):
+    """Outcome of evaluating the current scan or queue state."""
+
+    CONTINUE = "continue"
+    DONE = "done"
+    WAIT = "wait"
+
+
+def check_alarms(bec: BECClient) -> None:
+    """Raise any pending alarms for the active client."""
     bec.alarm_handler.raise_alarms()
+
+
+def evaluate_scan_state(
+    *, scan_item: ScanItem | None = None, queue: QueueItem | None = None
+) -> ScanState:
+    """Evaluate restart, completion, and interruption state for live callbacks.
+
+    Args:
+        scan_item: Scan-centric state, used by callbacks that poll a concrete scan item.
+        queue: Queue-centric state, used by callbacks that follow a queue entry directly.
+
+    Returns:
+        `ScanState.DONE` when the scan should stop cleanly.
+        `ScanState.WAIT` when the callback should keep polling, typically while a restart is in
+        progress and the replacement request has not arrived yet.
+        `ScanState.CONTINUE` when no terminal state has been reached.
+
+    Raises:
+        ScanRestart: When a restart message is already available.
+        ScanInterruption: When the scan ended in an interruption state.
+    """
+    current_scan = scan_item or _latest_scan(queue)
+    restarted_msg = _restart_signal(scan_item=scan_item, queue=queue)
+    if restarted_msg is not None:
+        raise ScanRestart(new_scan_msg=restarted_msg)
+
+    if getattr(current_scan, "status", None) == "user_completed":
+        return ScanState.DONE
+
+    if queue is not None:
+        queue_status = getattr(queue, "status", None)
+        if queue_status == "STOPPED" and getattr(queue, "reason", None) == "restart":
+            return ScanState.WAIT
+        if queue_status in ["STOPPED", "CANCELLED"]:
+            raise ScanInterruption(_interruption_message(queue_status, current_scan))
+
+    status_message = getattr(current_scan, "status_message", None)
+    if status_message and getattr(status_message, "reason", None) == "user":
+        raise ScanInterruption(_aborted_by_user_message(current_scan))
+
+    if getattr(current_scan, "status", None) in {"aborted", "halted"}:
+        raise ScanInterruption(_interrupted_message(current_scan))
+
+    return ScanState.CONTINUE
+
+
+def _restart_signal(
+    *, scan_item: ScanItem | None = None, queue: QueueItem | None = None
+) -> messages.ScanQueueMessage | None:
+    """Return the restart message currently associated with the scan, if any."""
+    current_scan = scan_item or _latest_scan(queue)
+    restarted_msg = getattr(current_scan, "restarted_msg", None)
+    if restarted_msg is not None:
+        return restarted_msg
+    return None
+
+
+def _latest_scan(queue: QueueItem | None) -> ScanItem | None:
+    """Return the latest scan item associated with a queue entry."""
+    if queue is None:
+        return None
+    scans = getattr(queue, "scans", None) or []
+    return scans[-1] if scans else None
+
+
+def _scan_number(scan_item: ScanItem | None) -> int | None:
+    """Return the scan number when it is present and well-typed."""
+    scan_number = getattr(scan_item, "scan_number", None)
+    return scan_number if isinstance(scan_number, int) else None
+
+
+def _aborted_by_user_message(scan_item: ScanItem | None) -> str:
+    """Build a user-facing message for a user-initiated abort."""
+    scan_number = _scan_number(scan_item)
+    if scan_number is None:
+        return "Scan was aborted by user."
+    return f"Scan {scan_number} was aborted by user."
+
+
+def _interrupted_message(scan_item: ScanItem | None) -> str:
+    """Build a user-facing message for a non-user interruption."""
+    scan_number = _scan_number(scan_item)
+    if scan_number is None:
+        return "Scan was interrupted."
+    return f"Scan {scan_number} was interrupted."
+
+
+def _interruption_message(queue_status: str, scan_item: ScanItem | None) -> str:
+    """Build a user-facing message for an interrupted queue entry."""
+    if queue_status == "CANCELLED":
+        return "Scan was cancelled."
+    status_message = getattr(scan_item, "status_message", None)
+    if status_message is not None and getattr(status_message, "reason", None) == "user":
+        return _aborted_by_user_message(scan_item)
+    return _interrupted_message(scan_item)
 
 
 class LiveUpdatesBase(abc.ABC):
     def __init__(
         self,
         bec: BECClient,
-        report_instruction: dict = None,
-        request: messages.ScanQueueMessage = None,
-        callbacks: list[Callable] = None,
+        report_instruction: dict[str, Any] | None = None,
+        request: messages.ScanQueueMessage | None = None,
+        callbacks: list[Callable[..., Any]] | Callable[..., Any] | None = None,
     ) -> None:
-        """Base class for live updates
+        """Base class for live update callbacks.
 
         Args:
-            bec (BECClient): BECClient instance
-            report_instruction (dict, optional): report instruction. Defaults to None.
-            request (messages.ScanQueueMessage, optional): scan queue request. Defaults to None.
-            callbacks (list[Callable], optional): list of callback functions. Defaults to None.
+            bec: Active BEC client instance.
+            report_instruction: Callback-specific report instruction payload.
+            request: Scan queue request currently being processed.
+            callbacks: One or more user callbacks to invoke for emitted points.
         """
         self.bec = bec
         self.request = request
@@ -56,10 +163,11 @@ class LiveUpdatesBase(abc.ABC):
         self.scan_queue_request = scan_request.scan_queue_request
 
     @abc.abstractmethod
-    def run(self):
-        pass
+    def run(self) -> None:
+        """Run the live update callback."""
 
-    def emit_point(self, data: dict, metadata: dict = None):
+    def emit_point(self, data: dict[str, Any], metadata: dict[str, Any] | None = None) -> None:
+        """Emit a point update to all registered user callbacks."""
         for cb in self.callbacks:
             if not cb:
                 continue
@@ -70,7 +178,7 @@ class LiveUpdatesBase(abc.ABC):
                 logger.warning(f"Failed to run callback function: {content}")
 
     def _print_client_msgs_asap(self):
-        """Print client messages flagged as show_asap"""
+        """Print queued client messages marked for immediate display."""
         # pylint: disable=protected-access
         if self.scan_queue_request is None:
             return
@@ -86,7 +194,7 @@ class LiveUpdatesBase(abc.ABC):
             print(queue.format_client_msg(msg))
 
     def _print_client_msgs_all(self):
-        """Print summary of client messages"""
+        """Print a summary of all queued client messages."""
         # pylint: disable=protected-access
         if self.scan_queue_request is None:
             return
@@ -109,22 +217,22 @@ class LiveUpdatesBase(abc.ABC):
 
 class ScanRequestMixin:
     def __init__(self, bec: BECClient, RID: str) -> None:
-        """Mixin to handle scan request acceptance
+        """Mixin providing request-acceptance waiting helpers.
 
         Args:
-            bec (BECClient): BECClient instance
-            RID (str): request ID
+            bec: Active BEC client instance.
+            RID: Request identifier to wait for.
         """
         self.bec = bec
         self.request_storage = self.bec.queue.request_storage
         self.RID = RID
-        self.scan_queue_request = None
+        self.scan_queue_request: RequestItem | None = None
 
     def _wait_for_scan_request(self) -> RequestItem:
-        """wait for scan queuest
+        """Wait until the request item appears in request storage.
 
         Returns:
-            RequestItem: scan queue request
+            The matching queue request item.
         """
         logger.trace("Waiting for request ID")
         start = time.time()
@@ -134,8 +242,8 @@ class ScanRequestMixin:
         logger.trace(f"Waiting for request ID finished after {time.time()-start} s.")
         return self.request_storage.find_request_by_ID(self.RID)
 
-    def _wait_for_scan_request_decision(self):
-        """wait for a scan queuest decision"""
+    def _wait_for_scan_request_decision(self) -> None:
+        """Wait until the server has accepted or rejected the request."""
         logger.trace("Waiting for decision")
         start = time.time()
         while self.scan_queue_request.decision_pending:
@@ -143,8 +251,8 @@ class ScanRequestMixin:
             check_alarms(self.bec)
         logger.trace(f"Waiting for decision finished after {time.time()-start} s.")
 
-    def wait(self):
-        """wait for the request acceptance"""
+    def wait(self) -> None:
+        """Wait until the request is accepted and linked to a queue entry."""
         self.scan_queue_request = self._wait_for_scan_request()
 
         self._wait_for_scan_request_decision()

--- a/bec_ipython_client/tests/client_tests/test_device_progress.py
+++ b/bec_ipython_client/tests/client_tests/test_device_progress.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 from bec_ipython_client.callbacks.device_progress import LiveUpdatesDeviceProgress
+from bec_ipython_client.callbacks.utils import ScanState
 from bec_lib import messages
 from bec_lib.bec_errors import ScanInterruption, ScanRestart
 
@@ -92,6 +93,19 @@ def test_update_progressbar_raises_scan_restart_when_scan_restarted():
     mock_print.assert_not_called()
 
 
+def test_check_scan_state_returns_wait_for_restart_reason():
+    bec = mock.MagicMock()
+    request = mock.MagicMock()
+    live_update = LiveUpdatesDeviceProgress(bec=bec, report_instruction={}, request=request)
+    live_update.scan_item = mock.MagicMock(
+        status="open",
+        restarted_msg=None,
+        queue=mock.MagicMock(status="STOPPED", reason="restart", scans=[mock.MagicMock()]),
+    )
+
+    assert live_update._check_scan_state() == ScanState.WAIT
+
+
 def test_update_progressbar_returns_true_when_scan_completed_by_user():
     bec = mock.MagicMock()
     request = mock.MagicMock()
@@ -123,3 +137,40 @@ def test_update_progressbar_raises_scan_interruption_when_aborted_by_user():
 
     with pytest.raises(ScanInterruption, match="Scan 5 was aborted by user."):
         live_update._update_progressbar(progressbar, ["async_dev1"])
+
+
+def test_update_progressbar_waits_for_restart_message_before_finishing():
+    bec = mock.MagicMock()
+    request = mock.MagicMock()
+    live_update = LiveUpdatesDeviceProgress(bec=bec, report_instruction={}, request=request)
+    progressbar = mock.MagicMock()
+    restart_msg = messages.ScanQueueMessage(scan_type="grid_scan", parameter={"args": {}})
+    queue = mock.MagicMock(status="STOPPED", reason="restart")
+    scan_item = mock.MagicMock(
+        scan_id="scan_id",
+        scan_number=5,
+        restarted_msg=None,
+        status="open",
+        status_message=None,
+        queue=queue,
+    )
+    queue.scans = [scan_item]
+    live_update.scan_item = scan_item
+
+    bec.connector.get.return_value = messages.ProgressMessage(
+        value=10, max_value=10, done=True, metadata={"scan_id": "scan_id"}
+    )
+
+    with mock.patch("bec_ipython_client.callbacks.device_progress.time.sleep") as sleep:
+
+        def trigger_restart(*_args, **_kwargs):
+            scan_item.restarted_msg = restart_msg
+
+        sleep.side_effect = trigger_restart
+
+        first = live_update._update_progressbar(progressbar, ["async_dev1"])
+        assert first is False
+        with pytest.raises(ScanRestart) as exc_info:
+            live_update._update_progressbar(progressbar, ["async_dev1"])
+
+    assert exc_info.value.new_scan_msg == restart_msg

--- a/bec_ipython_client/tests/client_tests/test_ipython_live_updates.py
+++ b/bec_ipython_client/tests/client_tests/test_ipython_live_updates.py
@@ -177,9 +177,92 @@ def test_live_updates_process_queue_cancelled_pending_request_raises_interruptio
     with (
         mock.patch.object(queue, "_update_with_buffer"),
         mock.patch("bec_lib.queue_items.QueueItem.queue_position", new_callable=mock.PropertyMock),
+        pytest.raises(ScanInterruption, match="Scan was cancelled."),
+    ):
+        live_updates._process_queue(queue, request_msg, "something")
+
+
+def test_live_updates_process_queue_stopped_started_request_raises_interruption(bec_client_mock):
+    client = bec_client_mock
+    live_updates = IPythonLiveUpdates(client)
+    request_msg = messages.ScanQueueMessage(
+        scan_type="grid_scan",
+        parameter={"args": {"samx": (-5, 5, 3)}, "kwargs": {}},
+        queue="primary",
+        metadata={"RID": "something"},
+    )
+    request_block = messages.RequestBlock(
+        msg=request_msg,
+        RID="something",
+        report_instructions=[],
+        readout_priority={"monitored": ["samx"]},
+        is_scan=True,
+        scan_number=1,
+        scan_id="scan_id",
+    )
+    queue = QueueItem(
+        scan_manager=client.queue,
+        queue_id="queue_id",
+        request_blocks=[request_block],
+        status="STOPPED",
+        active_request_block=None,
+        scan_id=["scan_id"],
+    )
+
+    with (
+        mock.patch.object(queue, "_update_with_buffer"),
+        mock.patch.object(
+            client.queue.scan_storage,
+            "find_scan_by_ID",
+            return_value=mock.MagicMock(
+                status="aborted", restarted_msg=None, status_message=mock.MagicMock(reason="user")
+            ),
+        ),
+        mock.patch("bec_lib.queue_items.QueueItem.queue_position", new_callable=mock.PropertyMock),
         pytest.raises(ScanInterruption, match="stopped by the user"),
     ):
         live_updates._process_queue(queue, request_msg, "something")
+
+
+def test_live_updates_process_queue_stopped_restart_without_restart_message_waits_nonblocking(
+    bec_client_mock,
+):
+    client = bec_client_mock
+    live_updates = IPythonLiveUpdates(client)
+    request_msg = messages.ScanQueueMessage(
+        scan_type="grid_scan",
+        parameter={"args": {"samx": (-5, 5, 3)}, "kwargs": {}},
+        queue="primary",
+        metadata={"RID": "something"},
+    )
+    request_block = messages.RequestBlock(
+        msg=request_msg,
+        RID="something",
+        report_instructions=[],
+        readout_priority={"monitored": ["samx"]},
+        is_scan=True,
+        scan_number=1,
+        scan_id="scan_id",
+    )
+    queue = QueueItem(
+        scan_manager=client.queue,
+        queue_id="queue_id",
+        request_blocks=[request_block],
+        status="STOPPED",
+        active_request_block=None,
+        scan_id=["scan_id"],
+        reason="restart",
+    )
+
+    with (
+        mock.patch.object(queue, "_update_with_buffer"),
+        mock.patch.object(
+            client.queue.scan_storage,
+            "find_scan_by_ID",
+            return_value=mock.MagicMock(status="aborted", restarted_msg=None),
+        ),
+    ):
+        assert live_updates._process_queue(queue, request_msg, "something") is False
 
 
 def test_process_request_repeats_on_ScanRestart_error(

--- a/bec_ipython_client/tests/client_tests/test_ipython_live_updates.py
+++ b/bec_ipython_client/tests/client_tests/test_ipython_live_updates.py
@@ -215,11 +215,14 @@ def test_live_updates_process_queue_stopped_started_request_raises_interruption(
             client.queue.scan_storage,
             "find_scan_by_ID",
             return_value=mock.MagicMock(
-                status="aborted", restarted_msg=None, status_message=mock.MagicMock(reason="user")
+                status="aborted",
+                scan_number=1,
+                restarted_msg=None,
+                status_message=mock.MagicMock(reason="user"),
             ),
         ),
         mock.patch("bec_lib.queue_items.QueueItem.queue_position", new_callable=mock.PropertyMock),
-        pytest.raises(ScanInterruption, match="stopped by the user"),
+        pytest.raises(ScanInterruption, match="Scan 1 was aborted by user."),
     ):
         live_updates._process_queue(queue, request_msg, "something")
 

--- a/bec_ipython_client/tests/client_tests/test_move_callback.py
+++ b/bec_ipython_client/tests/client_tests/test_move_callback.py
@@ -9,6 +9,7 @@ from bec_ipython_client.callbacks.move_device import (
     ReadbackDataHandler,
 )
 from bec_lib import messages
+from bec_lib.bec_errors import ScanInterruption, ScanRestart
 from bec_lib.endpoints import MessageEndpoints
 
 
@@ -101,6 +102,119 @@ def test_move_callback_with_report_instruction(bec_client_mock):
                                     report_instruction=report_instruction,
                                     request=request,
                                 ).run()
+
+
+def test_move_callback_check_scan_state_raises_user_interruption(bec_client_mock):
+    request = messages.ScanQueueMessage(
+        scan_type="umv",
+        parameter={"args": {"samx": [10]}, "kwargs": {"relative": True}},
+        metadata={"RID": "something"},
+    )
+    live_update = LiveUpdatesReadbackProgressbar(bec=bec_client_mock, request=request)
+    live_update.scan_queue_request = mock.MagicMock(
+        queue=mock.MagicMock(
+            status="STOPPED",
+            scans=[
+                mock.MagicMock(
+                    scan_number=5, restarted_msg=None, status_message=mock.MagicMock(reason="user")
+                )
+            ],
+        )
+    )
+
+    with pytest.raises(ScanInterruption, match="stopped by the user"):
+        live_update._check_scan_state()
+
+
+def test_move_callback_check_scan_state_raises_scan_restart(bec_client_mock):
+    request = messages.ScanQueueMessage(
+        scan_type="umv",
+        parameter={"args": {"samx": [10]}, "kwargs": {"relative": True}},
+        metadata={"RID": "something"},
+    )
+    restart_msg = messages.ScanQueueMessage(
+        scan_type="umv",
+        parameter={"args": {"samx": [10]}, "kwargs": {"relative": True}},
+        metadata={"RID": "restart"},
+    )
+    live_update = LiveUpdatesReadbackProgressbar(bec=bec_client_mock, request=request)
+    live_update.scan_queue_request = mock.MagicMock(
+        queue=mock.MagicMock(
+            status="STOPPED",
+            scans=[
+                mock.MagicMock(
+                    scan_number=5,
+                    restarted_msg=restart_msg,
+                    status_message=mock.MagicMock(reason="alarm"),
+                )
+            ],
+        )
+    )
+
+    with pytest.raises(ScanRestart) as exc_info:
+        live_update._check_scan_state()
+
+    assert exc_info.value.new_scan_msg == restart_msg
+
+
+def test_move_callback_check_scan_state_raises_alarm_interruption(bec_client_mock):
+    request = messages.ScanQueueMessage(
+        scan_type="umv",
+        parameter={"args": {"samx": [10]}, "kwargs": {"relative": True}},
+        metadata={"RID": "something"},
+        allow_restart=False,
+    )
+    live_update = LiveUpdatesReadbackProgressbar(bec=bec_client_mock, request=request)
+    live_update.scan_queue_request = mock.MagicMock(
+        queue=mock.MagicMock(
+            status="STOPPED",
+            scans=[
+                mock.MagicMock(
+                    scan_number=7, restarted_msg=None, status_message=mock.MagicMock(reason="alarm")
+                )
+            ],
+        )
+    )
+
+    with pytest.raises(ScanInterruption, match="Scan 7 was interrupted."):
+        live_update._check_scan_state()
+
+
+def test_move_callback_check_scan_state_raises_cancelled_interruption(bec_client_mock):
+    request = messages.ScanQueueMessage(
+        scan_type="umv",
+        parameter={"args": {"samx": [10]}, "kwargs": {"relative": True}},
+        metadata={"RID": "something"},
+    )
+    live_update = LiveUpdatesReadbackProgressbar(bec=bec_client_mock, request=request)
+    live_update.scan_queue_request = mock.MagicMock(
+        queue=mock.MagicMock(status="CANCELLED", scans=[None])
+    )
+
+    with pytest.raises(ScanInterruption, match="Scan was cancelled."):
+        live_update._check_scan_state()
+
+
+def test_move_callback_check_scan_state_restart_without_restart_message_is_nonblocking(
+    bec_client_mock,
+):
+    request = messages.ScanQueueMessage(
+        scan_type="umv",
+        parameter={"args": {"samx": [10]}, "kwargs": {"relative": True}},
+        metadata={"RID": "something"},
+    )
+    live_update = LiveUpdatesReadbackProgressbar(bec=bec_client_mock, request=request)
+    live_update.scan_queue_request = mock.MagicMock(
+        queue=mock.MagicMock(
+            status="STOPPED",
+            reason="restart",
+            scans=[
+                mock.MagicMock(restarted_msg=None, status_message=mock.MagicMock(reason="alarm"))
+            ],
+        )
+    )
+
+    assert live_update._check_scan_state() is None
 
 
 def test_readback_data_handler(readback_data_handler):

--- a/bec_ipython_client/tests/client_tests/test_move_callback.py
+++ b/bec_ipython_client/tests/client_tests/test_move_callback.py
@@ -8,6 +8,7 @@ from bec_ipython_client.callbacks.move_device import (
     LiveUpdatesReadbackProgressbar,
     ReadbackDataHandler,
 )
+from bec_ipython_client.callbacks.utils import ScanState
 from bec_lib import messages
 from bec_lib.bec_errors import ScanInterruption, ScanRestart
 from bec_lib.endpoints import MessageEndpoints
@@ -122,7 +123,7 @@ def test_move_callback_check_scan_state_raises_user_interruption(bec_client_mock
         )
     )
 
-    with pytest.raises(ScanInterruption, match="stopped by the user"):
+    with pytest.raises(ScanInterruption, match="Scan 5 was aborted by user."):
         live_update._check_scan_state()
 
 
@@ -214,7 +215,56 @@ def test_move_callback_check_scan_state_restart_without_restart_message_is_nonbl
         )
     )
 
-    assert live_update._check_scan_state() is None
+    assert live_update._check_scan_state() == ScanState.WAIT
+
+
+def test_move_callback_run_waits_for_restart_message_before_exiting(bec_client_mock):
+    client = bec_client_mock
+    request = messages.ScanQueueMessage(
+        scan_type="umv",
+        parameter={"args": {"samx": [10]}, "kwargs": {"relative": True}},
+        metadata={"RID": "something"},
+    )
+    report_instruction = {
+        "readback": {"RID": "something", "devices": ["samx"], "start": [0], "end": [10]}
+    }
+    restart_msg = messages.ScanQueueMessage(
+        scan_type="umv",
+        parameter={"args": {"samx": [10]}, "kwargs": {"relative": True}},
+        metadata={"RID": "restart"},
+    )
+    live_update = LiveUpdatesReadbackProgressbar(
+        bec=client, report_instruction=report_instruction, request=request
+    )
+    queue = mock.MagicMock(
+        status="STOPPED",
+        reason="restart",
+        scans=[mock.MagicMock(restarted_msg=None, status_message=mock.MagicMock(reason="alarm"))],
+    )
+    live_update.scan_queue_request = mock.MagicMock(queue=queue)
+
+    with (
+        mock.patch("bec_ipython_client.callbacks.move_device.check_alarms"),
+        mock.patch.object(LiveUpdatesReadbackProgressbar, "wait_for_request_acceptance"),
+        mock.patch.object(LiveUpdatesReadbackProgressbar, "_print_client_msgs_asap"),
+        mock.patch.object(LiveUpdatesReadbackProgressbar, "_print_client_msgs_all"),
+        mock.patch.object(ReadbackDataHandler, "get_device_values", side_effect=[[0], [10]]),
+        mock.patch.object(
+            ReadbackDataHandler, "device_states", return_value={"samx": (True, True)}
+        ),
+        mock.patch.object(ReadbackDataHandler, "done", return_value=True),
+        mock.patch("bec_ipython_client.callbacks.move_device.time.sleep") as sleep,
+    ):
+
+        def trigger_restart(*_args, **_kwargs):
+            queue.scans[-1].restarted_msg = restart_msg
+
+        sleep.side_effect = trigger_restart
+
+        with pytest.raises(ScanRestart) as exc_info:
+            live_update.core()
+
+    assert exc_info.value.new_scan_msg == restart_msg
 
 
 def test_readback_data_handler(readback_data_handler):

--- a/bec_lib/bec_lib/messages.py
+++ b/bec_lib/bec_lib/messages.py
@@ -401,6 +401,8 @@ class QueueInfoEntry(BaseModel):
         scan_number (list[int | None]): List of scan numbers for each request block
         status (str): Current status of the queue entry
         active_request_block (RequestBlock | None): The currently active request block, if any
+        reason (Literal["user", "alarm", "restart"] | None): Reason for the queue item's
+            terminal transition, if known.
     """
 
     queue_id: str
@@ -410,6 +412,7 @@ class QueueInfoEntry(BaseModel):
     scan_number: list[int | None]
     status: str
     active_request_block: RequestBlock | None = None
+    reason: Literal["user", "alarm", "restart"] | None = None
 
 
 class ScanQueueLock(BaseModel):

--- a/bec_lib/bec_lib/queue_items.py
+++ b/bec_lib/bec_lib/queue_items.py
@@ -43,6 +43,7 @@ class QueueItem:
         status: str,
         active_request_block: messages.RequestBlock | None,
         scan_id: list[str | None],
+        reason: str | None = None,
         client_messages: list | None = None,
         **_kwargs,
     ) -> None:
@@ -52,6 +53,7 @@ class QueueItem:
         self._status = status
         self.active_request_block = active_request_block
         self.scan_ids = scan_id
+        self.reason = reason
         if client_messages is None:
             client_messages = []
         self.client_messages = client_messages
@@ -107,6 +109,7 @@ class QueueItem:
         self._status = queue_item.status
         self.active_request_block = queue_item.active_request_block
         self.scan_ids = queue_item.scan_id
+        self.reason = queue_item.reason
 
     def update_with_client_message(self, message: messages.ClientInfoMessage):
         """append a client message to the queue item"""

--- a/bec_server/bec_server/scan_server/scan_queue.py
+++ b/bec_server/bec_server/scan_server/scan_queue.py
@@ -520,6 +520,12 @@ class QueueManager:
             # If the scan is not running, we don't need to restart it
             return
 
+        restart_scan_msg = instruction_queue.scan_msgs[0].model_copy(deep=True)
+        request_id = parameter.get("RID") if parameter else None
+        if request_id:
+            restart_scan_msg.metadata["RID"] = request_id
+        instruction_queue.reason = "restart"
+
         # Abort the current scan first and wait for it to appear in history
         with AutoResetCM(que):
             original_queue_status = que.status
@@ -531,18 +537,16 @@ class QueueManager:
             ]:
                 que.worker_status = InstructionQueueStatus.STOPPED
         self._lock.release()
-        instruction_queue = self._wait_for_queue_to_appear_in_history(scan_id, queue)
+        self._wait_for_queue_to_appear_in_history(scan_id, queue)
         self._lock.acquire()
 
-        scan_msg = instruction_queue.scan_msgs[0]
-        request_id = parameter.get("RID")
-        if request_id:
-            scan_msg.metadata["RID"] = request_id
-        scan_restart_msg = messages.ScanRestartMessage(original_scan_id=scan_id, scan_msg=scan_msg)
+        scan_restart_msg = messages.ScanRestartMessage(
+            original_scan_id=scan_id, scan_msg=restart_scan_msg
+        )
         self.connector.send(MessageEndpoints.scan_restart(), scan_restart_msg)
-        if scan_msg.allow_restart:
+        if restart_scan_msg.allow_restart:
             logger.info(f"Restarting scan {scan_id} in queue {queue}")
-            self.add_to_queue(queue, scan_msg, 0)
+            self.add_to_queue(queue, restart_scan_msg, 0)
         else:
             logger.info(f"Scan {scan_id} restart not allowed, only sending ScanRestartMessage")
         self.queues[queue].status = original_queue_status
@@ -1324,6 +1328,7 @@ class InstructionQueueItem:
         self.stopped = False
         self._status = InstructionQueueStatus.PENDING
         self._return_to_start = None
+        self.reason: Literal["user", "alarm", "restart"] | None = None
 
     @property
     def scan_number(self) -> list[int]:
@@ -1409,6 +1414,7 @@ class InstructionQueueItem:
             active_request_block=(
                 self.active_request_block.describe() if self.active_request_block else None
             ),
+            reason=self.reason or (self.exit_info[1] if self.exit_info else None),
         )
         return content
 
@@ -1513,6 +1519,7 @@ class DirectInstructionQueueItem:
         self.active_scan: ScanBase_v4 | None = None
         self.scans: list[ScanBase_v4] = []
         self.scan_msgs: list[messages.ScanQueueMessage] = []
+        self.reason: Literal["user", "alarm", "restart"] | None = None
 
     @property
     def status(self) -> InstructionQueueStatus:
@@ -1588,6 +1595,7 @@ class DirectInstructionQueueItem:
             scan_number=self.scan_number,
             status=self.status.name,
             active_request_block=self.describe_active_scan(),
+            reason=self.reason or (self.exit_info[1] if self.exit_info else None),
         )
         return content
 

--- a/bec_server/tests/tests_scan_server/test_scan_server_queue.py
+++ b/bec_server/tests/tests_scan_server/test_scan_server_queue.py
@@ -746,11 +746,23 @@ def test_set_restart(queuemanager_mock):
             with mock.patch.object(
                 queue_manager, "_wait_for_queue_to_appear_in_history"
             ) as scan_msg_wait:
-                scan_msg_wait.return_value = iq
-                with queue_manager._lock:
-                    queue_manager.set_restart(queue="primary", parameter={"RID": "something_new"})
-                scan_msg_wait.assert_called_once_with(iq.scan_id[0], "primary")
-                add_new_scan_to_queue.assert_called_once()
+                with mock.patch.object(queue_manager.connector, "send") as connector_send:
+                    scan_msg_wait.return_value = iq
+                    with queue_manager._lock:
+                        queue_manager.set_restart(
+                            queue="primary", parameter={"RID": "something_new"}
+                        )
+                    scan_msg_wait.assert_called_once_with(iq.scan_id[0], "primary")
+                    add_new_scan_to_queue.assert_called_once()
+                    restart_msg = connector_send.call_args_list[0].args[1]
+                    assert restart_msg.original_scan_id == iq.scan_id[0]
+                    assert restart_msg.scan_msg.metadata["RID"] == "something_new"
+                    assert iq.scan_msgs[0].metadata["RID"] == "something"
+                    assert iq.reason == "restart"
+                    assert iq.describe().reason == "restart"
+                    assert (
+                        add_new_scan_to_queue.call_args.args[1].metadata["RID"] == "something_new"
+                    )
 
 
 @pytest.mark.timeout(5)


### PR DESCRIPTION
## Description

The scan repeat exception was not properly handled for device progress and move progress. This PR fixes it. It also solves a timing issue on the bec server where a restarted scan would be treated as stopped instead. Now the queue update also carries a "reason" flag. 

## Type of Change

- Add "reason" flag to the scan queue update
- Fix support for restart events during live updates. 

## How to test

- Run unit tests
- Trigger a restart with the scan interlock widget

