### PR TITLE
fix: prevent inserts when worker is busy

### DIFF
--- a/bec_ipython_client/tests/end-2-end/test_scans_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_scans_e2e.py
@@ -424,10 +424,7 @@ def test_scan_observer_repeat(bec_ipython_client_fixture):
                 continue
             if len(bec.queue.scan_storage.current_scan.live_data) > 0:
                 time.sleep(2)
-                bec.queue.request_scan_interruption(deferred_pause=False)
-                time.sleep(5)
                 bec.queue.request_scan_restart()
-                bec.queue.request_scan_continuation()
                 break
 
     scan_number_start = bec.queue.next_scan_number

--- a/bec_server/bec_server/scan_server/scan_queue.py
+++ b/bec_server/bec_server/scan_server/scan_queue.py
@@ -184,7 +184,6 @@ class QueueManager:
         # instructions = self.scan_assembler.assemble_device_instructions(scan_msg)
         queue = scan_msg.content.get("queue", "primary")
         self.add_to_queue(queue, scan_msg)
-        self.send_queue_status()
 
     def _scan_queue_modification_callback(self, msg):
         scan_mod_msg = msg.value
@@ -526,7 +525,18 @@ class QueueManager:
             restart_scan_msg.metadata["RID"] = request_id
         instruction_queue.reason = "restart"
 
-        # Abort the current scan first and wait for it to appear in history
+        scan_restart_msg = messages.ScanRestartMessage(
+            original_scan_id=scan_id, scan_msg=restart_scan_msg
+        )
+        self.connector.send(MessageEndpoints.scan_restart(), scan_restart_msg)
+        if restart_scan_msg.allow_restart:
+            logger.info(f"Restarting scan {scan_id} in queue {queue}")
+            # Queue the replacement before stopping the original so the restarted scan is next.
+            self.add_to_queue(queue, restart_scan_msg, 1)
+        else:
+            logger.info(f"Scan {scan_id} restart not allowed, only sending ScanRestartMessage")
+
+        # Abort the current scan after queueing its restart replacement.
         with AutoResetCM(que):
             original_queue_status = que.status
             que.status = ScanQueueStatus.PAUSED
@@ -536,19 +546,7 @@ class QueueManager:
                 InstructionQueueStatus.DEFERRED_PAUSE,
             ]:
                 que.worker_status = InstructionQueueStatus.STOPPED
-        self._lock.release()
-        self._wait_for_queue_to_appear_in_history(scan_id, queue)
-        self._lock.acquire()
 
-        scan_restart_msg = messages.ScanRestartMessage(
-            original_scan_id=scan_id, scan_msg=restart_scan_msg
-        )
-        self.connector.send(MessageEndpoints.scan_restart(), scan_restart_msg)
-        if restart_scan_msg.allow_restart:
-            logger.info(f"Restarting scan {scan_id} in queue {queue}")
-            self.add_to_queue(queue, restart_scan_msg, 0)
-        else:
-            logger.info(f"Scan {scan_id} restart not allowed, only sending ScanRestartMessage")
         self.queues[queue].status = original_queue_status
 
     @requires_queue
@@ -742,6 +740,7 @@ class ScanQueue:
         ) = None,
     ) -> None:
         self.queue: Deque[InstructionQueueItem | DirectInstructionQueueItem] = collections.deque()
+        self._deferred_inserts: Deque[tuple[messages.ScanQueueMessage, int]] = collections.deque()
         self.queue_name = queue_name
         self.history_queue: collections.deque[InstructionQueueItem | DirectInstructionQueueItem] = (
             collections.deque(maxlen=self.MAX_HISTORY)
@@ -911,8 +910,8 @@ class ScanQueue:
 
     def _next_instruction_queue(self) -> bool:
         """get the next instruction queue from the queue. If no update is available, it will return False."""
-        with self._lock:
-            try:
+        try:
+            with self._lock:
                 aiq = self.active_instruction_queue
                 if (
                     aiq is not None
@@ -924,54 +923,67 @@ class ScanQueue:
                     self.queue_manager.send_queue_status()
 
                 if self._queue_should_continue():
+                    self._flush_deferred_inserts()
                     if len(self.queue) == 0:
                         if aiq is None:
-                            self.signal_event.wait(0.1)
-                            return False
-                        self.active_instruction_queue = None
-                        self.signal_event.wait(0.01)
-                        return False
+                            wait_time = 0.1
+                        else:
+                            self.active_instruction_queue = None
+                            wait_time = 0.01
+                    else:
+                        self.active_instruction_queue = self.queue[0]
+                        self.history_queue.append(self.active_instruction_queue)
+                        return True
+                else:
+                    wait_time = None
 
-                    self.active_instruction_queue = self.queue[0]
-                    self.history_queue.append(self.active_instruction_queue)
-                    return True
+            if wait_time is not None:
+                self.signal_event.wait(wait_time)
+                return False
 
-                while self.status == ScanQueueStatus.LOCKED and not self.signal_event.is_set():
-                    self.signal_event.wait(0.1)
-                    if self._queue_should_continue():
+            while not self.signal_event.is_set():
+                with self._lock:
+                    if self.status != ScanQueueStatus.LOCKED or self._queue_should_continue():
                         break
+                    self._flush_deferred_inserts()
+                self.signal_event.wait(0.1)
 
-                while self.status == ScanQueueStatus.PAUSED and not self.signal_event.is_set():
+            while not self.signal_event.is_set():
+                with self._lock:
+                    if self.status != ScanQueueStatus.PAUSED:
+                        break
                     if len(self.queue) == 0 and self.auto_reset_enabled:
                         # we don't need to pause if there is no scan enqueued
                         self.status = ScanQueueStatus.RUNNING
                         logger.info("resetting queue status to running")
+                        break
                     if (
                         len(self.queue) > 0
                         and self.queue[0].status == InstructionQueueStatus.STOPPED
                     ):
                         # The next instruction queue is stopped, we can remove it
                         break
-                    self.signal_event.wait(0.1)
+                self.signal_event.wait(0.1)
 
+            with self._lock:
+                self._flush_deferred_inserts()
                 self.active_instruction_queue = self.queue[0]
                 self.history_queue.append(self.active_instruction_queue)
                 return True
-            except IndexError:
-                self.signal_event.wait(0.01)
-            return False
+        except IndexError:
+            self.signal_event.wait(0.01)
+        return False
 
-    def insert(self, msg: messages.ScanQueueMessage, position=-1, **_kwargs):
-        """insert a new message to the queue"""
-        while self.worker_status == InstructionQueueStatus.STOPPED:
-            logger.info("Waiting for worker to become active.")
-            if self.signal_event.wait(0.1):
-                break
-        while self.status == ScanQueueStatus.PAUSED and len(self.queue) == 0:
-            logger.info("Waiting for queue to become active.")
-            if self.signal_event.wait(0.1):
-                break
+    def _flush_deferred_inserts(self) -> None:
+        """Move buffered inserts into the live queue once the stopped head no longer blocks them."""
+        if not self._deferred_inserts or self.worker_status == InstructionQueueStatus.STOPPED:
+            return
+        while self._deferred_inserts:
+            msg, position = self._deferred_inserts.popleft()
+            self._insert_now(msg, position=position)
 
+    def _insert_now(self, msg: messages.ScanQueueMessage, position=-1) -> None:
+        """Insert a new message into the live queue without waiting."""
         target_group = msg.metadata.get("queue_group")
         scan_def_id = msg.metadata.get("scan_def_id")
         logger.debug(f"Inserting new queue message {msg}")
@@ -1007,8 +1019,28 @@ class ScanQueue:
             instruction_queue.queue_group = target_group
             if position == -1:
                 self.queue.append(instruction_queue)
+            else:
+                self.queue.insert(position, instruction_queue)
+
+        self.queue_manager.send_queue_status()
+
+    def insert(self, msg: messages.ScanQueueMessage, position=-1, **_kwargs):
+        """Insert a new message into the queue or buffer it until a stopped head item clears."""
+        with self._lock:
+            if self.worker_status == InstructionQueueStatus.STOPPED:
+                logger.info("Deferring queue insert until worker becomes active again.")
+                self._deferred_inserts.append((msg, position))
                 return
-            self.queue.insert(position, instruction_queue)
+
+            self._flush_deferred_inserts()
+
+        while self.status == ScanQueueStatus.PAUSED and len(self.queue) == 0:
+            logger.info("Waiting for queue to become active.")
+            if self.signal_event.wait(0.1):
+                break
+
+        with self._lock:
+            self._insert_now(msg, position=position)
 
     def get_queue_item(self, group=None, scan_def_id=None):
         """get a queue item based on its group or scan_def_id"""

--- a/bec_server/bec_server/scan_server/scan_worker.py
+++ b/bec_server/bec_server/scan_server/scan_worker.py
@@ -97,6 +97,7 @@ class ScanWorker(threading.Thread):
 
     def shutdown(self):
         """shutdown the scan worker"""
+        self.status = InstructionQueueStatus.STOPPED
         self.signal_event.set()
         if self._started.is_set():  # type: ignore ; _started is defined in threading.Thread
             self.join()

--- a/bec_server/tests/tests_scan_server/test_scan_server_queue.py
+++ b/bec_server/tests/tests_scan_server/test_scan_server_queue.py
@@ -109,6 +109,21 @@ def test_queuemanager_add_to_queue(queuemanager_mock, queue):
     assert queue_manager.queues[queue].queue.popleft().scan_msgs[0] == msg
 
 
+def test_queuemanager_add_to_queue_publishes_status_for_default_append(queuemanager_mock):
+    queue_manager = queuemanager_mock()
+    msg = messages.ScanQueueMessage(
+        scan_type="mv",
+        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        queue="primary",
+        metadata={"RID": "something"},
+    )
+
+    with mock.patch.object(queue_manager, "send_queue_status") as send_queue_status:
+        queue_manager.add_to_queue(scan_queue="primary", msg=msg)
+
+    send_queue_status.assert_called_once()
+
+
 @pytest.mark.timeout(20)
 def test_queuemanger_shuts_down_idle_queue(queuemanager_mock):
     """
@@ -179,10 +194,8 @@ def test_queuemanager_scan_queue_callback(queuemanager_mock):
     )
     obj = MessageObject("scan_queue", msg)
     with mock.patch.object(queue_manager, "add_to_queue") as add_to_queue:
-        with mock.patch.object(queue_manager, "send_queue_status") as send_queue_status:
-            queue_manager._scan_queue_callback(obj)
-            add_to_queue.assert_called_once_with("primary", msg)
-            send_queue_status.assert_called_once()
+        queue_manager._scan_queue_callback(obj)
+        add_to_queue.assert_called_once_with("primary", msg)
 
 
 def test_scan_queue_modification_callback(queuemanager_mock):
@@ -752,8 +765,8 @@ def test_set_restart(queuemanager_mock):
                         queue_manager.set_restart(
                             queue="primary", parameter={"RID": "something_new"}
                         )
-                    scan_msg_wait.assert_called_once_with(iq.scan_id[0], "primary")
-                    add_new_scan_to_queue.assert_called_once()
+                    scan_msg_wait.assert_not_called()
+                    add_new_scan_to_queue.assert_called_once_with("primary", mock.ANY, 1)
                     restart_msg = connector_send.call_args_list[0].args[1]
                     assert restart_msg.original_scan_id == iq.scan_id[0]
                     assert restart_msg.scan_msg.metadata["RID"] == "something_new"
@@ -1016,6 +1029,111 @@ def test_scan_queue_next_instruction_queue_pops_stopped_elements(queuemanager_mo
     assert len(queue.queue) == 1
     assert queue._next_instruction_queue() is False
     assert len(queue.queue) == 0
+
+
+def test_scan_queue_insert_defers_while_head_is_stopped(queuemanager_mock):
+    queue_manager = queuemanager_mock()
+    queue = ScanQueue(queue_manager, InstructionQueueMock)
+    stopped_item = InstructionQueueItem(queue, mock.MagicMock(), mock.MagicMock())
+    stopped_item.status = InstructionQueueStatus.STOPPED
+    queue.queue.append(stopped_item)
+
+    msg = messages.ScanQueueMessage(
+        scan_type="mv",
+        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        queue="primary",
+        metadata={"RID": "rid-stopped"},
+    )
+
+    insert_finished = threading.Event()
+
+    def do_insert():
+        queue.insert(msg)
+        insert_finished.set()
+
+    thread = threading.Thread(target=do_insert)
+    thread.start()
+    thread.join(timeout=5)
+
+    assert insert_finished.is_set()
+    assert len(queue.queue) == 1
+    assert len(queue._deferred_inserts) == 1
+
+
+def test_scan_queue_flushes_deferred_inserts_once_stopped_head_is_removed(queuemanager_mock):
+    queue_manager = queuemanager_mock()
+    queue = ScanQueue(queue_manager, InstructionQueueMock)
+    stopped_item = InstructionQueueItem(queue, mock.MagicMock(), mock.MagicMock())
+    stopped_item.status = InstructionQueueStatus.STOPPED
+    queued_item = InstructionQueueItem(queue, mock.MagicMock(), mock.MagicMock())
+    queue.queue.extend([stopped_item, queued_item])
+    queue.active_instruction_queue = stopped_item
+
+    msg = messages.ScanQueueMessage(
+        scan_type="mv",
+        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        queue="primary",
+        metadata={"RID": "rid-flush"},
+    )
+    queue._deferred_inserts.append((msg, -1))
+
+    assert queue._next_instruction_queue() is True
+    assert len(queue._deferred_inserts) == 0
+    assert len(queue.queue) == 2
+    assert queue.queue[-1].scan_msgs[0] == msg
+
+
+def test_scan_queue_insert_does_not_block_while_worker_waits_on_lock(queuemanager_mock):
+    queue_manager = queuemanager_mock()
+    queue = ScanQueue(queue_manager, InstructionQueueMock)
+    pending_item = InstructionQueueItem(queue, mock.MagicMock(), mock.MagicMock())
+    pending_item.status = InstructionQueueStatus.PENDING
+    queue.queue.append(pending_item)
+
+    lock = messages.ScanQueueLock(
+        identifier="insert_during_lock",
+        reason="Testing insert while locked",
+        allow_device_instructions=False,
+    )
+    queue.add_lock(lock)
+
+    worker_waiting = threading.Event()
+    worker_finished = threading.Event()
+
+    def try_next():
+        worker_waiting.set()
+        queue._next_instruction_queue()
+        worker_finished.set()
+
+    thread = threading.Thread(target=try_next)
+    thread.start()
+    worker_waiting.wait(timeout=1)
+    time.sleep(0.2)
+
+    msg = messages.ScanQueueMessage(
+        scan_type="mv",
+        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        queue="primary",
+        metadata={"RID": "rid-locked-insert"},
+    )
+
+    insert_finished = threading.Event()
+
+    def do_insert():
+        queue.insert(msg)
+        insert_finished.set()
+
+    insert_thread = threading.Thread(target=do_insert)
+    insert_thread.start()
+    insert_thread.join(timeout=5)
+
+    assert insert_finished.is_set()
+    assert len(queue.queue) == 2
+    assert queue.queue[-1].scan_msgs[0] == msg
+
+    queue.remove_lock(lock)
+    thread.join(timeout=2)
+    assert worker_finished.is_set()
 
 
 def test_queue_manager_wait_for_queue_to_appear_in_history_raises_timeout(queuemanager_mock):


### PR DESCRIPTION
## Description

There was a risk that during the cleanup of a scan, a new submission would lead to a deadlock of the redis dispatcher thread and thus completely block the scan server queue. 
In general, we should not wait while being on the redis dispatcher and the fix here is trying to avoid it by moving the pending requests to a stack which will be flushed with the next opportunity. 

