### PR TITLE
feat: add validation for device name to prevent conflicts and enforce…

### DIFF
--- a/bec_lib/bec_lib/atlas_models.py
+++ b/bec_lib/bec_lib/atlas_models.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import keyword
 from enum import Enum
+from functools import lru_cache
 from typing import AbstractSet, Any, Literal, TypeVar
 
 from pydantic import BaseModel, Field, PrivateAttr, create_model, field_validator, model_validator
@@ -60,6 +62,17 @@ class _DeviceModelCore(BaseModel):
         if v is None:
             return ""
         return v
+
+
+@lru_cache(maxsize=1)
+def _reserved_device_names() -> frozenset[str]:
+    """Names that would shadow attributes on the interactive device namespace."""
+    from bec_lib.devicemanager import DeviceContainer
+
+    reserved = dir(DeviceContainer)
+    return frozenset(
+        name for name in reserved if not (name.startswith("__") and name.endswith("__"))
+    )
 
 
 class HashInclusion(str, Enum):
@@ -140,6 +153,19 @@ class Device(_DeviceModelCore):
     """
 
     name: str
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        if value.startswith("_"):
+            raise ValueError(f"{value!r} must not start with '_'.")
+        if not value.isidentifier() or keyword.iskeyword(value):
+            raise ValueError(f"{value!r} is not a valid Python identifier.")
+        if value in _reserved_device_names():
+            raise ValueError(
+                f"{value!r} is reserved because it conflicts with an existing device namespace attribute or method."
+            )
+        return value
 
 
 _ModelDumpKeys = list[str]

--- a/bec_lib/tests/test_atlas_models.py
+++ b/bec_lib/tests/test_atlas_models.py
@@ -2,7 +2,7 @@ import pytest
 from annotated_types import Lt, MaxLen
 from pydantic import BaseModel, Field, ValidationError
 
-from bec_lib.atlas_models import DevicePartial, make_all_fields_optional
+from bec_lib.atlas_models import Device, DevicePartial, make_all_fields_optional
 
 
 def test_make_all_fields_optional():
@@ -40,3 +40,47 @@ def test_device_partial():
 
     with pytest.raises(ValidationError):
         DevicePartial(name="test", readoutPriority="invalid")
+
+
+def test_device_name_accepts_valid_identifier():
+    device = Device(
+        name="samx",
+        enabled=True,
+        deviceClass="ophyd_devices.SimPositioner",
+        readoutPriority="monitored",
+    )
+    assert device.name == "samx"
+
+
+@pytest.mark.parametrize("name", ["1samx", "sam-x", "for", "with space"])
+def test_device_name_rejects_invalid_python_identifier(name):
+    with pytest.raises(ValidationError, match="valid Python identifier"):
+        Device(
+            name=name,
+            enabled=True,
+            deviceClass="ophyd_devices.SimPositioner",
+            readoutPriority="monitored",
+        )
+
+
+def test_device_name_rejects_private_prefix():
+    with pytest.raises(ValidationError, match="must not start with '_'"):
+        Device(
+            name="_samx",
+            enabled=True,
+            deviceClass="ophyd_devices.SimPositioner",
+            readoutPriority="monitored",
+        )
+
+
+@pytest.mark.parametrize("name", ["wm", "items", "get"])
+def test_device_name_rejects_bec_namespace_conflicts(name):
+    with pytest.raises(
+        ValidationError, match="conflicts with an existing device namespace attribute or method"
+    ):
+        Device(
+            name=name,
+            enabled=True,
+            deviceClass="ophyd_devices.SimPositioner",
+            readoutPriority="monitored",
+        )


### PR DESCRIPTION
## Description

We currently don't prevent overrides of builtin methods on the device container with device names. This PR validates the device names for valid python identifiers, no `_` prefix and no collision with methods or attributes of the device container.


