### PR TITLE
fix: remove config value destructor, only do manual cleanup

### DIFF
--- a/bec_lib/bec_lib/config_values.py
+++ b/bec_lib/bec_lib/config_values.py
@@ -42,10 +42,6 @@ class RedisConfigValue(property, Generic[ValueT]):
         self._config = self._fetch()
         self._connector.register(self._ep, cb=self._update_cb)
 
-    def __del__(self):
-        if hasattr(self, "_connector"):
-            self.unregister_all()
-
     def __bool__(self):
         raise ValueError(f"Maybe you meant to check {self}.value?")
 


### PR DESCRIPTION
Not needed since the addition of manual cleanup, and causing bec widgets tests to deadlock on test teardown