### PR TITLE
fix: trim the history to 50

### DIFF
--- a/bec_lib/bec_lib/scan_history.py
+++ b/bec_lib/bec_lib/scan_history.py
@@ -39,7 +39,7 @@ class ScanHistory:
         self._scan_history_loaded_event = threading.Event()
         self._loaded = False
         self._loading_thread = None
-        self._max_scans = 10000
+        self._max_scans = 50
         self._start_retrieval()
 
     def _start_retrieval(self) -> None:


### PR DESCRIPTION
## Description

We trim the history for now to just 50 scans until we restructure the scan history endpoints in redis and run the lookup there. 

