### PR TITLE
fix: allow v4 scan abortion to be handled similar to legacy scans

### DIFF
--- a/bec_server/bec_server/scan_server/direct_scan_worker.py
+++ b/bec_server/bec_server/scan_server/direct_scan_worker.py
@@ -87,30 +87,50 @@ class DirectScanWorker:
                         raise ScanAbortion(f"Scan is missing required method: {step}")
                     self.check_for_interruption()
                     method()
+        except ScanAbortion as exc:
+            if not self._prepare_exception_cleanup(queue, exc):
+                return
+            raise exc
         except Exception as exc:
-            if self.worker.signal_event.is_set():
-                # If the signal event is set, it means that the scan worker is shutting down, so we don't need to handle the abortion
+            if not self._prepare_exception_cleanup(queue, exc):
                 return
-            if queue is None:
-                return
-            if queue.stopped or not queue.active_request_block:
-                raise exc
-            queue.stopped = True
-            try:
-                # We reset the worker to RUNNING to allow for cleanup tasks
-                # during the on_exception hook.
-                self.worker.status = InstructionQueueStatus.RUNNING
-                self.scan.actions._metadata_suffix = "__on-exception"
-                self._run_on_exception_hook(exc)
-            except Exception as exc_cleanup:
-                self.worker.connector.send_client_info("")
-                self._handle_exception(exc_cleanup)
             self._handle_exception(exc)
         if queue is None:
             return
         queue.status = InstructionQueueStatus.COMPLETED
         self.worker.current_instruction_queue_item = None
         self.reset()
+
+    def _prepare_exception_cleanup(
+        self, queue: DirectInstructionQueueItem | None, exc: Exception
+    ) -> bool:
+        """Prepare exception cleanup for a failed direct scan run.
+
+        Returns True when the caller should continue propagating/handling the
+        original exception, or False when shutdown/no-queue means the run can
+        exit early.
+        """
+        if self.worker.signal_event.is_set():
+            # If the signal event is set, the worker is shutting down and does
+            # not need additional exception handling.
+            return False
+        if queue is None:
+            return False
+        if queue.stopped or not queue.active_request_block:
+            raise exc
+
+        queue.stopped = True
+        try:
+            # We reset the worker to RUNNING to allow for cleanup tasks during
+            # the on_exception hook.
+            self.worker.status = InstructionQueueStatus.RUNNING
+            if self.scan is not None:
+                self.scan.actions._metadata_suffix = "__on-exception"
+            self._run_on_exception_hook(exc)
+        except Exception as exc_cleanup:
+            self.worker.connector.send_client_info("")
+            self._handle_exception(exc_cleanup)
+        return True
 
     def _handle_exception(self, exc: Exception):
         content = traceback.format_exc()

--- a/bec_server/tests/tests_scan_server/test_direct_scan_worker.py
+++ b/bec_server/tests/tests_scan_server/test_direct_scan_worker.py
@@ -417,6 +417,25 @@ def test_run_uses_on_exception_cleanup_before_handling_error(direct_worker_conte
     direct_worker_context.direct_worker._handle_exception.assert_called_once()
 
 
+def test_run_uses_on_exception_cleanup_for_scan_abortion(direct_worker_context, make_scan):
+    scan = make_scan()
+    scan.on_exception = mock.MagicMock()
+    scan.scan_core = mock.MagicMock(side_effect=ScanAbortion())
+    direct_worker_context.queue.active_scan = scan
+    direct_worker_context.scan_worker.current_instruction_queue_item = direct_worker_context.queue
+    direct_worker_context.device_manager._rpc_method = mock.MagicMock(return_value=mock.MagicMock())
+    direct_worker_context.direct_worker._handle_exception = mock.MagicMock()
+
+    with pytest.raises(ScanAbortion):
+        direct_worker_context.direct_worker.run(scan)
+
+    assert direct_worker_context.queue.stopped is True
+    assert direct_worker_context.scan_worker.status == InstructionQueueStatus.RUNNING
+    assert scan.actions._metadata_suffix == "__on-exception"
+    scan.on_exception.assert_called_once()
+    direct_worker_context.direct_worker._handle_exception.assert_not_called()
+
+
 def test_run_handles_cleanup_exception_before_original_error(direct_worker_context, make_scan):
     scan = make_scan(fail_step="scan_core")
     cleanup_exc = UserScanInterruption(exit_info=("halted", "user"))


### PR DESCRIPTION
## Description

ScanAbortions are handled differently in v3 and v4-type scans. This PR unifies the flow for both variants. 

