### PR TITLE
feat: throttle auto-monitor updates through shared pipeline

### DIFF
--- a/bec_server/bec_server/device_server/devices/devicemanager.py
+++ b/bec_server/bec_server/device_server/devices/devicemanager.py
@@ -38,7 +38,10 @@ from bec_server.device_server.devices.device_serializer import (
 )
 
 if TYPE_CHECKING:  # pragma: no cover
+    from redis.client import Pipeline
+
     from bec_lib.redis_connector import RedisConnector
+
 
 logger = bec_logger.logger
 
@@ -148,6 +151,29 @@ class DeviceManagerDS(DeviceManagerBase):
         self.failed_devices = {}
         self._bec_message_handler = BECMessageHandler(self)
         self._device_order_map = {}
+        self._auto_monitor_readback_updates = set()
+        self._auto_monitor_configuration_updates = set()
+        self._limit_change_updates = set()
+        self._auto_monitor_update_lock = threading.Lock()
+        self._shutdown_event = threading.Event()
+        self._auto_monitor_update_thread = self._create_auto_monitor_update_thread()
+
+    def _create_auto_monitor_update_thread(self) -> threading.Thread:
+        return threading.Thread(
+            target=self._auto_monitor_update_loop, daemon=True, name="AutoMonitorUpdateThread"
+        )
+
+    def _ensure_auto_monitor_update_thread(self) -> None:
+        if self._auto_monitor_update_thread is None:
+            self._auto_monitor_update_thread = self._create_auto_monitor_update_thread()
+        elif (
+            not self._auto_monitor_update_thread.is_alive()
+            and self._auto_monitor_update_thread.ident is not None
+        ):
+            self._auto_monitor_update_thread = self._create_auto_monitor_update_thread()
+
+        if not self._auto_monitor_update_thread.is_alive():
+            self._auto_monitor_update_thread.start()
 
     def initialize(self, bootstrap_server) -> None:
         self.config_update_handler = (
@@ -563,9 +589,11 @@ class DeviceManagerDS(DeviceManagerBase):
             obj (OphydObject): Ophyd object to subscribe to limit updates
         """
         if hasattr(obj, "low_limit_travel") and hasattr(obj.low_limit_travel, "subscribe"):
-            obj.low_limit_travel.subscribe(self._obj_callback_limit_change, run=False)
+            self._ensure_auto_monitor_update_thread()
+            obj.low_limit_travel.subscribe(self._obj_callback_auto_monitor_limits, run=False)
         if hasattr(obj, "high_limit_travel") and hasattr(obj.high_limit_travel, "subscribe"):
-            obj.high_limit_travel.subscribe(self._obj_callback_limit_change, run=False)
+            self._ensure_auto_monitor_update_thread()
+            obj.high_limit_travel.subscribe(self._obj_callback_auto_monitor_limits, run=False)
 
     def _subscribe_to_device_events(self, obj: OphydObject, opaas_obj: DSDevice):
         """Subscribe to device events"""
@@ -625,10 +653,11 @@ class DeviceManagerDS(DeviceManagerBase):
                 continue
             if not getattr(component, "_auto_monitor", False):
                 continue
+            self._ensure_auto_monitor_update_thread()
             if component.kind in (ophyd.Kind.normal, ophyd.Kind.hinted):
-                component.subscribe(self._obj_callback_readback, run=False)
+                component.subscribe(self._obj_callback_auto_monitor_readback, run=False)
             elif component.kind == ophyd.Kind.config:
-                component.subscribe(self._obj_callback_configuration, run=False)
+                component.subscribe(self._obj_callback_auto_monitor_configuration, run=False)
 
     def _subscribe_to_bec_signals(self, obj: OphydObject):
         """
@@ -742,7 +771,9 @@ class DeviceManagerDS(DeviceManagerBase):
         self.connector.delete(MessageEndpoints.device_read_configuration(obj.name), pipe)
         self.connector.delete(MessageEndpoints.device_info(obj.name), pipe)
 
-    def _obj_callback_limit_change(self, *_args, obj: OphydObject, **kwargs):
+    def _obj_callback_limit_change(
+        self, *_args, obj: OphydObject, pipe: Pipeline | None = None, **kwargs
+    ):
         """Callback for limit changes"""
         if not obj.connected:
             return
@@ -752,22 +783,28 @@ class DeviceManagerDS(DeviceManagerBase):
             "high": {"value": obj.root.high_limit_travel.get()},
         }
         dev_msg = messages.DeviceMessage(signals=limits)
-        pipe = self.connector.pipeline()
-        self.connector.set_and_publish(MessageEndpoints.device_limits(name), dev_msg, pipe=pipe)
-        pipe.execute()
+        _pipe = pipe if pipe is not None else self.connector.pipeline()
+        self.connector.set_and_publish(MessageEndpoints.device_limits(name), dev_msg, pipe=_pipe)
+        if pipe is None:
+            _pipe.execute()
 
-    def _obj_callback_readback(self, *_args, obj: OphydObject, **kwargs):
+    def _obj_callback_readback(
+        self, *_args, obj: OphydObject, pipe: Pipeline | None = None, **kwargs
+    ):
         if not obj.connected:
             return
         name = obj.root.name
         signals = obj.root.read()
         metadata = self.devices.get(obj.root.name).metadata
         dev_msg = messages.DeviceMessage(signals=signals, metadata=metadata)
-        pipe = self.connector.pipeline()
-        self.connector.set_and_publish(MessageEndpoints.device_readback(name), dev_msg, pipe)
-        pipe.execute()
+        _pipe = pipe if pipe is not None else self.connector.pipeline()
+        self.connector.set_and_publish(MessageEndpoints.device_readback(name), dev_msg, pipe=_pipe)
+        if pipe is None:
+            _pipe.execute()
 
-    def _obj_callback_configuration(self, *_args, obj: OphydObject, **kwargs):
+    def _obj_callback_configuration(
+        self, *_args, obj: OphydObject, pipe: Pipeline | None = None, **kwargs
+    ):
         if not obj.connected:
             return
         if isinstance(obj.root, ophyd.Signal):
@@ -777,11 +814,74 @@ class DeviceManagerDS(DeviceManagerBase):
         signals = obj.root.read_configuration()
         metadata = self.devices.get(obj.root.name).metadata
         dev_msg = messages.DeviceMessage(signals=signals, metadata=metadata)
-        pipe = self.connector.pipeline()
+        _pipe = pipe if pipe is not None else self.connector.pipeline()
         self.connector.set_and_publish(
-            MessageEndpoints.device_read_configuration(name), dev_msg, pipe
+            MessageEndpoints.device_read_configuration(name), dev_msg, pipe=_pipe
         )
-        pipe.execute()
+        if pipe is None:
+            _pipe.execute()
+
+    def _obj_callback_auto_monitor_readback(self, *_args, obj: OphydObject, **kwargs):
+        if not obj.connected:
+            return
+        name = obj.root.name
+        with self._auto_monitor_update_lock:
+            self._auto_monitor_readback_updates.add(name)
+
+    def _obj_callback_auto_monitor_configuration(self, *_args, obj: OphydObject, **kwargs):
+        if not obj.connected:
+            return
+        name = obj.root.name
+        with self._auto_monitor_update_lock:
+            self._auto_monitor_configuration_updates.add(name)
+
+    def _obj_callback_auto_monitor_limits(self, *_args, obj: OphydObject, **kwargs):
+        if not obj.connected:
+            return
+        name = obj.root.name
+        with self._auto_monitor_update_lock:
+            self._limit_change_updates.add(name)
+
+    def _auto_monitor_update_loop(self):
+        while not self._shutdown_event.wait(0.01):
+            try:
+                if (
+                    not self._auto_monitor_readback_updates
+                    and not self._auto_monitor_configuration_updates
+                    and not self._limit_change_updates
+                ):
+                    continue
+                with self._auto_monitor_update_lock:
+                    readback_updates = list(self._auto_monitor_readback_updates)
+                    configuration_updates = list(self._auto_monitor_configuration_updates)
+                    limits_updates = list(self._limit_change_updates)
+                    self._auto_monitor_readback_updates.clear()
+                    self._auto_monitor_configuration_updates.clear()
+                    self._limit_change_updates.clear()
+
+                pipe = self.connector.pipeline()
+                for name in readback_updates:
+                    if name not in self.devices:
+                        continue
+                    obj = self.devices[name].obj
+                    self._obj_callback_readback(obj=obj, pipe=pipe)
+
+                for name in configuration_updates:
+                    if name not in self.devices:
+                        continue
+                    obj = self.devices[name].obj
+                    self._obj_callback_configuration(obj=obj, pipe=pipe)
+
+                for name in limits_updates:
+                    if name not in self.devices:
+                        continue
+                    obj = self.devices[name].obj
+                    self._obj_callback_limit_change(obj=obj, pipe=pipe)
+
+                pipe.execute()
+            except Exception as exc:
+                logger.error(f"Error in auto monitor update loop: {exc}")
+                logger.error(traceback.format_exc())
 
     @typechecked
     def _obj_callback_device_monitor_2d(
@@ -1006,6 +1106,9 @@ class DeviceManagerDS(DeviceManagerBase):
 
     def shutdown(self):
         """Shutdown the device manager and disconnect all devices"""
+        self._shutdown_event.set()
+        if self._auto_monitor_update_thread.is_alive():
+            self._auto_monitor_update_thread.join(timeout=5)
         for device in self.devices.values():
             try:
                 logger.info(f"Disconnecting device {device.name}")

--- a/bec_server/tests/tests_device_server/test_device_manager_ds.py
+++ b/bec_server/tests/tests_device_server/test_device_manager_ds.py
@@ -1,8 +1,10 @@
 import copy
 import time
+from types import SimpleNamespace
 from unittest import mock
 
 import numpy as np
+import ophyd
 import pytest
 from ophyd_devices.devices.psi_motor import EpicsMotor
 from ophyd_devices.tests.utils import patched_device
@@ -177,6 +179,22 @@ def test_obj_callback_progress(dm_with_devices):
             ),
             expire=3600,
         )
+
+
+@pytest.mark.parametrize("device_manager_class", [DeviceManagerDS])
+def test_obj_callback_configuration(dm_with_devices, connected_connector):
+    device_manager = dm_with_devices
+    samx = device_manager.devices.samx
+    samx.metadata = {"scan_id": "12345"}
+    device_manager.connector = connected_connector
+
+    device_manager._obj_callback_configuration(obj=samx.obj)
+
+    msg = connected_connector.get(MessageEndpoints.device_read_configuration("samx"))
+    expected = messages.DeviceMessage(
+        signals=samx.obj.read_configuration(), metadata={"scan_id": "12345"}
+    )
+    assert msg == expected
 
 
 @pytest.mark.parametrize(
@@ -490,13 +508,201 @@ def test_initialize_device(dm_with_devices, epics_motor, epics_motor_config, tim
             mock_connect_device.assert_called_once_with(
                 epics_motor, wait_for_all=True, timeout=timeout
             )
-            # Check that subscriptions to limit updates are made
+            # Limit updates are queued through the auto-monitor thread callback.
             mock_low_subscribe.assert_called_once_with(
-                dm_with_devices._obj_callback_limit_change, run=False
+                dm_with_devices._obj_callback_auto_monitor_limits, run=False
             )
             mock_high_subscribe.assert_called_once_with(
-                dm_with_devices._obj_callback_limit_change, run=False
+                dm_with_devices._obj_callback_auto_monitor_limits, run=False
             )
+
+
+@pytest.mark.parametrize("device_manager_class", [DeviceManagerDS])
+def test_obj_callback_auto_monitor_limits_queues_root_device(dm_with_devices):
+    samx = dm_with_devices.devices.samx
+    dm_with_devices._limit_change_updates.clear()
+
+    dm_with_devices._obj_callback_auto_monitor_limits(obj=samx.obj.low_limit_travel)
+
+    assert samx.name in dm_with_devices._limit_change_updates
+
+
+@pytest.mark.parametrize("device_manager_class", [DeviceManagerDS])
+def test_obj_callback_auto_monitor_queueing(dm_with_devices):
+    samx = dm_with_devices.devices.samx
+    dm_with_devices._auto_monitor_readback_updates.clear()
+    dm_with_devices._auto_monitor_configuration_updates.clear()
+
+    dm_with_devices._obj_callback_auto_monitor_readback(obj=samx.obj.readback)
+    dm_with_devices._obj_callback_auto_monitor_configuration(obj=samx.obj.velocity)
+
+    assert samx.name in dm_with_devices._auto_monitor_readback_updates
+    assert samx.name in dm_with_devices._auto_monitor_configuration_updates
+
+
+@pytest.mark.parametrize("device_manager_class", [DeviceManagerDS])
+def test_subscribe_to_auto_monitors_recurses_and_subscribes_by_kind(dm_with_devices):
+    service = mock.MagicMock()
+    service.connector = mock.MagicMock()
+    service._service_name = "device_server"
+    device_manager = DeviceManagerDS(service)
+
+    normal_component = SimpleNamespace(
+        _auto_monitor=True, kind=ophyd.Kind.normal, subscribe=mock.MagicMock()
+    )
+    hinted_component = SimpleNamespace(
+        _auto_monitor=True, kind=ophyd.Kind.hinted, subscribe=mock.MagicMock()
+    )
+    config_component = SimpleNamespace(
+        _auto_monitor=True, kind=ophyd.Kind.config, subscribe=mock.MagicMock()
+    )
+    ignored_component = SimpleNamespace(
+        _auto_monitor=False, kind=ophyd.Kind.normal, subscribe=mock.MagicMock()
+    )
+
+    nested = SimpleNamespace(component_names=["hinted_component"])
+    nested.hinted_component = hinted_component
+
+    obj = SimpleNamespace(
+        component_names=["normal_component", "config_component", "ignored_component", "nested"],
+        normal_component=normal_component,
+        config_component=config_component,
+        ignored_component=ignored_component,
+        nested=nested,
+    )
+
+    device_manager._auto_monitor_update_thread = mock.MagicMock()
+    device_manager._auto_monitor_update_thread.ident = None
+    thread_state = {"alive": False}
+    device_manager._auto_monitor_update_thread.is_alive.side_effect = lambda: thread_state["alive"]
+    device_manager._auto_monitor_update_thread.start.side_effect = lambda: thread_state.__setitem__(
+        "alive", True
+    )
+
+    device_manager._subscribe_to_auto_monitors(obj)
+
+    device_manager._auto_monitor_update_thread.start.assert_called_once_with()
+    normal_component.subscribe.assert_called_once_with(
+        device_manager._obj_callback_auto_monitor_readback, run=False
+    )
+    hinted_component.subscribe.assert_called_once_with(
+        device_manager._obj_callback_auto_monitor_readback, run=False
+    )
+    config_component.subscribe.assert_called_once_with(
+        device_manager._obj_callback_auto_monitor_configuration, run=False
+    )
+    ignored_component.subscribe.assert_not_called()
+
+
+@pytest.mark.parametrize("device_manager_class", [DeviceManagerDS])
+def test_subscribe_to_limit_updates_starts_thread_and_handles_missing_signals(dm_with_devices):
+    service = mock.MagicMock()
+    service.connector = mock.MagicMock()
+    service._service_name = "device_server"
+    device_manager = DeviceManagerDS(service)
+
+    low_limit = mock.MagicMock()
+    high_limit = mock.MagicMock()
+    obj = SimpleNamespace(low_limit_travel=low_limit, high_limit_travel=high_limit)
+
+    device_manager._auto_monitor_update_thread = mock.MagicMock()
+    device_manager._auto_monitor_update_thread.ident = None
+    thread_state = {"alive": False}
+    device_manager._auto_monitor_update_thread.is_alive.side_effect = lambda: thread_state["alive"]
+    device_manager._auto_monitor_update_thread.start.side_effect = lambda: thread_state.__setitem__(
+        "alive", True
+    )
+
+    device_manager._subscribe_to_limit_updates(obj)
+
+    device_manager._auto_monitor_update_thread.start.assert_called_once_with()
+    low_limit.subscribe.assert_called_once_with(
+        device_manager._obj_callback_auto_monitor_limits, run=False
+    )
+    high_limit.subscribe.assert_called_once_with(
+        device_manager._obj_callback_auto_monitor_limits, run=False
+    )
+
+    device_manager._auto_monitor_update_thread.start.reset_mock()
+    device_manager._subscribe_to_limit_updates(SimpleNamespace())
+    device_manager._auto_monitor_update_thread.start.assert_not_called()
+
+
+@pytest.mark.parametrize("device_manager_class", [DeviceManagerDS])
+def test_ensure_auto_monitor_update_thread_recreates_dead_thread(dm_with_devices):
+    service = mock.MagicMock()
+    service.connector = mock.MagicMock()
+    service._service_name = "device_server"
+    device_manager = DeviceManagerDS(service)
+
+    dead_thread = mock.MagicMock()
+    dead_thread.is_alive.return_value = False
+    dead_thread.ident = 123
+
+    replacement_thread = mock.MagicMock()
+    replacement_thread.is_alive.side_effect = [False, True]
+
+    device_manager._auto_monitor_update_thread = dead_thread
+    with mock.patch.object(
+        device_manager, "_create_auto_monitor_update_thread", return_value=replacement_thread
+    ) as mock_create_thread:
+        device_manager._ensure_auto_monitor_update_thread()
+
+    mock_create_thread.assert_called_once_with()
+    replacement_thread.start.assert_called_once_with()
+    assert device_manager._auto_monitor_update_thread is replacement_thread
+
+
+@pytest.mark.parametrize("device_manager_class", [DeviceManagerDS])
+def test_auto_monitor_callbacks_ignore_disconnected_objects(dm_with_devices):
+    disconnected_root = SimpleNamespace(name="samx")
+    disconnected_obj = SimpleNamespace(connected=False, root=disconnected_root)
+    dm_with_devices._auto_monitor_readback_updates.clear()
+    dm_with_devices._auto_monitor_configuration_updates.clear()
+    dm_with_devices._limit_change_updates.clear()
+
+    dm_with_devices._obj_callback_auto_monitor_readback(obj=disconnected_obj)
+    dm_with_devices._obj_callback_auto_monitor_configuration(obj=disconnected_obj)
+    dm_with_devices._obj_callback_auto_monitor_limits(obj=disconnected_obj)
+
+    assert not dm_with_devices._auto_monitor_readback_updates
+    assert not dm_with_devices._auto_monitor_configuration_updates
+    assert not dm_with_devices._limit_change_updates
+
+
+@pytest.mark.parametrize("device_manager_class", [DeviceManagerDS])
+def test_auto_monitor_update_loop_batches_updates_and_skips_missing_devices(dm_with_devices):
+    service = mock.MagicMock()
+    service.connector = mock.MagicMock()
+    service._service_name = "device_server"
+    device_manager = DeviceManagerDS(service)
+    samx_obj = mock.MagicMock()
+    samx_obj.connected = False
+    device_manager.devices["samx"] = SimpleNamespace(name="samx", obj=samx_obj)
+    device_manager._auto_monitor_readback_updates = {"samx", "missing"}
+    device_manager._auto_monitor_configuration_updates = {"samx"}
+    device_manager._limit_change_updates = {"samx"}
+    device_manager._shutdown_event = mock.MagicMock()
+    device_manager._shutdown_event.wait.side_effect = [False, True]
+
+    pipe = mock.MagicMock()
+    device_manager.connector = mock.MagicMock()
+    device_manager.connector.pipeline.return_value = pipe
+
+    with (
+        mock.patch.object(device_manager, "_obj_callback_readback") as mock_readback,
+        mock.patch.object(device_manager, "_obj_callback_configuration") as mock_configuration,
+        mock.patch.object(device_manager, "_obj_callback_limit_change") as mock_limit_change,
+    ):
+        device_manager._auto_monitor_update_loop()
+
+        mock_readback.assert_called_once_with(obj=samx_obj, pipe=pipe)
+        mock_configuration.assert_called_once_with(obj=samx_obj, pipe=pipe)
+        mock_limit_change.assert_called_once_with(obj=samx_obj, pipe=pipe)
+        pipe.execute.assert_called_once()
+        assert not device_manager._auto_monitor_readback_updates
+        assert not device_manager._auto_monitor_configuration_updates
+        assert not device_manager._limit_change_updates
 
 
 @pytest.mark.parametrize("device_manager_class", [DeviceManagerDS])


### PR DESCRIPTION
## Description

This PR moves the auto-monitored updates to a shared pipeline at a throttled update rate. This solves two issues:

- We deal better with unreasonably high updates rates, e.g. from ECMC
- The communication to Redis is now more efficient thanks to a shared pipeline. 

## Additional Comments

If we wanted to, we could further extend it in a follow-up PR to also provide support for the long-awaited "readout priority continous". 

## Definition of Done
- [x] Documentation is up-to-date.

