### PR TITLE
Send positions to scilog

### DIFF
--- a/bec_lib/bec_lib/client.py
+++ b/bec_lib/bec_lib/client.py
@@ -225,7 +225,7 @@ class BECClient(BECService):
             self.callbacks.run(
                 EventType.NAMESPACE_UPDATE, action="add", ns_objects=default_namespace
             )
-            self.messaging = MessagingContainer(self.connector)
+            self.messaging = MessagingContainer(self.connector, client=self._parent)
             logger.info("Starting new client")
             self.status = BECStatus.RUNNING
         except redis.exceptions.ConnectionError:

--- a/bec_lib/bec_lib/devicemanager.py
+++ b/bec_lib/bec_lib/devicemanager.py
@@ -78,6 +78,15 @@ def _rgetattr_safe(obj, attr, *args):
 
 
 class DeviceContainer(dict):
+    @staticmethod
+    def _get_value_str(val) -> str:
+        if not isinstance(val, str):
+            try:
+                return f"{val:.4f}"
+            except Exception:
+                return "N/A"
+        return val
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         for arg in args:
@@ -336,6 +345,63 @@ class DeviceContainer(dict):
                 raise DeviceConfigError(f"Device {dev} does not exist.") from exc
         return expanded_devices
 
+    def _resolve_wm_devices(
+        self, device_names: list[str | DeviceBase | None] = None
+    ) -> list[DeviceBase]:
+        if not device_names:
+            return list(self.values())
+
+        expanded_devices = []
+        if not isinstance(device_names, list):
+            device_names = [device_names]
+        if len(device_names) == 0:
+            return []
+
+        for dev in device_names:
+            if isinstance(dev, DeviceBase):
+                expanded_devices.append(dev)
+            else:
+                expanded_devices.extend(self._resolve_device_names(dev))
+        return expanded_devices
+
+    def _position_rows(
+        self, device_names: list[str | DeviceBase | None] = None
+    ) -> list[dict[str, str]]:
+        """
+        Return normalized position rows for one or more devices.
+
+        Args:
+            device_names (list): List of device names or Device objects
+
+        Returns:
+            list[dict[str, str]]: Position rows with ``name``, ``readback``,
+                ``setpoint`` and ``limits`` keys.
+        """
+        devices = self._resolve_wm_devices(device_names)
+        dev_read = {dev.name: dev.read(cached=True) for dev in devices}
+        rows = []
+
+        for dev in devices:
+            read = dev_read[dev.name]
+            limits = str(dev.limits) if hasattr(dev, "limits") else "[]"
+
+            if dev.name in read:
+                readback = self._get_value_str(read[dev.name]["value"])
+            else:
+                readback = "N/A"
+
+            if f"{dev.name}_setpoint" in read:
+                setpoint = self._get_value_str(read[f"{dev.name}_setpoint"]["value"])
+            elif f"{dev.name}_user_setpoint" in read:
+                setpoint = self._get_value_str(read[f"{dev.name}_user_setpoint"]["value"])
+            else:
+                setpoint = "N/A"
+
+            rows.append(
+                {"name": dev.name, "readback": readback, "setpoint": setpoint, "limits": limits}
+            )
+        return rows
+
     def wm(self, device_names: list[str | DeviceBase | None] = None, *args):
         """
         Get the current position of one or more devices.
@@ -358,62 +424,15 @@ class DeviceContainer(dict):
             >>> dev.wm(dev.get_devices_with_tags('user motors')) # returns the positions of all devices with the tag 'user motors'
 
         """
-        if not device_names:
-            device_names = self.values()
-        else:
-            expanded_devices = []
-            if not isinstance(device_names, list):
-                device_names = [device_names]
-            if len(device_names) == 0:
-                return
-
-            for dev in device_names:
-                if isinstance(dev, DeviceBase):
-                    expanded_devices.append(dev)
-                else:
-                    expanded_devices.extend(self._resolve_device_names(dev))
-            device_names = expanded_devices
+        rows = self._position_rows(device_names)
         console = Console()
         table = Table()
         table.add_column("", justify="center")
         table.add_column("readback", justify="center")
         table.add_column("setpoint", justify="center")
         table.add_column("limits", justify="center")
-        dev_read = {dev.name: dev.read(cached=True) for dev in device_names}
-        readbacks = {}
-        setpoints = {}
-        limits = {}
-        for dev in device_names:
-            if hasattr(dev, "limits"):
-                limits[dev.name] = str(dev.limits)
-            else:
-                limits[dev.name] = "[]"
-
-        def _get_value_str(val):
-            if not isinstance(val, str):
-                try:
-                    return f"{val:.4f}"
-                except Exception:
-                    return "N/A"
-            return val
-
-        for dev, read in dev_read.items():
-            if dev in read:
-                val = read[dev]["value"]
-                readbacks[dev] = _get_value_str(val)
-            else:
-                readbacks[dev] = "N/A"
-
-            if f"{dev}_setpoint" in read:
-                val = read[f"{dev}_setpoint"]["value"]
-                setpoints[dev] = _get_value_str(val)
-            elif f"{dev}_user_setpoint" in read:
-                val = read[f"{dev}_user_setpoint"]["value"]
-                setpoints[dev] = _get_value_str(val)
-            else:
-                setpoints[dev] = "N/A"
-        for dev in device_names:
-            table.add_row(dev.name, readbacks[dev.name], setpoints[dev.name], limits[dev.name])
+        for row in rows:
+            table.add_row(row["name"], row["readback"], row["setpoint"], row["limits"])
         console.print(table)
 
     def _add_device(self, name, obj) -> None:

--- a/bec_lib/bec_lib/messaging_services.py
+++ b/bec_lib/bec_lib/messaging_services.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
 
 import enum
+import html
+import inspect
 import mimetypes
 import os
+import textwrap
 from abc import ABC
 from typing import TYPE_CHECKING, Generic, Literal, Self, TypeVar
+
+from rich.console import Console
+from rich.table import Table
 
 from bec_lib import messages
 from bec_lib.endpoints import MessageEndpoints
 
 if TYPE_CHECKING:
+    from bec_lib.client import BECClient
     from bec_lib.connector import MessageObject
     from bec_lib.redis_connector import RedisConnector
 
@@ -86,8 +93,8 @@ class MessagingContainer:
     A container for providing easy access to multiple messaging services.
     """
 
-    def __init__(self, connector: RedisConnector) -> None:
-        self.scilog = SciLogMessagingService(connector)
+    def __init__(self, connector: RedisConnector, client: BECClient | None = None) -> None:
+        self.scilog = SciLogMessagingService(connector, client=client)
         self.teams = TeamsMessagingService(connector)
         self.signal = SignalMessagingService(connector)
 
@@ -534,9 +541,10 @@ class SciLogMessagingService(MessagingService[SciLogMessageServiceObject]):
     _SERVICE_NAME = "scilog"
     _MESSAGE_OBJECT_CLASS = SciLogMessageServiceObject
 
-    def __init__(self, redis_connector: RedisConnector) -> None:
+    def __init__(self, redis_connector: RedisConnector, client: BECClient | None = None) -> None:
         super().__init__(redis_connector)
         self._default_tags: list[str] = ["bec"]
+        self._client = client
 
     def set_default_tags(self, tags: str | list[str]):
         """
@@ -557,6 +565,132 @@ class SciLogMessagingService(MessagingService[SciLogMessageServiceObject]):
             list[str]: The current default tags.
         """
         return self._default_tags
+
+    @staticmethod
+    def _table_cell(value: str, bold: bool = False) -> str:
+        content = html.escape(value)
+        if bold:
+            content = f"<strong>{content}</strong>"
+        return f"<td>{content}</td>"
+
+    @classmethod
+    def _position_table_html(cls, rows: list[dict[str, str]]) -> str:
+        table_rows = [
+            "<tr>"
+            f"{cls._table_cell('device', bold=True)}"
+            f"{cls._table_cell('readback', bold=True)}"
+            f"{cls._table_cell('setpoint', bold=True)}"
+            f"{cls._table_cell('limits', bold=True)}"
+            "</tr>"
+        ]
+        table_rows.extend(
+            "<tr>"
+            f"{cls._table_cell(row['name'])}"
+            f"{cls._table_cell(row['readback'])}"
+            f"{cls._table_cell(row['setpoint'])}"
+            f"{cls._table_cell(row['limits'])}"
+            "</tr>"
+            for row in rows
+        )
+        return (
+            f"<figure class=\"table\"><table><tbody>{''.join(table_rows)}</tbody></table></figure>"
+        )
+
+    @staticmethod
+    def _code_block_html(source: str, language: str = "python") -> str:
+        escaped_language = html.escape(language, quote=True)
+        escaped_source = html.escape(textwrap.dedent(source).strip("\n"))
+        return f'<pre><code class="language-{escaped_language}">{escaped_source}</code></pre>'
+
+    def log_positions(
+        self,
+        devices: list[str] | str | None = None,
+        scope: str | list[str] | None = None,
+        title: str | None = None,
+        tags: str | list[str] | None = None,
+    ) -> None:
+        """
+        Send the current device positions to SciLog as an HTML table.
+
+        Args:
+            devices: Device names, glob patterns or device objects accepted by ``dev.wm``.
+            scope: Optional override for the SciLog scope.
+            title: Optional text shown above the table.
+            tags: Optional tags added to the SciLog message.
+        """
+        if self._client is None or getattr(self._client, "device_manager", None) is None:
+            raise RuntimeError(
+                "SciLog position logging requires a client-backed messaging service."
+            )
+        if self._client.device_manager is None or self._client.device_manager.devices is None:
+            raise RuntimeError(
+                "SciLog position logging requires a client-backed messaging service with a device manager."
+            )
+        dev = self._client.device_manager.devices
+        rows = dev._position_rows(devices)
+        message = self.new()
+        content = self._position_table_html(rows)
+        if title:
+            content = f"<p>{html.escape(title)}</p>{content}"
+        message.add_text(content)
+        if tags is not None:
+            message.add_tags(tags)
+        message.send(scope=scope)
+
+        print("The following position table was sent to SciLog:")
+
+        console = Console()
+        table = Table()
+        table.add_column("", justify="center")
+        table.add_column("readback", justify="center")
+        table.add_column("setpoint", justify="center")
+        table.add_column("limits", justify="center")
+        for row in rows:
+            table.add_row(row["name"], row["readback"], row["setpoint"], row["limits"])
+        console.print(table)
+
+    def log_code(
+        self,
+        source: object,
+        scope: str | list[str] | None = None,
+        title: str | None = None,
+        tags: str | list[str] | None = None,
+        language: str = "python",
+    ) -> None:
+        """
+        Send source code to SciLog as a syntax-highlighted code block.
+
+        Args:
+            source: A callable or raw source string to send.
+            scope: Optional override for the SciLog scope.
+            title: Optional text shown above the code block.
+            tags: Optional tags added to the SciLog message.
+            language: Syntax highlighting language class for the code block.
+
+        Examples:
+            >>> # Log a function's source code
+            >>> def my_function():
+            >>>     print("Hello, World!")
+            >>> bec.messaging.scilog.log_code(my_function, title="My Function", tags="code")
+        """
+        if isinstance(source, str):
+            source_code = source
+        else:
+            try:
+                source_code = inspect.getsource(source)
+            except (OSError, TypeError) as exc:
+                raise ValueError(
+                    "Could not extract source code. Pass a function with available source or a source string."
+                ) from exc
+
+        content = self._code_block_html(source_code, language=language)
+        if title:
+            content = f"<p>{html.escape(title)}</p>{content}"
+        message = self.new()
+        message.add_text(content)
+        if tags is not None:
+            message.add_tags(tags)
+        message.send(scope=scope)
 
 
 class TeamsMessagingService(MessagingService[MessageServiceObject]):

--- a/bec_lib/tests/test_devices.py
+++ b/bec_lib/tests/test_devices.py
@@ -635,6 +635,21 @@ def test_device_container_wm_read_contains_None(dev_container, capsys):
         assert "N/A" in captured.out
 
 
+def test_device_container_position_rows(dev_container):
+    with (
+        mock.patch.object(
+            dev_container.test,
+            "read",
+            return_value={"test": {"value": 1}, "test_setpoint": {"value": 2}},
+        ),
+        mock.patch.object(AdjustableMixin, "limits", new_callable=mock.PropertyMock) as limits,
+    ):
+        limits.return_value = []
+        assert dev_container._position_rows("test") == [
+            {"name": "test", "readback": "1.0000", "setpoint": "2.0000", "limits": "[]"}
+        ]
+
+
 @pytest.mark.parametrize(
     "reading",
     [

--- a/bec_lib/tests/test_messaging_service.py
+++ b/bec_lib/tests/test_messaging_service.py
@@ -1,4 +1,6 @@
 import time
+from types import SimpleNamespace
+from unittest import mock
 
 import pytest
 
@@ -17,6 +19,48 @@ from bec_lib.messaging_services import (
 @pytest.fixture
 def scilog_service(connected_connector):
     service = SciLogMessagingService(connected_connector)
+    available_services = messages.AvailableMessagingServicesMessage(
+        config=messages.MessagingConfig(
+            signal=messages.MessagingServiceScopeConfig(enabled=False),
+            teams=messages.MessagingServiceScopeConfig(enabled=False),
+            scilog=messages.MessagingServiceScopeConfig(enabled=True),
+        ),
+        deployment_services=[
+            messages.SciLogServiceInfo(
+                id="test_scilog", scope="default", enabled=True, logbook_id="test_logbook"
+            )
+        ],
+        session_services=[],
+    )
+    service._on_new_scope_change_msg(message={"data": available_services})
+    yield service
+
+
+@pytest.fixture
+def scilog_service_with_owner(connected_connector):
+    owner = SimpleNamespace(
+        device_manager=SimpleNamespace(
+            devices=SimpleNamespace(
+                _position_rows=mock.Mock(
+                    return_value=[
+                        {
+                            "name": "samx",
+                            "readback": "1.0000",
+                            "setpoint": "1.5000",
+                            "limits": "[]",
+                        },
+                        {
+                            "name": "samy",
+                            "readback": "2.0000",
+                            "setpoint": "2.5000",
+                            "limits": "[-1, 1]",
+                        },
+                    ]
+                )
+            )
+        )
+    )
+    service = SciLogMessagingService(connected_connector, client=owner)
     available_services = messages.AvailableMessagingServicesMessage(
         config=messages.MessagingConfig(
             signal=messages.MessagingServiceScopeConfig(enabled=False),
@@ -199,6 +243,85 @@ def test_scilog_messaging_service_add_tags(scilog_message, connected_connector):
     assert sorted(tags_part.tags) == sorted(
         ["bec", "tag1", "tag2"]
     )  # default "bec" tag should be included
+
+
+def test_scilog_log_positions(scilog_service_with_owner, connected_connector):
+    scilog_service_with_owner.log_positions(
+        devices="sam*", title="Current positions", tags="snapshot"
+    )
+
+    scilog_service_with_owner._client.device_manager.devices._position_rows.assert_called_once_with(  # type: ignore[attr-defined]  # pylint: disable=protected-access
+        "sam*"
+    )
+
+    out = connected_connector.xread(
+        MessageEndpoints.message_service_queue(), from_start=True, count=1
+    )
+    assert len(out) == 1
+    out = out[0]["data"]
+    assert out.service_name == "scilog"
+    assert len(out.message) == 2
+    assert isinstance(out.message[0], messages.MessagingServiceTextContent)
+    assert "<p>Current positions</p>" in out.message[0].content
+    assert '<figure class="table"><table><tbody>' in out.message[0].content
+    assert "<strong>device</strong>" in out.message[0].content
+    assert "<td>samx</td><td>1.0000</td><td>1.5000</td><td>[]</td>" in out.message[0].content
+    assert "<td>samy</td><td>2.0000</td><td>2.5000</td><td>[-1, 1]</td>" in out.message[0].content
+    assert isinstance(out.message[1], messages.MessagingServiceTagsContent)
+    assert sorted(out.message[1].tags) == ["bec", "snapshot"]
+
+
+def test_scilog_log_positions_requires_owner(scilog_service):
+    with pytest.raises(
+        RuntimeError, match="SciLog position logging requires a client-backed messaging service."
+    ):
+        scilog_service.log_positions()
+
+
+def test_scilog_log_code(connected_connector):
+    def my_func():
+        print()
+
+    service = SciLogMessagingService(connected_connector)
+    available_services = messages.AvailableMessagingServicesMessage(
+        config=messages.MessagingConfig(
+            signal=messages.MessagingServiceScopeConfig(enabled=False),
+            teams=messages.MessagingServiceScopeConfig(enabled=False),
+            scilog=messages.MessagingServiceScopeConfig(enabled=True),
+        ),
+        deployment_services=[
+            messages.SciLogServiceInfo(
+                id="test_scilog", scope="default", enabled=True, logbook_id="test_logbook"
+            )
+        ],
+        session_services=[],
+    )
+    service._on_new_scope_change_msg(message={"data": available_services})
+
+    service.log_code(my_func, title="Function source", tags="code")
+
+    out = connected_connector.xread(
+        MessageEndpoints.message_service_queue(), from_start=True, count=1
+    )
+    assert len(out) == 1
+    out = out[0]["data"]
+    assert out.service_name == "scilog"
+    assert len(out.message) == 2
+    assert isinstance(out.message[0], messages.MessagingServiceTextContent)
+    assert "<p>Function source</p>" in out.message[0].content
+    assert '<pre><code class="language-python">' in out.message[0].content
+    assert "def my_func():" in out.message[0].content
+    assert "    print()" in out.message[0].content
+    assert isinstance(out.message[1], messages.MessagingServiceTagsContent)
+    assert sorted(out.message[1].tags) == ["bec", "code"]
+
+
+def test_scilog_log_code_raises_for_missing_source(scilog_service):
+    with pytest.raises(
+        ValueError,
+        match="Could not extract source code. Pass a function with available source or a source string.",
+    ):
+        scilog_service.log_code(len)
 
 
 def test_signal_messaging_service_new(signal_service):


### PR DESCRIPTION
## Description

This PR adds two new methods to the SciLog API:
- `log_positions`: A method that accepts a wildcard for devices like `dev.wm` and sends the content formatted as a table to SciLog
- `log_code`: A method that receives a function, e.g. a macro, and sends the source code formatted as python code to SciLog.

## Definition of Done
- [x] Documentation is up-to-date: https://github.com/bec-project/bec_docs/pull/78
- [x] Clean up commits

