### PR TITLE
fix: run .get for position instead of full rpc

### DIFF
--- a/bec_lib/bec_lib/device.py
+++ b/bec_lib/bec_lib/device.py
@@ -1417,9 +1417,11 @@ class Positioner(AdjustableMixin, Device):
         return self.root.parent.parent.scans.mv(self, val, relative=relative)
 
     @property
-    @rpc
     def position(self):
-        pass
+        pos_signal = getattr(self, "readback", None) or getattr(self, "user_readback", None)
+        if pos_signal:
+            return pos_signal.get()
+        return self._run(fcn="position")
 
     @rpc
     def moving(self):


### PR DESCRIPTION
## Description

It is more efficient to simply run a .get when asking for the position as these methods bypass the queue

