### PR TITLE
Fix/path optimizer

### DIFF
--- a/bec_server/bec_server/scan_server/path_optimization.py
+++ b/bec_server/bec_server/scan_server/path_optimization.py
@@ -1,8 +1,14 @@
+from time import perf_counter
 from typing import Literal
 
 import numpy as np
 from pydantic import BaseModel
 from scipy.spatial import cKDTree  # type: ignore
+
+from bec_lib.logger import bec_logger
+from bec_server.scan_server.scans.position_generators import Direction
+
+logger = bec_logger.logger
 
 
 class PathQualityStats(BaseModel):
@@ -15,6 +21,19 @@ class PathQualityStats(BaseModel):
 
 
 class PathOptimizerMixin:
+    def _log_optimization_result(
+        self, method: str, original_path: np.ndarray, optimized_path: np.ndarray, duration_s: float
+    ) -> None:
+        original_length = self.get_path_length(original_path)
+        optimized_length = self.get_path_length(optimized_path)
+        reduced_by = original_length - optimized_length
+        reduction_pct = (reduced_by / original_length * 100) if original_length > 0 else 0.0
+
+        logger.info(
+            f"Path optimizer ({method}) reduced path length from {original_length:.4f} to {optimized_length:.4f} "
+            f"({reduced_by:.4f} reduction, {reduction_pct:.2f}% decrease) in {duration_s:.4f} seconds."
+        )
+
     def get_radius(self, pos: np.ndarray) -> np.ndarray:
         """
         Calculate the radial distance from the origin for each position
@@ -31,9 +50,10 @@ class PathOptimizerMixin:
         self,
         positions: np.ndarray,
         corridor_size: float | None = None,
-        sort_axis: int = 1,
+        fast_axis: Literal[0, 1] = 0,
         num_iterations: int = 1,
-        preferred_direction: int | None = None,
+        first_corridor_direction: Direction | Literal[-1, 1] = Direction.ASCENDING,
+        snaked: bool = True,
         corridor_estimation: Literal["density", "median_distance"] = "median_distance",
     ):
         """
@@ -45,18 +65,24 @@ class PathOptimizerMixin:
         Args:
             positions (np.ndarray): Array of positions
             corridor_size (float, optional): Width of each corridor. Defaults to None (auto-estimated).
-            sort_axis (int, optional): Axis along which to create corridors (0 or 1). Defaults to 1.
+            fast_axis (Literal[0, 1], optional): Axis traversed within each corridor (0 or 1). Defaults to 0.
             num_iterations (int, optional): Number of corridor sizes to try. Defaults to 1.
-            preferred_direction (int | None, optional): Preferred direction for the primary axis (1 or -1).
-                If None, alternates direction for each corridor.
-            corridor_estimation (str, optional): Method for estimating corridor size if not provided.
-                Options are "density" or "median_distance". Defaults to "density".
+            first_corridor_direction (Direction | Literal[-1, 1], optional): Traversal direction of the first
+                corridor along the fast axis. Positive means ascending, negative means
+                descending. Defaults to Direction.ASCENDING.
+            snaked (bool, optional): If True, alternate the traversal direction between
+                successive corridors. If False, keep the same direction in every corridor.
+            corridor_estimation (Literal["density", "median_distance"], optional): Method for estimating corridor size if not provided.
+                Options are "density" or "median_distance". Defaults to "median_distance".
 
         Returns:
             np.ndarray: Optimized positions
         """
         if positions.ndim != 2 or positions.shape[1] < 2:
             return positions
+
+        start_time = perf_counter()
+        original_path = positions
 
         # Estimate corridor size if needed
         if corridor_size is None:
@@ -70,8 +96,14 @@ class PathOptimizerMixin:
                     'Choose "density" or "median_distance".'
                 )
 
-        axis_vals = positions[:, sort_axis]
-        sec_axis = int(not sort_axis)
+        if not isinstance(first_corridor_direction, Direction):
+            first_corridor_direction = Direction(first_corridor_direction)
+
+        if fast_axis not in (0, 1):
+            raise ValueError("fast_axis must be 0 or 1")
+
+        slow_axis = int(not fast_axis)
+        axis_vals = positions[:, slow_axis]
 
         best_length = np.inf
         best_path = positions
@@ -97,17 +129,15 @@ class PathOptimizerMixin:
                 if block.size == 0:
                     continue
 
-                # Sort within corridor along secondary axis
-                block = block[np.argsort(positions[block, sec_axis])]
+                # Sort within corridor along fast axis
+                block = block[np.argsort(positions[block, fast_axis])]
 
                 # Direction handling
-                if preferred_direction is not None:
-                    if preferred_direction < 0:
-                        block = block[::-1]
-                else:
-                    # Alternate direction between corridors
-                    if step % 2 == 0:
-                        block = block[::-1]
+                direction = first_corridor_direction
+                if snaked and step % 2 == 1:
+                    direction = Direction(-direction)
+                if direction == Direction.DESCENDING:
+                    block = block[::-1]
 
                 index_sorted.append(block)
 
@@ -122,6 +152,9 @@ class PathOptimizerMixin:
                 best_length = path_length
                 best_path = path
 
+        self._log_optimization_result(
+            "corridor", original_path, best_path, perf_counter() - start_time
+        )
         return best_path
 
     def _corridor_estimate_density(self, positions: np.ndarray) -> float:
@@ -182,6 +215,9 @@ class PathOptimizerMixin:
         if pos.ndim != 2 or pos.shape[1] < 2 or len(pos) < 2:
             return pos
 
+        start_time = perf_counter()
+        original_path = pos
+
         # Calculate radii once
         radii = self.get_radius(pos)
         max_rad = np.max(radii)
@@ -227,7 +263,9 @@ class PathOptimizerMixin:
                     best_score = score
                     best_path = optimized_path
 
-        return best_path if best_path is not None else pos
+        result = best_path if best_path is not None else pos
+        self._log_optimization_result("shell", original_path, result, perf_counter() - start_time)
+        return result
 
     def _estimate_shell_width(self, pos: np.ndarray, radii: np.ndarray, max_rad: float) -> float:
         """
@@ -413,6 +451,9 @@ class PathOptimizerMixin:
         if len(positions) <= 1:
             return positions
 
+        start_time = perf_counter()
+        original_path = positions
+
         n_points = len(positions)
 
         # Use a copy to avoid modifying the original
@@ -455,4 +496,8 @@ class PathOptimizerMixin:
             path.append(current_pos)
             remaining_indices.remove(original_idx)
 
-        return np.array(path)
+        result = np.array(path)
+        self._log_optimization_result(
+            "nearest_neighbor", original_path, result, perf_counter() - start_time
+        )
+        return result

--- a/bec_server/bec_server/scan_server/scans/fermat_scan.py
+++ b/bec_server/bec_server/scan_server/scans/fermat_scan.py
@@ -24,6 +24,7 @@ from bec_lib.device import DeviceBase
 from bec_lib.logger import bec_logger
 from bec_lib.scan_args import DefaultArgType, ScanArgument, Units
 from bec_server.scan_server.scans import position_generators
+from bec_server.scan_server.scans.position_generators import Direction
 from bec_server.scan_server.scans.scan_base import ScanBase, ScanType
 from bec_server.scan_server.scans.scan_modifier import scan_hook
 
@@ -172,6 +173,18 @@ class FermatSpiralScan(ScanBase):
         if self.relative:
             self.start_positions = self.components.get_start_positions(self.motors)
             self.positions += self.start_positions
+
+        if self.optim_trajectory:
+            self.positions = self.components.optimize_trajectory(
+                self.positions,
+                optimization_type=self.optim_trajectory,
+                fast_axis=0,
+                first_direction=(
+                    Direction.ASCENDING
+                    if self.motor1_start_stop[1] > self.motor1_start_stop[0]
+                    else Direction.DESCENDING
+                ),
+            )
 
         self.components.check_limits(self.motors, self.positions)
 

--- a/bec_server/bec_server/scan_server/scans/legacy_scans.py
+++ b/bec_server/bec_server/scan_server/scans/legacy_scans.py
@@ -19,7 +19,7 @@ from bec_lib.logger import bec_logger
 from bec_server.scan_server.instruction_handler import InstructionHandler
 
 from ..errors import LimitError, ScanAbortion
-from ..path_optimization import PathOptimizerMixin
+from ..path_optimization import Direction, PathOptimizerMixin
 from ..scan_stubs import ScanStubs
 
 logger = bec_logger.logger
@@ -519,26 +519,14 @@ class ScanBase(RequestBase, PathOptimizerMixin):
         if not self.optim_trajectory:
             return
 
-        # Get preferred directions from scan parameters if available
-        preferred_directions = getattr(self, "preferred_directions", None)
-
         if self.optim_trajectory == "corridor":
-            # For corridor optimization, we use the primary axis preferred direction
-            if preferred_directions and len(preferred_directions) > 0:
-                primary_axis = getattr(self, "sort_axis", 1)
-                preferred_direction = (
-                    preferred_directions[primary_axis]
-                    if len(preferred_directions) > primary_axis
-                    else None
-                )
-                self.positions = self.optimize_corridor(
-                    self.positions,
-                    num_iterations=5,
-                    sort_axis=primary_axis,
-                    preferred_direction=preferred_direction,
-                )
-            else:
-                self.positions = self.optimize_corridor(self.positions, num_iterations=5)
+            # Corridor traversal direction follows the first pass along the axis within each corridor.
+            self.positions = self.optimize_corridor(
+                self.positions,
+                num_iterations=5,
+                fast_axis=getattr(self, "fast_axis", 0),
+                first_corridor_direction=getattr(self, "first_direction", 1),
+            )
             return
 
         if self.optim_trajectory == "shell":
@@ -1102,6 +1090,9 @@ class FermatSpiralScan(ScanBase):
         self.stop_motor2 = stop_motor2
         self.step = step
         self.spiral_type = spiral_type
+        self.first_direction = (
+            Direction.ASCENDING if self.stop_motor1 > self.start_motor1 else Direction.DESCENDING
+        )
 
     def update_scan_motors(self):
         self.scan_motors = [self.motor1, self.motor2]

--- a/bec_server/bec_server/scan_server/scans/position_generators.py
+++ b/bec_server/bec_server/scan_server/scans/position_generators.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+import enum
 from collections.abc import Iterator, Sequence
 
 import numpy as np
+
+
+class Direction(int, enum.Enum):
+    ASCENDING = 1
+    DESCENDING = -1
 
 
 def rotate_points(

--- a/bec_server/bec_server/scan_server/scans/scan_components.py
+++ b/bec_server/bec_server/scan_server/scans/scan_components.py
@@ -8,6 +8,7 @@ import numpy as np
 from bec_lib.device import DeviceBase
 from bec_server.scan_server.errors import LimitError
 from bec_server.scan_server.path_optimization import PathOptimizerMixin
+from bec_server.scan_server.scans.position_generators import Direction
 
 if TYPE_CHECKING:
     from bec_lib.devicemanager import DeviceContainer
@@ -160,49 +161,43 @@ class ScanComponents:
         self,
         positions: np.ndarray,
         optimization_type: Literal["corridor", "shell", "nearest"] = "corridor",
-        primary_axis: int = 1,
-        preferred_directions: list[int] | None = None,
+        fast_axis: Literal[0, 1] = 0,
+        first_direction: Literal[-1, 1] | Direction = Direction.ASCENDING,
+        snaked: bool = True,
         corridor_size: float | None = None,
         num_iterations: int = 5,
     ) -> np.ndarray:
         """
         Optimize the trajectory of the scan by reordering the positions. This can help to minimize the movement time of the motors.
+
+        Important note: The optimization is only done for 2D scans. For higher-dimensional scans, the positions are not reordered and simply
+        returned as they are.
+
         The optimization can be done in different ways, depending on the optimization_type parameter:
-            - "corridor": optimize the trajectory in a corridor-like way, where the scan moves back and forth along the primary axis. This is typically a good choice for grid scans. If preferred_directions are provided, the optimizer will try to optimize the trajectory in a way that minimizes the movement in the non-preferred direction.
+            - "corridor": optimize the trajectory in a corridor-like way, where the scan progresses between corridors along the slow axis and traverses each corridor along the fast axis. This is typically a good choice for grid scans. If first_direction is provided, it sets the traversal direction of the first corridor and snaked controls whether later corridors alternate direction, producing a snaked path along the fast axis.
             - "shell": optimize the trajectory in a shell-like way, where the scan moves in a spiral from the outside to the inside. This is typically a good choice for round scans.
             - "nearest": optimize the trajectory by always moving to the nearest next point. This is typically a good choice for random scans.
 
         Args:
             positions (np.ndarray): Array of positions to optimize, shape (num_points, num_motors).
             optimization_type (str, optional): Type of optimization to perform. Defaults to "corridor".
-            primary_axis (int, optional): Primary axis for corridor optimization. Defaults to 1.
-            preferred_directions (list[int] | None, optional): List of preferred directions for the non-primary axes. Each entry should be -1, 0, or 1, indicating the preferred direction of movement along that axis. The length of the list should be equal to the number of non-primary axes. Defaults to None, which means no preferred directions.
+            fast_axis (int, optional): Fast axis for corridor optimization. Defaults to 0.
+            first_direction (Direction | Literal[-1, 1], optional): Traversal direction for the first corridor along the fast axis. Positive means ascending, negative means descending. Defaults to Direction.ASCENDING.
+            snaked (bool, optional): If True, alternate direction between corridors. Defaults to True.
             corridor_size (float | None, optional): Size of the corridor for corridor optimization. Defaults to None, which means the default corridor size will be used.
         Returns:
             np.ndarray: Optimized array of positions, shape (num_points, num_motors).
         """
 
         if optimization_type == "corridor":
-            if preferred_directions is None or len(preferred_directions) == 0:
-                positions = self._path_optimizer.optimize_corridor(
-                    positions,
-                    num_iterations=num_iterations,
-                    corridor_size=corridor_size,
-                    sort_axis=primary_axis,
-                )
-            else:
-                preferred_direction = (
-                    preferred_directions[primary_axis]
-                    if len(preferred_directions) > primary_axis
-                    else None
-                )
-                positions = self._path_optimizer.optimize_corridor(
-                    positions,
-                    num_iterations=num_iterations,
-                    sort_axis=primary_axis,
-                    preferred_direction=preferred_direction,
-                    corridor_size=corridor_size,
-                )
+            positions = self._path_optimizer.optimize_corridor(
+                positions,
+                num_iterations=num_iterations,
+                corridor_size=corridor_size,
+                fast_axis=fast_axis,
+                first_corridor_direction=first_direction,
+                snaked=snaked,
+            )
 
         elif optimization_type == "shell":
             positions = self._path_optimizer.optimize_shell(

--- a/bec_server/tests/tests_scan_server/scans_v4/test_fermat_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_fermat_scan.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import numpy as np
 import pytest
 
@@ -44,3 +46,52 @@ def test_fermat_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler)
     assert len(read_messages) == 1
     assert read_messages[0].device == ["samz"]
     assert read_messages[0].metadata["readout_priority"] == "baseline"
+
+
+def test_fermat_scan_prepare_scan_uses_first_axis_as_corridor_axis(v4_scan_assembler):
+    scan = v4_scan_assembler(
+        "_v4_fermat_scan",
+        "samx",
+        -1.0,
+        1.0,
+        "samy",
+        -2.0,
+        2.0,
+        step=0.5,
+        optim_trajectory="corridor",
+        relative=False,
+    )
+    optimized = np.array([[1.0, 0.0], [0.0, 1.0]])
+    scan.components.optimize_trajectory = mock.MagicMock(return_value=optimized)
+
+    scan.prepare_scan()
+
+    scan.components.optimize_trajectory.assert_called_once()
+    _, kwargs = scan.components.optimize_trajectory.call_args
+    assert kwargs["optimization_type"] == "corridor"
+    assert kwargs["fast_axis"] == 0
+    assert kwargs["first_direction"] == 1
+    np.testing.assert_allclose(scan.positions, optimized)
+
+
+def test_fermat_scan_prepare_scan_uses_first_axis_range_for_preferred_direction(v4_scan_assembler):
+    scan = v4_scan_assembler(
+        "_v4_fermat_scan",
+        "samx",
+        1.0,
+        -1.0,
+        "samy",
+        -4.0,
+        4.0,
+        step=0.5,
+        optim_trajectory="corridor",
+        relative=False,
+    )
+    optimized = np.array([[1.0, 0.0], [0.0, 1.0]])
+    scan.components.optimize_trajectory = mock.MagicMock(return_value=optimized)
+
+    scan.prepare_scan()
+
+    _, kwargs = scan.components.optimize_trajectory.call_args
+    assert kwargs["fast_axis"] == 0
+    assert kwargs["first_direction"] == -1

--- a/bec_server/tests/tests_scan_server/scans_v4/test_scan_components.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_scan_components.py
@@ -99,7 +99,7 @@ def test_get_start_positions_supports_motor_names_and_instances(v4_scan_assemble
     assert start_positions == [1.25, -3.5]
 
 
-def test_optimize_trajectory_uses_corridor_defaults_without_preferred_direction(v4_scan_assembler):
+def test_optimize_trajectory_uses_corridor_defaults(v4_scan_assembler):
     scan = v4_scan_assembler("_v4_mv", "samx", 1.5, "samy", -2.0, relative=False)
     positions = np.array([[0.0, 1.0], [1.0, 0.0]])
     optimized = np.array([[1.0, 0.0], [0.0, 1.0]])
@@ -110,12 +110,17 @@ def test_optimize_trajectory_uses_corridor_defaults_without_preferred_direction(
     )
 
     scan.components._path_optimizer.optimize_corridor.assert_called_once_with(
-        positions, num_iterations=7, corridor_size=4, sort_axis=1
+        positions,
+        num_iterations=7,
+        corridor_size=4,
+        fast_axis=0,
+        first_corridor_direction=1,
+        snaked=True,
     )
     np.testing.assert_allclose(result, optimized)
 
 
-def test_optimize_trajectory_passes_primary_axis_preference_for_corridor(v4_scan_assembler):
+def test_optimize_trajectory_passes_first_direction_for_corridor(v4_scan_assembler):
     scan = v4_scan_assembler("_v4_mv", "samx", 1.5, "samy", -2.0, relative=False)
     positions = np.array([[0.0, 1.0], [1.0, 0.0]])
     scan.components._path_optimizer.optimize_corridor = mock.MagicMock(return_value=positions)
@@ -123,14 +128,47 @@ def test_optimize_trajectory_passes_primary_axis_preference_for_corridor(v4_scan
     scan.components.optimize_trajectory(
         positions,
         optimization_type="corridor",
-        primary_axis=1,
-        preferred_directions=[-1, 1],
+        fast_axis=0,
+        first_direction=-1,
+        snaked=True,
         corridor_size=2,
         num_iterations=3,
     )
 
     scan.components._path_optimizer.optimize_corridor.assert_called_once_with(
-        positions, num_iterations=3, sort_axis=1, preferred_direction=1, corridor_size=2
+        positions,
+        num_iterations=3,
+        fast_axis=0,
+        first_corridor_direction=-1,
+        snaked=True,
+        corridor_size=2,
+    )
+
+
+def test_optimize_trajectory_passes_first_direction_when_first_axis_is_corridor_axis(
+    v4_scan_assembler,
+):
+    scan = v4_scan_assembler("_v4_mv", "samx", 1.5, "samy", -2.0, relative=False)
+    positions = np.array([[0.0, 1.0], [1.0, 0.0]])
+    scan.components._path_optimizer.optimize_corridor = mock.MagicMock(return_value=positions)
+
+    scan.components.optimize_trajectory(
+        positions,
+        optimization_type="corridor",
+        fast_axis=1,
+        first_direction=1,
+        snaked=True,
+        corridor_size=2,
+        num_iterations=3,
+    )
+
+    scan.components._path_optimizer.optimize_corridor.assert_called_once_with(
+        positions,
+        num_iterations=3,
+        fast_axis=1,
+        first_corridor_direction=1,
+        snaked=True,
+        corridor_size=2,
     )
 
 

--- a/bec_server/tests/tests_scan_server/test_path_optimization.py
+++ b/bec_server/tests/tests_scan_server/test_path_optimization.py
@@ -257,3 +257,20 @@ def test_optimize_corridor_raises_corridor_estimation():
         optim.optimize_corridor(
             positions_orig, num_iterations=10, corridor_estimation="invalid_method"
         )
+
+
+def test_optimize_corridor_respects_first_corridor_direction_and_snaking():
+    optim = PathOptimizerMixin()
+    positions = np.asarray([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]])
+
+    snaked = optim.optimize_corridor(
+        positions, corridor_size=1.0, fast_axis=1, first_corridor_direction=1, snaked=True
+    )
+    non_snaked = optim.optimize_corridor(
+        positions, corridor_size=1.0, fast_axis=1, first_corridor_direction=1, snaked=False
+    )
+
+    np.testing.assert_allclose(snaked, np.asarray([[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [1.0, 0.0]]))
+    np.testing.assert_allclose(
+        non_snaked, np.asarray([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]])
+    )


### PR DESCRIPTION
## Description

This PR fixes the trajectory optimization for the v4 fermat spiral and improved the API. You can now select the column sorting and toggle "snaking". In addition, the default for the column sorting is not ascending as most scans are given with a positive range. This however, breaks a test in cSAXS and needs to be fixed once this PR is merged (https://gitea.psi.ch/bec/csaxs_bec/pulls/237)


