### PR TITLE
Feature/device locks

### DIFF
--- a/bec_ipython_client/bec_ipython_client/callbacks/ipython_live_updates.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/ipython_live_updates.py
@@ -16,7 +16,13 @@ from bec_lib.request_context import ActiveRequestContext, active_request_context
 
 from .live_table import LiveUpdatesTable
 from .move_device import LiveUpdatesReadbackProgressbar
-from .utils import ScanRequestMixin, ScanState, check_alarms, evaluate_scan_state
+from .utils import (
+    ScanRequestMixin,
+    ScanState,
+    check_alarms,
+    evaluate_scan_state,
+    pending_queue_message,
+)
 
 if TYPE_CHECKING:
     from bec_lib import messages
@@ -308,7 +314,7 @@ class IPythonLiveUpdates:
         if queue.queue_position is None:
             return False
 
-        if queue.status == "PENDING":
+        if self._is_pending_queue_state(queue):
             self._process_pending_queue_element(queue)
             return False
 
@@ -342,6 +348,28 @@ class IPythonLiveUpdates:
 
         return False
 
+    def _is_pending_queue_state(self, queue: QueueItem) -> bool:
+        """
+        Check if the queue is in a pending state, which can be due to either the queue
+        being locked or other scans being ahead in the queue.
+
+        Args:
+            queue(QueueItem): The queue item to check.
+
+        Returns:
+            bool: True if the queue is in a pending state, False otherwise.
+        """
+        if queue.status == "PENDING":
+            return True
+
+        active_request_block = queue.active_request_block
+        if active_request_block is not None and getattr(
+            active_request_block, "pending_device_locks", None
+        ):
+            return True
+
+        return False
+
     def _process_pending_queue_element(self, queue: QueueItem) -> None:
         """
         Process a pending queue element.
@@ -353,45 +381,22 @@ class IPythonLiveUpdates:
 
         if self.client.queue is None or self.client.queue.queue_storage.current_scan_queue is None:
             return
-        target_queue = self.client.queue.get_default_scan_queue()
-        target_queue_status = self.client.queue.queue_storage.current_scan_queue.get(target_queue)
-        if target_queue_status is None:
-            return
 
         queue_position = queue.queue_position
         if queue_position is None:
             return
 
-        status = target_queue_status.status
-        if status == "LOCKED" and any(queue.scan_ids):
-            lock_info = [
-                f"{lock.identifier}: {lock.reason}\n" for lock in target_queue_status.locks
-            ]
-            message = (
-                f"Scan is waiting for the lock to be released. Active locks: \n{''.join(lock_info)}"
-            )
-            if self._status_live is None:
-                self._status_live = Live(
-                    Panel(message, title="[yellow]Scan Status[/yellow]"), refresh_per_second=4
-                )
-                self._status_live.start()
-            else:
-                self._status_live.update(Panel(message, title="[yellow]Scan Status[/yellow]"))
+        message = pending_queue_message(bec=self.client, queue=queue, queue_position=queue_position)
+        if message is None:
             return
-
-        if queue_position > 0:
-            message = (
-                f"Scan is enqueued and is waiting for execution. Current position in queue {target_queue}:"
-                f" {queue_position + 1}. Queue status: {status}."
+        if self._status_live is None:
+            self._status_live = Live(
+                Panel(message, title="[yellow]Scan Status[/yellow]"), refresh_per_second=4
             )
-            if self._status_live is None:
-                self._status_live = Live(
-                    Panel(message, title="[yellow]Scan Status[/yellow]"), refresh_per_second=4
-                )
-                self._status_live.start()
-            else:
-                self._status_live.update(Panel(message, title="[yellow]Scan Status[/yellow]"))
-            return
+            self._status_live.start()
+        else:
+            self._status_live.update(Panel(message, title="[yellow]Scan Status[/yellow]"))
+        return
 
     def _reset(self, forced=False):
         """Reset the active request and callback.

--- a/bec_ipython_client/bec_ipython_client/callbacks/live_table.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/live_table.py
@@ -11,7 +11,7 @@ from bec_ipython_client.progressbar import ScanProgressBar
 from bec_lib.bec_errors import ScanInterruption, ScanRestart
 from bec_lib.logger import bec_logger
 
-from .utils import LiveUpdatesBase, check_alarms
+from .utils import LiveUpdatesBase, check_alarms, pending_queue_message
 
 if TYPE_CHECKING:
     from bec_lib import messages
@@ -75,20 +75,18 @@ class LiveUpdatesTable(LiveUpdatesBase):
         while True:
             if not self.scan_item or not self.scan_item.queue:
                 raise RuntimeError("No scan item or scan queue available.")
-            queue_pos = self.scan_item.queue.queue_position
+            queue = self.scan_item.queue
+            queue_pos = queue.queue_position
             self.check_alarms()
             if self.scan_item.status == "closed":
                 break
             if queue_pos is None:
                 logger.trace(f"Could not find queue entry for scan_id {self.scan_item.scan_id}")
                 continue
-            if queue_pos == 0:
+            message = pending_queue_message(bec=self.bec, queue=queue, queue_position=queue_pos)
+            if message is None:
                 break
-            print(
-                f"Scan is enqueued and is waiting for execution. Current position in queue: {queue_pos + 1}.",
-                end="\r",
-                flush=True,
-            )
+            print(message, end="\r", flush=True)
             time.sleep(0.1)
         while not self.scan_item.scan_number:
             time.sleep(0.05)

--- a/bec_ipython_client/bec_ipython_client/callbacks/move_device.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/move_device.py
@@ -12,7 +12,13 @@ from bec_lib import messages
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.redis_connector import MessageObject
 
-from .utils import LiveUpdatesBase, ScanState, check_alarms, evaluate_scan_state
+from .utils import (
+    LiveUpdatesBase,
+    ScanState,
+    check_alarms,
+    evaluate_scan_state,
+    pending_queue_message,
+)
 
 if TYPE_CHECKING:
     from bec_lib.client import BECClient
@@ -183,6 +189,7 @@ class LiveUpdatesReadbackProgressbar(LiveUpdatesBase):
         data_source = ReadbackDataHandler(self.bec.device_manager, self.devices, request_id)
         start_values = data_source.get_device_values()
         self.wait_for_request_acceptance()
+        self._wait_for_move_to_start(data_source)
 
         if self.report_instruction:
             target_values = self.report_instruction["readback"]["end"]
@@ -231,3 +238,36 @@ class LiveUpdatesReadbackProgressbar(LiveUpdatesBase):
         if self.scan_queue_request is None or self.scan_queue_request.queue is None:
             return ScanState.CONTINUE
         return evaluate_scan_state(queue=self.scan_queue_request.queue)
+
+    def _wait_for_move_to_start(self, data_source: ReadbackDataHandler) -> None:
+        """Wait until the move starts, mirroring the queue wait behavior of live table updates."""
+        if self.scan_queue_request is None or self.scan_queue_request.queue is None:
+            return
+
+        while True:
+            if self.scan_queue_request is None or self.scan_queue_request.queue is None:
+                return
+
+            queue = self.scan_queue_request.queue
+            check_alarms(self.bec)
+            scan_state = self._check_scan_state()
+            if scan_state == ScanState.WAIT:
+                time.sleep(0.05)
+                continue
+
+            queue_position = getattr(queue, "queue_position", None)
+
+            if queue_position is None:
+                if data_source.done():
+                    return
+                time.sleep(0.05)
+                continue
+
+            message = pending_queue_message(
+                bec=self.bec, queue=queue, queue_position=queue_position
+            )
+            if message is None:
+                break
+
+            print(message, end="\r", flush=True)
+            time.sleep(0.1)

--- a/bec_ipython_client/bec_ipython_client/callbacks/utils.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/utils.py
@@ -81,6 +81,69 @@ def evaluate_scan_state(
     return ScanState.CONTINUE
 
 
+def pending_queue_message(
+    *, bec: BECClient, queue: QueueItem, queue_position: int | None = None
+) -> str | None:
+    """Return a user-facing message for queue states that are still waiting to start."""
+    if queue_position is None:
+        queue_position = getattr(queue, "queue_position", None)
+    if not isinstance(queue_position, int):
+        return None
+
+    target_queue = None
+    target_queue_status = None
+    if bec.queue is not None:
+        current_scan_queue = getattr(bec.queue.queue_storage, "current_scan_queue", None)
+        if current_scan_queue is not None:
+            target_queue = bec.queue.get_default_scan_queue()
+            target_queue_status = current_scan_queue.get(target_queue)
+
+    request_blocks = getattr(queue, "request_blocks", None) or []
+    has_scan_request = any(
+        getattr(request_block, "is_scan", False) for request_block in request_blocks
+    )
+    if (
+        target_queue_status is not None
+        and getattr(target_queue_status, "status", None) == "LOCKED"
+        and has_scan_request
+    ):
+        lock_info = [
+            f"{lock.identifier}: {lock.reason}\n"
+            for lock in getattr(target_queue_status, "locks", None) or []
+        ]
+        return f"Scan is waiting for the lock to be released. Active locks: \n{''.join(lock_info)}"
+
+    owned_device_locks: list[str] = []
+    pending_device_locks: list[str] = []
+    get_device_lock_state = getattr(queue, "get_device_lock_state", None)
+    if callable(get_device_lock_state):
+        try:
+            owned_device_locks, pending_device_locks = get_device_lock_state()
+        except Exception:
+            owned_device_locks, pending_device_locks = [], []
+    if pending_device_locks:
+        pending_locks = ", ".join(pending_device_locks)
+        message = f"Scan is waiting for device locks to be released. Pending device locks: {pending_locks}."
+        if owned_device_locks:
+            owned_locks = ", ".join(owned_device_locks)
+            message += f" Currently owned device locks: {owned_locks}."
+        return message
+
+    if getattr(queue, "status", None) == "PENDING" and queue_position > 0:
+        if target_queue is not None:
+            status = getattr(target_queue_status, "status", getattr(queue, "status", None))
+            return (
+                "Scan is enqueued and is waiting for execution. "
+                f"Current position in queue {target_queue}: {queue_position + 1}. Queue status: {status}."
+            )
+        return (
+            "Scan is enqueued and is waiting for execution. "
+            f"Current position in queue: {queue_position + 1}."
+        )
+
+    return None
+
+
 def _restart_signal(
     *, scan_item: ScanItem | None = None, queue: QueueItem | None = None
 ) -> messages.ScanQueueMessage | None:

--- a/bec_ipython_client/tests/client_tests/test_ipython_live_updates.py
+++ b/bec_ipython_client/tests/client_tests/test_ipython_live_updates.py
@@ -147,6 +147,41 @@ def test_live_updates_process_queue_running(ipython_live_updates_with_mocked_liv
                     assert res is True
 
 
+@pytest.mark.timeout(20)
+def test_live_updates_process_queue_waiting_for_device_locks(
+    ipython_live_updates_with_mocked_live, queue_elements
+):
+    live_updates, _ = ipython_live_updates_with_mocked_live
+    client = live_updates.client
+    queue, request_block, request_msg = queue_elements
+
+    request_block.pending_device_locks = ["samx"]
+    queue = QueueItem(
+        scan_manager=client.queue,
+        queue_id="queue_id",
+        request_blocks=[request_block],
+        status="RUNNING",
+        active_request_block=request_block,
+        scan_id=["scan_id"],
+    )
+    client.queue.queue_storage.current_scan_queue = {
+        "primary": messages.ScanQueueStatus(info=[], status="RUNNING")
+    }
+
+    with (
+        mock.patch.object(queue, "_update_with_buffer"),
+        mock.patch(
+            "bec_lib.queue_items.QueueItem.queue_position", new_callable=mock.PropertyMock
+        ) as queue_pos,
+        mock.patch.object(live_updates, "_process_pending_queue_element") as process_pending,
+    ):
+        queue_pos.return_value = 0
+
+        assert live_updates._process_queue(queue, request_msg, "req_id") is False
+
+    process_pending.assert_called_once_with(queue)
+
+
 def test_live_updates_process_queue_cancelled_pending_request_raises_interruption(bec_client_mock):
     client = bec_client_mock
     live_updates = IPythonLiveUpdates(client)
@@ -1016,3 +1051,137 @@ def test_process_pending_queue_element_locked_then_position(
         assert "user123" in panel_renderable
         # Should not show position info
         assert "position in queue" not in panel_renderable
+
+
+@pytest.mark.timeout(20)
+def test_process_pending_queue_element_waiting_for_device_locks(
+    ipython_live_updates_with_mocked_live, queue_elements
+):
+    live_updates, mock_live = ipython_live_updates_with_mocked_live
+    client = live_updates.client
+    queue, request_block, _ = queue_elements
+
+    request_block.pending_device_locks = ["bpm4i", "samz"]
+    request_block.owned_device_locks = ["samx"]
+    queue.active_request_block = request_block
+
+    running_scan_queue_status = messages.ScanQueueStatus(info=[], status="RUNNING")
+    client.queue.queue_storage.current_scan_queue = {"primary": running_scan_queue_status}
+
+    with mock.patch(
+        "bec_lib.queue_items.QueueItem.queue_position", new_callable=mock.PropertyMock
+    ) as queue_pos:
+        queue_pos.return_value = 0
+
+        live_updates._process_pending_queue_element(queue)
+
+        mock_live.assert_called_once()
+        call_args = mock_live.call_args[0][0]
+        panel_renderable = call_args.renderable
+        assert "waiting for device locks" in panel_renderable
+        assert "bpm4i, samz" in panel_renderable
+        assert "Currently owned device locks: samx" in panel_renderable
+
+
+@pytest.mark.timeout(20)
+def test_process_pending_queue_element_waiting_for_device_locks_without_scan_id(
+    ipython_live_updates_with_mocked_live, queue_elements
+):
+    live_updates, mock_live = ipython_live_updates_with_mocked_live
+    client = live_updates.client
+    queue, request_block, _ = queue_elements
+
+    request_block.pending_device_locks = ["bpm4i", "samz"]
+    request_block.owned_device_locks = ["samx"]
+    queue.active_request_block = request_block
+    queue.scan_ids = [None]
+
+    running_scan_queue_status = messages.ScanQueueStatus(info=[], status="RUNNING")
+    client.queue.queue_storage.current_scan_queue = {"primary": running_scan_queue_status}
+
+    with mock.patch(
+        "bec_lib.queue_items.QueueItem.queue_position", new_callable=mock.PropertyMock
+    ) as queue_pos:
+        queue_pos.return_value = 0
+
+        live_updates._process_pending_queue_element(queue)
+
+        mock_live.assert_called_once()
+        call_args = mock_live.call_args[0][0]
+        panel_renderable = call_args.renderable
+        assert "waiting for device locks" in panel_renderable
+        assert "bpm4i, samz" in panel_renderable
+        assert "Currently owned device locks: samx" in panel_renderable
+
+
+@pytest.mark.timeout(20)
+def test_process_pending_queue_element_waiting_for_device_locks_beats_queue_position(
+    ipython_live_updates_with_mocked_live, queue_elements
+):
+    live_updates, mock_live = ipython_live_updates_with_mocked_live
+    client = live_updates.client
+    queue, request_block, _ = queue_elements
+
+    request_block.pending_device_locks = ["bpm4i"]
+    queue.active_request_block = request_block
+
+    running_scan_queue_status = messages.ScanQueueStatus(info=[], status="RUNNING")
+    client.queue.queue_storage.current_scan_queue = {"primary": running_scan_queue_status}
+
+    with mock.patch(
+        "bec_lib.queue_items.QueueItem.queue_position", new_callable=mock.PropertyMock
+    ) as queue_pos:
+        queue_pos.return_value = 2
+
+        live_updates._process_pending_queue_element(queue)
+
+        call_args = mock_live.call_args[0][0]
+        panel_renderable = call_args.renderable
+        assert "waiting for device locks" in panel_renderable
+        assert "position in queue" not in panel_renderable
+
+
+@pytest.mark.timeout(20)
+def test_process_pending_queue_element_waiting_for_device_locks_on_secondary_queue(
+    ipython_live_updates_with_mocked_live, queue_elements
+):
+    live_updates, mock_live = ipython_live_updates_with_mocked_live
+    client = live_updates.client
+    queue, request_block, _ = queue_elements
+
+    queue.queue_id = "secondary_queue_id"
+    request_block.pending_device_locks = ["bpm4i"]
+    request_block.owned_device_locks = ["samx"]
+    queue.active_request_block = request_block
+
+    client.queue.queue_storage.current_scan_queue = {
+        "primary": messages.ScanQueueStatus(info=[], status="RUNNING"),
+        "secondary": messages.ScanQueueStatus(
+            info=[
+                messages.QueueInfoEntry(
+                    queue_id="secondary_queue_id",
+                    scan_id=["scan_id"],
+                    is_scan=[True],
+                    request_blocks=[request_block],
+                    scan_number=[1],
+                    status="PENDING",
+                    active_request_block=request_block,
+                )
+            ],
+            status="RUNNING",
+        ),
+    }
+
+    with mock.patch(
+        "bec_lib.queue_items.QueueItem.queue_position", new_callable=mock.PropertyMock
+    ) as queue_pos:
+        queue_pos.return_value = 0
+
+        live_updates._process_pending_queue_element(queue)
+
+        mock_live.assert_called_once()
+        call_args = mock_live.call_args[0][0]
+        panel_renderable = call_args.renderable
+        assert "waiting for device locks" in panel_renderable
+        assert "bpm4i" in panel_renderable
+        assert "Currently owned device locks: samx" in panel_renderable

--- a/bec_ipython_client/tests/client_tests/test_live_table.py
+++ b/bec_ipython_client/tests/client_tests/test_live_table.py
@@ -130,6 +130,39 @@ class TestLiveTable:
         with mock.patch.object(client.queue.queue_storage, "find_queue_item_by_requestID"):
             live_update.wait_for_request_acceptance()
 
+    def test_wait_for_scan_to_start_prints_pending_queue_message(self, client_with_grid_scan):
+        client, request_msg = client_with_grid_scan
+        live_update = LiveUpdatesTable(
+            client, {"scan_progress": {"points": 10, "show_table": True}}, request_msg
+        )
+        client.queue.queue_storage.current_scan_queue = None
+
+        class QueueStub:
+            def __init__(self):
+                self.status = "PENDING"
+                self.request_blocks = []
+                self._positions = iter([2, 0])
+
+            @property
+            def queue_position(self):
+                return next(self._positions)
+
+            def get_device_lock_state(self):
+                return ([], [])
+
+        live_update.scan_item = mock.MagicMock(
+            queue=QueueStub(), status="open", scan_id="scan_id", scan_number=1
+        )
+
+        with mock.patch("bec_ipython_client.callbacks.live_table.print") as mock_print:
+            live_update.wait_for_scan_to_start()
+
+        mock_print.assert_called_once_with(
+            "Scan is enqueued and is waiting for execution. Current position in queue: 3.",
+            end="\r",
+            flush=True,
+        )
+
     @pytest.mark.timeout(20)
     def test_run_update(self, bec_client_mock, scan_item):
         request_msg = messages.ScanQueueMessage(

--- a/bec_ipython_client/tests/client_tests/test_move_callback.py
+++ b/bec_ipython_client/tests/client_tests/test_move_callback.py
@@ -8,7 +8,7 @@ from bec_ipython_client.callbacks.move_device import (
     LiveUpdatesReadbackProgressbar,
     ReadbackDataHandler,
 )
-from bec_ipython_client.callbacks.utils import ScanState
+from bec_ipython_client.callbacks.utils import ScanState, pending_queue_message
 from bec_lib import messages
 from bec_lib.bec_errors import ScanInterruption, ScanRestart
 from bec_lib.endpoints import MessageEndpoints
@@ -216,6 +216,133 @@ def test_move_callback_check_scan_state_restart_without_restart_message_is_nonbl
     )
 
     assert live_update._check_scan_state() == ScanState.WAIT
+
+
+def test_move_callback_pending_queue_message_for_device_locks(bec_client_mock):
+    bec_client_mock.queue.queue_storage.current_scan_queue = None
+    request_block = mock.MagicMock(is_scan=True)
+    queue = mock.MagicMock(status="RUNNING", request_blocks=[request_block])
+    queue.get_device_lock_state.return_value = (["samz"], ["samx", "bpm4i"])
+
+    message = pending_queue_message(bec=bec_client_mock, queue=queue, queue_position=0)
+
+    assert (
+        message
+        == "Scan is waiting for device locks to be released. Pending device locks: samx, bpm4i. "
+        "Currently owned device locks: samz."
+    )
+
+
+def test_move_callback_pending_queue_message_for_queue_position(bec_client_mock):
+    bec_client_mock.queue.queue_storage.current_scan_queue = None
+    queue = mock.MagicMock(status="PENDING", request_blocks=[])
+    queue.get_device_lock_state.return_value = ([], [])
+
+    message = pending_queue_message(bec=bec_client_mock, queue=queue, queue_position=2)
+
+    assert message == "Scan is enqueued and is waiting for execution. Current position in queue: 3."
+
+
+def test_move_callback_wait_for_move_to_start_prints_pending_message(bec_client_mock):
+    request = messages.ScanQueueMessage(
+        scan_type="umv",
+        parameter={"args": {"samx": [10]}, "kwargs": {"relative": True}},
+        metadata={"RID": "something"},
+    )
+    live_update = LiveUpdatesReadbackProgressbar(bec=bec_client_mock, request=request)
+    bec_client_mock.queue.queue_storage.current_scan_queue = None
+
+    class QueueStub:
+        def __init__(self):
+            self.status = "PENDING"
+            self.request_blocks = []
+            self._positions = iter([2, 0])
+
+        @property
+        def queue_position(self):
+            return next(self._positions)
+
+        def get_device_lock_state(self):
+            return ([], [])
+
+    queue = QueueStub()
+    live_update.scan_queue_request = mock.MagicMock(queue=queue)
+    data_source = mock.MagicMock()
+    data_source.done.return_value = False
+
+    with (
+        mock.patch("bec_ipython_client.callbacks.move_device.print") as mock_print,
+        mock.patch("bec_ipython_client.callbacks.move_device.time.sleep") as sleep,
+        mock.patch.object(live_update, "_check_scan_state", return_value=ScanState.CONTINUE),
+    ):
+        live_update._wait_for_move_to_start(data_source)
+
+    mock_print.assert_called_once_with(
+        "Scan is enqueued and is waiting for execution. Current position in queue: 3.",
+        end="\r",
+        flush=True,
+    )
+    sleep.assert_called()
+
+
+def test_move_callback_wait_for_move_to_start_returns_when_queue_entry_is_gone(bec_client_mock):
+    request = messages.ScanQueueMessage(
+        scan_type="umv",
+        parameter={"args": {"samx": [10]}, "kwargs": {"relative": True}},
+        metadata={"RID": "something"},
+    )
+    live_update = LiveUpdatesReadbackProgressbar(bec=bec_client_mock, request=request)
+    queue = mock.MagicMock()
+    queue.queue_position = None
+    live_update.scan_queue_request = mock.MagicMock(queue=queue)
+    data_source = mock.MagicMock()
+    data_source.done.return_value = True
+
+    with (
+        mock.patch("bec_ipython_client.callbacks.move_device.print") as mock_print,
+        mock.patch("bec_ipython_client.callbacks.move_device.time.sleep") as sleep,
+        mock.patch.object(live_update, "_check_scan_state", return_value=ScanState.CONTINUE),
+    ):
+        live_update._wait_for_move_to_start(data_source)
+
+    mock_print.assert_not_called()
+    sleep.assert_not_called()
+
+
+def test_move_callback_wait_for_move_to_start_keeps_waiting_when_not_yet_registered(
+    bec_client_mock,
+):
+    request = messages.ScanQueueMessage(
+        scan_type="umv",
+        parameter={"args": {"samx": [10]}, "kwargs": {"relative": True}},
+        metadata={"RID": "something"},
+    )
+    live_update = LiveUpdatesReadbackProgressbar(bec=bec_client_mock, request=request)
+
+    class QueueStub:
+        def __init__(self):
+            self._positions = iter([None, None, 0])
+
+        @property
+        def queue_position(self):
+            return next(self._positions)
+
+    live_update.scan_queue_request = mock.MagicMock(queue=QueueStub())
+    data_source = mock.MagicMock()
+    data_source.done.return_value = False
+
+    with (
+        mock.patch("bec_ipython_client.callbacks.move_device.print") as mock_print,
+        mock.patch("bec_ipython_client.callbacks.move_device.time.sleep") as sleep,
+        mock.patch.object(live_update, "_check_scan_state", return_value=ScanState.CONTINUE),
+        mock.patch(
+            "bec_ipython_client.callbacks.move_device.pending_queue_message", return_value=None
+        ),
+    ):
+        live_update._wait_for_move_to_start(data_source)
+
+    mock_print.assert_not_called()
+    assert sleep.call_count == 2
 
 
 def test_move_callback_run_waits_for_restart_message_before_exiting(bec_client_mock):

--- a/bec_ipython_client/tests/end-2-end/test_scans_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_scans_e2e.py
@@ -261,6 +261,47 @@ def test_scan_abort(bec_ipython_client_fixture: BECIPythonClient):
 
 
 @pytest.mark.timeout(100)
+def test_umv_ctrl_c_stops_motion(bec_ipython_client_fixture: BECIPythonClient):
+    def send_abort_after_delay():
+        time.sleep(1)
+        _thread.interrupt_main()
+
+    bec = bec_ipython_client_fixture
+    bec.metadata.update({"unit_test": "test_umv_ctrl_c_stops_motion"})
+    scans = bec.scans
+    dev = bec.device_manager.devices
+    original_velocity = dev.samx.velocity.get()
+    aborted_scan = False
+
+    try:
+        dev.samx.velocity.set(100).wait()
+        scans.umv(dev.samx, 0, relative=False)
+        dev.samx.velocity.set(1).wait()
+
+        threading.Thread(target=send_abort_after_delay, daemon=True).start()
+        try:
+            scans.umv(dev.samx, 40, relative=False)
+        except ScanInterruption:
+            aborted_scan = True
+
+        assert aborted_scan is True
+
+        timeout = time.time() + 10
+        while dev.samx.motor_is_moving.get() and time.time() < timeout:
+            time.sleep(0.1)
+
+        assert not dev.samx.motor_is_moving.get()
+        assert dev.samx.readback.get() < 40
+    finally:
+        if dev.samx.motor_is_moving.get():
+            dev.samx.stop()
+            timeout = time.time() + 10
+            while dev.samx.motor_is_moving.get() and time.time() < timeout:
+                time.sleep(0.1)
+        dev.samx.velocity.set(original_velocity).wait()
+
+
+@pytest.mark.timeout(100)
 def test_limit_error(bec_ipython_client_fixture):
     bec = bec_ipython_client_fixture
     bec.metadata.update({"unit_test": "test_limit_error"})

--- a/bec_lib/bec_lib/devicemanager.py
+++ b/bec_lib/bec_lib/devicemanager.py
@@ -315,7 +315,9 @@ class DeviceContainer(dict):
         return list(tags)
 
     def get_software_triggered_devices(self) -> list:
-        """get a list of all devices that should receive a software trigger detectors"""
+        """
+        Get a list of all enabled devices that should receive a software trigger during a scan.
+        """
         # pylint: disable=protected-access
         devices = [
             dev for _, dev in self.items() if dev._config.get("softwareTrigger", False) is True

--- a/bec_lib/bec_lib/messages.py
+++ b/bec_lib/bec_lib/messages.py
@@ -415,6 +415,8 @@ class RequestBlock(BaseModel):
         scan_number (int | None): Scan number if applicable
         scan_id (str | None): Scan ID if applicable
         report_instructions (list[dict] | None): List of report instructions for the scan, if any
+        owned_device_locks (list[str]): List of device locks owned by the request
+        pending_device_locks (list[str]): List of device locks pending for the request
 
     """
 
@@ -427,6 +429,8 @@ class RequestBlock(BaseModel):
     scan_number: int | None
     scan_id: str | None
     report_instructions: list[dict] | None = None
+    owned_device_locks: list[str] = Field(default_factory=list)
+    pending_device_locks: list[str] = Field(default_factory=list)
 
 
 class QueueInfoEntry(BaseModel):

--- a/bec_lib/bec_lib/queue_items.py
+++ b/bec_lib/bec_lib/queue_items.py
@@ -54,6 +54,7 @@ class QueueItem:
         self.active_request_block = active_request_block
         self.scan_ids = scan_id
         self.reason = reason
+        self._lock = threading.RLock()
         if client_messages is None:
             client_messages = []
         self.client_messages = client_messages
@@ -85,6 +86,44 @@ class QueueItem:
     def status(self):
         return self._status
 
+    @threadlocked
+    def _get_device_lock_state(self) -> tuple[list[str], list[str]]:
+        """
+        Return a snapshot of owned and pending device locks.
+
+        Returns:
+            tuple[list[str], list[str]]: A tuple containing two lists:
+                - The first list contains the names of devices whose locks are currently owned.
+                - The second list contains the names of devices whose locks are pending.
+        """
+        owned_device_locks = sorted(
+            {
+                device
+                for request_block in self.request_blocks
+                for device in request_block.owned_device_locks
+            }
+        )
+        pending_device_locks = sorted(
+            {
+                device
+                for request_block in self.request_blocks
+                for device in request_block.pending_device_locks
+            }
+        )
+        return owned_device_locks, pending_device_locks
+
+    def get_device_lock_state(self) -> tuple[list[str], list[str]]:
+        """
+        Refresh and return a consistent snapshot of device-lock state.
+
+        Returns:
+            tuple[list[str], list[str]]: A tuple containing two lists:
+                - The first list contains the names of devices whose locks are currently owned.
+                - The second list contains the names of devices whose locks are pending.
+        """
+        self._update_with_buffer()
+        return self._get_device_lock_state()
+
     def _update_with_buffer(self):
         current_queue = self.scan_manager.queue_storage.current_scan_queue
         if not current_queue:
@@ -103,6 +142,7 @@ class QueueItem:
                 self.update_queue_item(queue_item.info)
                 return
 
+    @threadlocked
     def update_queue_item(self, queue_item: messages.QueueInfoEntry):
         """update the queue item"""
         self.request_blocks = queue_item.request_blocks

--- a/bec_lib/bec_lib/scan_input_validator.py
+++ b/bec_lib/bec_lib/scan_input_validator.py
@@ -13,7 +13,7 @@ from bec_lib.scan_args import ScanArgument
 from bec_lib.signature_serializer import deserialize_dtype, dict_to_signature
 
 # Internal scan kwargs that are automatically added to the scan request
-INTERNAL_SCAN_KWARGS = {"user_metadata", "system_config", "scan_queue"}
+INTERNAL_SCAN_KWARGS = {"user_metadata", "system_config", "scan_queue", "monitored", "on_request"}
 
 
 class ScanInputValidator:

--- a/bec_lib/bec_lib/scans.py
+++ b/bec_lib/bec_lib/scans.py
@@ -58,6 +58,7 @@ class ScanObject:
         hide_report: bool = False,
         metadata: dict | None = None,
         monitored: list[str | DeviceBase] | None = None,
+        on_request: list[str | DeviceBase] | None = None,
         file_suffix: str | None = None,
         file_directory: str | None = None,
         scan_queue: str | None = None,
@@ -72,7 +73,8 @@ class ScanObject:
             async_callback: Asynchronous callback function
             hide_report: Hide the report
             metadata: Metadata dictionary
-            monitored: List of monitored devices
+            monitored: List of devices to be put on the readout priority `monitored`
+            on_request: List of devices to be put on the readout priority `on_request`
             file_suffix: File suffix for the scan data
             file_directory: File directory for the scan data
             scan_queue: Scan queue name. If None, the default queue will be used.
@@ -110,12 +112,24 @@ class ScanObject:
                 monitored = [monitored]
             for mon_device in monitored:
                 if isinstance(mon_device, str):
-                    mon_device = self.client.device_manager.devices.get(mon_device)
-                    if not mon_device:
+                    mon_device_obj = self.client.device_manager.devices.get(mon_device)
+                    if not mon_device_obj:
                         raise RuntimeError(
                             f"Specified monitored device {mon_device} does not exist in the current device configuration."
                         )
             kwargs["monitored"] = monitored
+
+        if on_request is not None:
+            if not isinstance(on_request, list):
+                on_request = [on_request]
+            for or_device in on_request:
+                if isinstance(or_device, str):
+                    or_device_obj = self.client.device_manager.devices.get(or_device)
+                    if not or_device_obj:
+                        raise RuntimeError(
+                            f"Specified on_request device {or_device} does not exist in the current device configuration."
+                        )
+            kwargs["on_request"] = on_request
 
         sys_config = sys_config.model_dump()
         # pylint: disable=protected-access

--- a/bec_lib/tests/test_queue_items.py
+++ b/bec_lib/tests/test_queue_items.py
@@ -520,6 +520,73 @@ def test_queue_item_status_property(queue_item, scan_queue_status_message):
     assert queue_item._status == "pending"
 
 
+def test_queue_item_device_lock_properties(queue_item):
+    queue_item.request_blocks = [
+        messages.RequestBlock(
+            msg=messages.ScanQueueMessage(
+                queue="primary",
+                scan_type="step",
+                parameter={"args": {}, "kwargs": {}},
+                metadata={"RID": "rid_1"},
+            ),
+            RID="rid_1",
+            readout_priority={"monitored": []},
+            is_scan=True,
+            scan_number=1,
+            scan_id="scan_1",
+            owned_device_locks=["samx", "samy"],
+            pending_device_locks=["bpm4i"],
+        ),
+        messages.RequestBlock(
+            msg=messages.ScanQueueMessage(
+                queue="primary",
+                scan_type="step",
+                parameter={"args": {}, "kwargs": {}},
+                metadata={"RID": "rid_2"},
+            ),
+            RID="rid_2",
+            readout_priority={"monitored": []},
+            is_scan=True,
+            scan_number=2,
+            scan_id="scan_2",
+            owned_device_locks=["samy", "samz"],
+            pending_device_locks=["bpm4i", "bpm5i"],
+        ),
+    ]
+    queue_item.scan_manager.queue_storage.current_scan_queue = None
+
+    owned_device_locks, pending_device_locks = queue_item.get_device_lock_state()
+
+    assert owned_device_locks == ["samx", "samy", "samz"]
+    assert pending_device_locks == ["bpm4i", "bpm5i"]
+
+
+def test_queue_item_get_device_lock_state(queue_item):
+    queue_item.request_blocks = [
+        messages.RequestBlock(
+            msg=messages.ScanQueueMessage(
+                queue="primary",
+                scan_type="step",
+                parameter={"args": {}, "kwargs": {}},
+                metadata={"RID": "rid_1"},
+            ),
+            RID="rid_1",
+            readout_priority={"monitored": []},
+            is_scan=True,
+            scan_number=1,
+            scan_id="scan_1",
+            owned_device_locks=["samx", "samy"],
+            pending_device_locks=["bpm4i"],
+        )
+    ]
+    queue_item.scan_manager.queue_storage.current_scan_queue = None
+
+    owned_device_locks, pending_device_locks = queue_item.get_device_lock_state()
+
+    assert owned_device_locks == ["samx", "samy"]
+    assert pending_device_locks == ["bpm4i"]
+
+
 def test_queue_item_scans_property(queue_item, scan_queue_status_message):
     """Test scans property retrieves scan items."""
     queue_item.scan_ids = ["scan_1", "scan_2"]

--- a/bec_lib/tests/test_scan_object.py
+++ b/bec_lib/tests/test_scan_object.py
@@ -115,6 +115,16 @@ def test_scan_object_v4_rejects_additional_kwargs(scan_obj_no_args, dev):
     assert "Unknown keyword argument(s) for scan: 'additional_device'" in str(exc.value)
 
 
+def test_scan_object_v4_accepts_monitored_kwarg(scan_obj_no_args):
+    scan_obj_no_args.scan_info["base_class"] = "ScanBaseV4"
+
+    with mock.patch.object(scan_obj_no_args, "_send_scan_request") as send_scan_request:
+        scan_obj_no_args._run(points=10, interval=1.5, monitored=["samx"])
+
+    sent_msg = send_scan_request.call_args.args[0]
+    assert sent_msg.parameter["kwargs"]["monitored"] == ["samx"]
+
+
 def test_scan_object_raises_signature_kwargs_type_for_arg_input_scan(scan_obj, dev):
     with pytest.raises(ScanInputValidationError, match="step': .*float or int"):
         scan_obj._run(dev.samx, -5, 5, dev.samy, -5, 5, step="bad", exp_time=0.1, relative=False)

--- a/bec_server/bec_server/device_server/device_server.py
+++ b/bec_server/bec_server/device_server/device_server.py
@@ -380,7 +380,7 @@ class DeviceServer(BECService):
     def on_stop_devices(self, msg: MessageObject, **_kwargs) -> None:
         """
         Callback for receiving device stop requests.
-        Handles both stopping all devices (empty list) and stopping specific devices (list of device names).
+        Handles stop-all (`None`), stop-none (`[]`), and stopping specific devices (device-name list).
 
         Args:
             msg: MessageObject containing the stop request.
@@ -397,9 +397,12 @@ class DeviceServer(BECService):
                 for stop_id in mvalue.metadata["stop_id"]:
                     if stop_id is not None:
                         self.requests_handler._stopped_requests.append(stop_id)
-        if not mvalue.value:
+        if mvalue.value is None:
             self.stop_devices()
             logger.info("Received request to stop all devices.")
+            return
+        if mvalue.value == []:
+            logger.info("Received request to stop no devices.")
             return
         logger.info(f"Received request to stop devices: {mvalue.value}")
         self.stop_devices(mvalue.value)

--- a/bec_server/bec_server/device_server/devices/device_serializer.py
+++ b/bec_server/bec_server/device_server/devices/device_serializer.py
@@ -157,7 +157,14 @@ def get_ownership_mode(
     """
     explicit_mode = getattr(obj.__class__, "ownership_mode", None)
     if explicit_mode is not None:
-        return OwnershipMode(explicit_mode)
+        try:
+            return OwnershipMode(explicit_mode)
+        except ValueError as exc:
+            raise DeviceConfigError(
+                f"Invalid ownership_mode {explicit_mode!r} configured on "
+                f"{obj.__class__.__name__}. Expected one of: "
+                f"{', '.join(mode.value for mode in OwnershipMode)}."
+            ) from exc
 
     if isinstance(obj, PSIDeviceBase):
         return OwnershipMode.PINNED

--- a/bec_server/bec_server/device_server/devices/device_serializer.py
+++ b/bec_server/bec_server/device_server/devices/device_serializer.py
@@ -5,11 +5,12 @@ is used to create the device interface for proxy objects on other services.
 
 import functools
 from contextlib import contextmanager
+from enum import Enum
 from typing import Any, Generator
 
 import msgpack
 from ophyd import Device, Kind, PositionerBase, Signal
-from ophyd_devices import BECDeviceBase, ComputedSignal
+from ophyd_devices import BECDeviceBase, ComputedSignal, PSIDeviceBase
 from ophyd_devices.utils.bec_signals import BECMessageSignal
 
 from bec_lib.bec_errors import DeviceConfigError
@@ -19,6 +20,26 @@ from bec_lib.numpy_encoder import numpy_encode
 from bec_lib.signature_serializer import signature_to_dict
 
 logger = bec_logger.logger
+
+
+class OwnershipMode(str, Enum):
+    """
+    Ownership policy used in serialized device info.
+
+    FREE: The device is free to be used by any scan or procedure without acquiring a lock.
+        This is typically used for read-only signals.
+    CLAIMABLE: The device can be locked by a scan or procedure. It can be used without a lock,
+        but if a scan or procedure wants to use it, it should acquire a lock first. Typical
+        examples are motors that are normally on readout priority "baseline". When a scan wants
+        to use the motor, it should acquire a lock first. If the motor is already locked by
+        another scan or procedure, the scan will wait until the lock is released.
+    PINNED: When enabled, the device has to be locked by a scan before it can be used. This is
+        typically used for devices that are stateful during a scan, such as detectors or flyers.
+    """
+
+    FREE = "free"
+    CLAIMABLE = "claimable"
+    PINNED = "pinned"
 
 
 @contextmanager
@@ -115,6 +136,36 @@ def get_device_base_class(obj: Any) -> str:
         return "device"
 
     return "unknown"
+
+
+def get_ownership_mode(
+    obj: PositionerBase | ComputedSignal | Signal | Device | BECDeviceBase,
+) -> OwnershipMode:
+    """
+    Resolve ownership policy for a device or signal.
+    The logic is as follows:
+    1. If the class has an explicit ownership_mode attribute, use that.
+    2. If the object is a PSIDeviceBase, it is pinned.
+    3. If the object is a signal and has write_access set to False, it is free.
+    4. Otherwise, it is claimable.
+
+    Args:
+        obj (PositionerBase | ComputedSignal | Signal | Device | BECDeviceBase): object to get the ownership mode from
+
+    Returns:
+        OwnershipMode: ownership mode of the object
+    """
+    explicit_mode = getattr(obj.__class__, "ownership_mode", None)
+    if explicit_mode is not None:
+        return OwnershipMode(explicit_mode)
+
+    if isinstance(obj, PSIDeviceBase):
+        return OwnershipMode.PINNED
+
+    if get_device_base_class(obj) == "signal" and getattr(obj, "write_access", None) is False:
+        return OwnershipMode.FREE
+
+    return OwnershipMode.CLAIMABLE
 
 
 def get_device_info(
@@ -256,6 +307,7 @@ def get_device_info(
             "device_dotted_name": getattr(obj, "dotted_name", ""),
             "device_base_class": get_device_base_class(obj),
             "device_class": obj.__class__.__name__,
+            "ownership_mode": get_ownership_mode(obj).value,
             "read_access": getattr(obj, "read_access", None),
             "write_access": getattr(obj, "write_access", None),
             "signals": signals,

--- a/bec_server/bec_server/scan_server/device_lock_registry.py
+++ b/bec_server/bec_server/scan_server/device_lock_registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import threading
+import time
 from collections import defaultdict
 from collections.abc import Callable, Iterable
 
@@ -13,6 +14,7 @@ class DeviceLockRegistry:
     """Registry that tracks per-request device locks for the scan server."""
 
     WAIT_INTERVAL_S: float = 0.1
+    WAIT_LOG_INTERVAL_S: float = 5.0
 
     def __init__(self) -> None:
         """Initialize the device lock registry."""
@@ -25,6 +27,7 @@ class DeviceLockRegistry:
         request_id: str,
         devices: Iterable[str],
         interruption_callback: Callable[[], None] | None = None,
+        wait_state_callback: Callable[[list[str]], None] | None = None,
     ) -> list[str]:
         """
         Acquire locks for multiple devices on behalf of a request.
@@ -39,14 +42,70 @@ class DeviceLockRegistry:
         Returns:
             list[str]: sorted device names whose locks were acquired.
         """
-        acquired: list[str] = []
-        for device in sorted(set(devices)):
-            self.acquire(request_id, device, interruption_callback=interruption_callback)
-            acquired.append(device)
-        return acquired
+        device_names = sorted(set(devices))
+        if not device_names:
+            return []
+
+        waiting_devices: list[str] = []
+        next_log_time = 0.0
+        while True:
+            should_wait = False
+            should_broadcast = False
+            next_waiting_devices: list[str] = []
+            blocked_owners: dict[str, str] = {}
+
+            with self._condition:
+                acquirable_devices: list[str] = []
+                blocked_devices: list[str] = []
+
+                for device in device_names:
+                    current_owner = self._device_owners.get(device)
+                    if current_owner == request_id:
+                        # we already own this device, so we can skip it
+                        continue
+                    if current_owner is None:
+                        # the device is not owned by anyone, so we can acquire it
+                        acquirable_devices.append(device)
+                        continue
+
+                    # the device is owned by another request, so we need to wait for it
+                    blocked_devices.append(device)
+                    blocked_owners[device] = current_owner
+
+                for device in acquirable_devices:
+                    self._device_owners[device] = request_id
+                    self._owner_devices[request_id].add(device)
+
+                next_waiting_devices = blocked_devices
+                if blocked_devices:
+                    should_wait = True
+                    next_log_time = self._log_waiting_for_device_lock(
+                        request_id=request_id,
+                        blocked_owners=blocked_owners,
+                        next_log_time=next_log_time,
+                    )
+                    self._condition.wait(timeout=self.WAIT_INTERVAL_S)
+
+                should_broadcast = bool(acquirable_devices) or (
+                    next_waiting_devices != waiting_devices
+                )
+
+            if should_broadcast and wait_state_callback is not None:
+                wait_state_callback(next_waiting_devices.copy())
+            waiting_devices = next_waiting_devices
+
+            if not should_wait:
+                return device_names
+
+            if interruption_callback is not None:
+                interruption_callback()
 
     def acquire(
-        self, request_id: str, device: str, interruption_callback: Callable[[], None] | None = None
+        self,
+        request_id: str,
+        device: str,
+        interruption_callback: Callable[[], None] | None = None,
+        wait_state_callback: Callable[[list[str]], None] | None = None,
     ) -> None:
         """
         Acquire the lock for a single device on behalf of a request.
@@ -60,28 +119,12 @@ class DeviceLockRegistry:
             interruption_callback (Callable[[], None] | None, optional):
                 callback invoked while waiting for the lock. Defaults to None.
         """
-        has_logged_wait = False
-        while True:
-            with self._condition:
-                current_owner = self._device_owners.get(device)
-                if current_owner in (None, request_id):
-                    self._device_owners[device] = request_id
-                    self._owner_devices[request_id].add(device)
-                    return
-
-                if not has_logged_wait:
-                    logger.info(
-                        "Request %s waiting for device lock on %s held by %s",
-                        request_id,
-                        device,
-                        current_owner,
-                    )
-                    has_logged_wait = True
-
-                self._condition.wait(timeout=self.WAIT_INTERVAL_S)
-
-            if interruption_callback is not None:
-                interruption_callback()
+        self.acquire_many(
+            request_id=request_id,
+            devices=[device],
+            interruption_callback=interruption_callback,
+            wait_state_callback=wait_state_callback,
+        )
 
     def release_all(self, request_id: str) -> list[str]:
         """
@@ -113,3 +156,17 @@ class DeviceLockRegistry:
         """
         with self._condition:
             return sorted(self._owner_devices.get(request_id, set()))
+
+    def _log_waiting_for_device_lock(
+        self, request_id: str, blocked_owners: dict[str, str], next_log_time: float
+    ) -> float:
+        now = time.monotonic()
+        if now < next_log_time:
+            return next_log_time
+
+        waiting_devices = ", ".join(sorted(blocked_owners))
+        owners = ", ".join(
+            f"{device} held by {owner}" for device, owner in sorted(blocked_owners.items())
+        )
+        logger.info(f"Request {request_id} waiting for device locks on {waiting_devices}; {owners}")
+        return now + self.WAIT_LOG_INTERVAL_S

--- a/bec_server/bec_server/scan_server/device_lock_registry.py
+++ b/bec_server/bec_server/scan_server/device_lock_registry.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import threading
+from collections import defaultdict
+from collections.abc import Callable, Iterable
+
+from bec_lib.logger import bec_logger
+
+logger = bec_logger.logger
+
+
+class DeviceLockRegistry:
+    """Registry that tracks per-request device locks for the scan server."""
+
+    WAIT_INTERVAL_S: float = 0.1
+
+    def __init__(self) -> None:
+        """Initialize the device lock registry."""
+        self._condition: threading.Condition = threading.Condition()
+        self._device_owners: dict[str, str] = {}
+        self._owner_devices: dict[str, set[str]] = defaultdict(set)
+
+    def acquire_many(
+        self,
+        request_id: str,
+        devices: Iterable[str],
+        interruption_callback: Callable[[], None] | None = None,
+    ) -> list[str]:
+        """
+        Acquire locks for multiple devices on behalf of a request.
+
+        Args:
+            request_id (str): request identifier that will own the device locks.
+            devices (Iterable[str]): device names to lock.
+            interruption_callback (Callable[[], None] | None, optional):
+                callback invoked while waiting for a lock, allowing the caller
+                to react to interruptions. Defaults to None.
+
+        Returns:
+            list[str]: sorted device names whose locks were acquired.
+        """
+        acquired: list[str] = []
+        for device in sorted(set(devices)):
+            self.acquire(request_id, device, interruption_callback=interruption_callback)
+            acquired.append(device)
+        return acquired
+
+    def acquire(
+        self, request_id: str, device: str, interruption_callback: Callable[[], None] | None = None
+    ) -> None:
+        """
+        Acquire the lock for a single device on behalf of a request.
+
+        If the device is already owned by another request, this call blocks
+        until the lock becomes available.
+
+        Args:
+            request_id (str): request identifier that will own the device lock.
+            device (str): device name to lock.
+            interruption_callback (Callable[[], None] | None, optional):
+                callback invoked while waiting for the lock. Defaults to None.
+        """
+        has_logged_wait = False
+        with self._condition:
+            while True:
+                current_owner = self._device_owners.get(device)
+                if current_owner in (None, request_id):
+                    self._device_owners[device] = request_id
+                    self._owner_devices[request_id].add(device)
+                    return
+
+                if not has_logged_wait:
+                    logger.info(
+                        "Request %s waiting for device lock on %s held by %s",
+                        request_id,
+                        device,
+                        current_owner,
+                    )
+                    has_logged_wait = True
+
+                self._condition.wait(timeout=self.WAIT_INTERVAL_S)
+
+                if interruption_callback is not None:
+                    interruption_callback()
+
+    def release_all(self, request_id: str) -> list[str]:
+        """
+        Release all device locks held by a request.
+
+        Args:
+            request_id (str): request identifier whose locks should be released.
+
+        Returns:
+            list[str]: sorted device names whose locks were released.
+        """
+        with self._condition:
+            devices = sorted(self._owner_devices.pop(request_id, set()))
+            for device in devices:
+                if self._device_owners.get(device) == request_id:
+                    self._device_owners.pop(device, None)
+            self._condition.notify_all()
+            return devices
+
+    def get_owned_devices(self, request_id: str) -> list[str]:
+        """
+        Get the devices currently locked by a request.
+
+        Args:
+            request_id (str): request identifier whose locked devices should be returned.
+
+        Returns:
+            list[str]: sorted device names currently owned by the request.
+        """
+        with self._condition:
+            return sorted(self._owner_devices.get(request_id, set()))

--- a/bec_server/bec_server/scan_server/device_lock_registry.py
+++ b/bec_server/bec_server/scan_server/device_lock_registry.py
@@ -19,15 +19,22 @@ class DeviceLockRegistry:
     def __init__(self) -> None:
         """Initialize the device lock registry."""
         self._condition: threading.Condition = threading.Condition()
+
+        # Maps device names to the request ID that currently owns the lock.
         self._device_owners: dict[str, str] = {}
+
+        # Maps request IDs to the set of device names they currently own.
         self._owner_devices: dict[str, set[str]] = defaultdict(set)
+
+        # Maps request IDs to the set of device names they are currently waiting for.
+        self._pending_device_locks: dict[str, set[str]] = defaultdict(set)
 
     def acquire_many(
         self,
         request_id: str,
         devices: Iterable[str],
         interruption_callback: Callable[[], None] | None = None,
-        wait_state_callback: Callable[[list[str]], None] | None = None,
+        queue_update_callback: Callable[[], None] | None = None,
     ) -> list[str]:
         """
         Acquire locks for multiple devices on behalf of a request.
@@ -38,6 +45,9 @@ class DeviceLockRegistry:
             interruption_callback (Callable[[], None] | None, optional):
                 callback invoked while waiting for a lock, allowing the caller
                 to react to interruptions. Defaults to None.
+            queue_update_callback (Callable[[], None] | None, optional):
+                callback invoked when queue-visible lock state changes, e.g.
+                owned or waiting devices. Defaults to None.
 
         Returns:
             list[str]: sorted device names whose locks were acquired.
@@ -46,13 +56,12 @@ class DeviceLockRegistry:
         if not device_names:
             return []
 
-        waiting_devices: list[str] = []
         next_log_time = 0.0
         while True:
             should_wait = False
-            should_broadcast = False
-            next_waiting_devices: list[str] = []
+            should_queue_update = False
             blocked_owners: dict[str, str] = {}
+            waiting_devices = sorted(self._pending_device_locks.get(request_id, set()))
 
             with self._condition:
                 acquirable_devices: list[str] = []
@@ -76,7 +85,7 @@ class DeviceLockRegistry:
                     self._device_owners[device] = request_id
                     self._owner_devices[request_id].add(device)
 
-                next_waiting_devices = blocked_devices
+                self._pending_device_locks[request_id] = set(blocked_devices)
                 if blocked_devices:
                     should_wait = True
                     next_log_time = self._log_waiting_for_device_lock(
@@ -86,13 +95,13 @@ class DeviceLockRegistry:
                     )
                     self._condition.wait(timeout=self.WAIT_INTERVAL_S)
 
-                should_broadcast = bool(acquirable_devices) or (
+                next_waiting_devices = sorted(self._pending_device_locks[request_id])
+                should_queue_update = bool(acquirable_devices) or (
                     next_waiting_devices != waiting_devices
                 )
 
-            if should_broadcast and wait_state_callback is not None:
-                wait_state_callback(next_waiting_devices.copy())
-            waiting_devices = next_waiting_devices
+            if should_queue_update and queue_update_callback is not None:
+                queue_update_callback()
 
             if not should_wait:
                 return device_names
@@ -105,7 +114,7 @@ class DeviceLockRegistry:
         request_id: str,
         device: str,
         interruption_callback: Callable[[], None] | None = None,
-        wait_state_callback: Callable[[list[str]], None] | None = None,
+        queue_update_callback: Callable[[], None] | None = None,
     ) -> None:
         """
         Acquire the lock for a single device on behalf of a request.
@@ -118,12 +127,14 @@ class DeviceLockRegistry:
             device (str): device name to lock.
             interruption_callback (Callable[[], None] | None, optional):
                 callback invoked while waiting for the lock. Defaults to None.
+            queue_update_callback (Callable[[], None] | None, optional):
+                callback invoked when queue-visible lock state changes. Defaults to None.
         """
         self.acquire_many(
             request_id=request_id,
             devices=[device],
             interruption_callback=interruption_callback,
-            wait_state_callback=wait_state_callback,
+            queue_update_callback=queue_update_callback,
         )
 
     def release_all(self, request_id: str) -> list[str]:
@@ -156,6 +167,16 @@ class DeviceLockRegistry:
         """
         with self._condition:
             return sorted(self._owner_devices.get(request_id, set()))
+
+    def get_pending_devices(self, request_id: str) -> list[str]:
+        """
+        Get the devices that a request is currently waiting to acquire.
+
+        Args:
+            request_id (str): request identifier whose pending devices should be returned.
+        """
+        with self._condition:
+            return sorted(self._pending_device_locks.get(request_id, set()))
 
     def _log_waiting_for_device_lock(
         self, request_id: str, blocked_owners: dict[str, str], next_log_time: float

--- a/bec_server/bec_server/scan_server/device_lock_registry.py
+++ b/bec_server/bec_server/scan_server/device_lock_registry.py
@@ -61,8 +61,8 @@ class DeviceLockRegistry:
                 callback invoked while waiting for the lock. Defaults to None.
         """
         has_logged_wait = False
-        with self._condition:
-            while True:
+        while True:
+            with self._condition:
                 current_owner = self._device_owners.get(device)
                 if current_owner in (None, request_id):
                     self._device_owners[device] = request_id
@@ -80,8 +80,8 @@ class DeviceLockRegistry:
 
                 self._condition.wait(timeout=self.WAIT_INTERVAL_S)
 
-                if interruption_callback is not None:
-                    interruption_callback()
+            if interruption_callback is not None:
+                interruption_callback()
 
     def release_all(self, request_id: str) -> list[str]:
         """

--- a/bec_server/bec_server/scan_server/direct_scan_worker.py
+++ b/bec_server/bec_server/scan_server/direct_scan_worker.py
@@ -192,6 +192,7 @@ class DirectScanWorker:
         Update the queue info for the current instruction queue item.
         This is used to propagate the queue status to the client during the scan execution.
         """
+        logger.info(f"Updating queue info")
         self.worker.current_instruction_queue_item.parent.queue_manager.send_queue_status()
 
     def _propagate_error(self, content: str, exc: Exception):

--- a/bec_server/bec_server/scan_server/direct_scan_worker.py
+++ b/bec_server/bec_server/scan_server/direct_scan_worker.py
@@ -81,6 +81,7 @@ class DirectScanWorker:
         queue = self.worker.current_instruction_queue_item
         try:
             with self.worker.device_manager._rpc_method(scan.actions.rpc_call):
+                scan.actions._initialize_scan()
                 for step in SCAN_SEQUENCE:
                     method = getattr(scan, step, None)
                     if not method:

--- a/bec_server/bec_server/scan_server/direct_scan_worker.py
+++ b/bec_server/bec_server/scan_server/direct_scan_worker.py
@@ -95,11 +95,26 @@ class DirectScanWorker:
             if not self._prepare_exception_cleanup(queue, exc):
                 return
             self._handle_exception(exc)
+        finally:
+            self._release_scan_locks(scan)
+
         if queue is None:
             return
+
         queue.status = InstructionQueueStatus.COMPLETED
         self.worker.current_instruction_queue_item = None
         self.reset()
+
+    def _release_scan_locks(self, scan: ScanBase | None) -> None:
+        if scan is None:
+            return
+        request_id = scan.scan_info.metadata.get("RID")
+        if request_id is None:
+            return
+        registry = getattr(self.worker.parent, "device_lock_registry", None)
+        if registry is None:
+            return
+        registry.release_all(request_id)
 
     def _prepare_exception_cleanup(
         self, queue: DirectInstructionQueueItem | None, exc: Exception
@@ -253,6 +268,7 @@ class DirectScanWorker:
             else:
                 self.scan.actions._send_scan_status("halted", reason=reason)
 
+        self._release_scan_locks(self.scan)
         queue.status = InstructionQueueStatus.STOPPED
         queue.append_to_queue_history()
         self.worker.parent.queue_manager.queues[self.worker.queue_name].abort()

--- a/bec_server/bec_server/scan_server/scan_assembler.py
+++ b/bec_server/bec_server/scan_server/scan_assembler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+from functools import partial
 from typing import TYPE_CHECKING
 
 from bec_lib import messages
@@ -129,18 +130,28 @@ class ScanAssembler:
             scan_cls, scan_info["signature"], resolved_args, resolved_kwargs
         )
 
-        scan_instance = scan_cls(
-            *resolved_args,
-            device_manager=self.device_manager,
-            redis_connector=self.connector,
-            scan_modifier=get_scan_modifier(),
-            metadata=msg.metadata,
-            instruction_handler=self.parent.queue_manager.instruction_handler,
-            scan_id=scan_id,
-            request_inputs=request_inputs,
-            **resolved_kwargs,
+        with self.device_manager._rpc_method(partial(self._raise_on_rpc_call, scan_cls)):
+            scan_instance = scan_cls(
+                *resolved_args,
+                device_manager=self.device_manager,
+                redis_connector=self.connector,
+                scan_modifier=get_scan_modifier(),
+                metadata=msg.metadata,
+                instruction_handler=self.parent.queue_manager.instruction_handler,
+                scan_id=scan_id,
+                request_inputs=request_inputs,
+                **resolved_kwargs,
+            )
+            return scan_instance
+
+    def _raise_on_rpc_call(self, scan_cls, device: str, func_call: str, *args, **kwargs):
+        # This function is used to raise an error if a runtime RPC call is made during scan initialization as it
+        # can lead to unpredictable behavior
+        raise RuntimeError(
+            f"The scan {scan_cls.__name__} attempted to make a runtime RPC call to `{func_call}` on device `{device}`. "
+            f"Please ensure that all runtime RPC calls are made within the scan's scan hooks and not during the scan's initialization."
+            f"If you want to set up a device before the scan starts, move the RPC call to the `prepare_scan` hook of the scan class."
         )
-        return scan_instance
 
     def _assemble_request_inputs(self, scan_cls, args, kwargs) -> dict:
         request_inputs = {}

--- a/bec_server/bec_server/scan_server/scan_queue.py
+++ b/bec_server/bec_server/scan_server/scan_queue.py
@@ -1200,7 +1200,21 @@ class RequestBlock:
             scan_number=self.scan_number,
             scan_id=self.scan_id,
             report_instructions=self.scan_report_instructions,
+            owned_device_locks=self._get_owned_device_locks(),
+            pending_device_locks=self._get_pending_device_locks(),
         )
+
+    def _get_owned_device_locks(self) -> list[str]:
+        # pylint: disable=protected-access
+        return self.parent.scan_queue.queue_manager._get_owned_devices_for_instruction_queue(
+            self.parent.instruction_queue
+        )
+
+    def _get_pending_device_locks(self) -> list[str]:
+        actions = getattr(self.scan, "actions", None)
+        if actions is None:
+            return []
+        return actions.get_pending_device_locks()
 
 
 class RequestBlockQueue:
@@ -1696,6 +1710,10 @@ class DirectInstructionQueueItem:
             scan_number=self._get_scan_number(scan),
             scan_id=scan.scan_info.scan_id,
             report_instructions=scan.scan_info.scan_report_instructions,
+            owned_device_locks=self.parent.queue_manager._get_owned_devices_for_instruction_queue(
+                self
+            ),
+            pending_device_locks=scan.actions.get_pending_device_locks(),
         )
 
     @property

--- a/bec_server/bec_server/scan_server/scan_queue.py
+++ b/bec_server/bec_server/scan_server/scan_queue.py
@@ -264,17 +264,20 @@ class QueueManager:
                 return instruction_queue
         return None
 
-    def stop_all_devices(self, stop_id: str | list[str] | None = None):
+    def stop_all_devices(
+        self, stop_id: str | list[str] | None = None, devices: list[str] | None = None
+    ):
         """
-        Send a message to the device server to stop all devices.
+        Send a message to the device server to stop devices.
         Args:
             stop_id (str | None): An optional identifier for the stop request.
                 If provided, this ID will be added to the list of stopped requests in the device server to
                 prevent any instructions associated with this ID raising alarms after the stop command is issued.
                 The stop_id can be a scan ID, request ID, or queue ID.
+            devices (list[str] | None): Optional list of devices to stop. If None, all devices are stopped.
         """
         # We send an empty list to indicate that all devices should be stopped
-        msg = messages.VariableMessage(value=[], metadata={})
+        msg = messages.VariableMessage(value=devices or [], metadata={})
         if stop_id is not None:
             msg.metadata["stop_id"] = stop_id
         self.connector.send(MessageEndpoints.stop_devices(), msg)
@@ -417,7 +420,10 @@ class QueueManager:
                 stop_id = instruction_queue.queue_id
             else:
                 stop_id = instruction_queue.scan_id
-            self.stop_all_devices(stop_id=stop_id)
+            self.stop_all_devices(
+                stop_id=stop_id,
+                devices=self._get_owned_devices_for_instruction_queue(instruction_queue),
+            )
 
     def _cancel_queue_item(
         self, target_queue_item: InstructionQueueItem | DirectInstructionQueueItem, queue: str
@@ -621,6 +627,24 @@ class QueueManager:
                 return None
             return instr_queue.active_scan.scan_info.scan_id
         return instr_queue.active_request_block.scan_id
+
+    def _get_owned_devices_for_instruction_queue(
+        self, instruction_queue: InstructionQueueItem | DirectInstructionQueueItem
+    ) -> list[str]:
+        registry = getattr(self.parent, "device_lock_registry", None)
+        if registry is None:
+            return []
+        if isinstance(instruction_queue, DirectInstructionQueueItem):
+            if instruction_queue.active_scan is None:
+                return []
+            request_id = instruction_queue.active_scan.scan_info.metadata.get("RID")
+        else:
+            if instruction_queue.active_request_block is None:
+                return []
+            request_id = instruction_queue.active_request_block.RID
+        if request_id is None:
+            return []
+        return registry.get_owned_devices(request_id)
 
     def _wait_for_queue_to_appear_in_history(
         self, scan_id, queue, timeout=60

--- a/bec_server/bec_server/scan_server/scan_queue.py
+++ b/bec_server/bec_server/scan_server/scan_queue.py
@@ -1200,21 +1200,9 @@ class RequestBlock:
             scan_number=self.scan_number,
             scan_id=self.scan_id,
             report_instructions=self.scan_report_instructions,
-            owned_device_locks=self._get_owned_device_locks(),
-            pending_device_locks=self._get_pending_device_locks(),
+            owned_device_locks=[],
+            pending_device_locks=[],
         )
-
-    def _get_owned_device_locks(self) -> list[str]:
-        # pylint: disable=protected-access
-        return self.parent.scan_queue.queue_manager._get_owned_devices_for_instruction_queue(
-            self.parent.instruction_queue
-        )
-
-    def _get_pending_device_locks(self) -> list[str]:
-        actions = getattr(self.scan, "actions", None)
-        if actions is None:
-            return []
-        return actions.get_pending_device_locks()
 
 
 class RequestBlockQueue:
@@ -1710,9 +1698,7 @@ class DirectInstructionQueueItem:
             scan_number=self._get_scan_number(scan),
             scan_id=scan.scan_info.scan_id,
             report_instructions=scan.scan_info.scan_report_instructions,
-            owned_device_locks=self.parent.queue_manager._get_owned_devices_for_instruction_queue(
-                self
-            ),
+            owned_device_locks=scan.actions.get_owned_device_locks(),
             pending_device_locks=scan.actions.get_pending_device_locks(),
         )
 

--- a/bec_server/bec_server/scan_server/scan_queue.py
+++ b/bec_server/bec_server/scan_server/scan_queue.py
@@ -630,21 +630,24 @@ class QueueManager:
 
     def _get_owned_devices_for_instruction_queue(
         self, instruction_queue: InstructionQueueItem | DirectInstructionQueueItem
-    ) -> list[str]:
+    ) -> list[str] | None:
         registry = getattr(self.parent, "device_lock_registry", None)
         if registry is None:
-            return []
+            return None if isinstance(instruction_queue, InstructionQueueItem) else []
         if isinstance(instruction_queue, DirectInstructionQueueItem):
             if instruction_queue.active_scan is None:
                 return []
             request_id = instruction_queue.active_scan.scan_info.metadata.get("RID")
         else:
             if instruction_queue.active_request_block is None:
-                return []
+                return None
             request_id = instruction_queue.active_request_block.RID
         if request_id is None:
-            return []
-        return registry.get_owned_devices(request_id)
+            return None if isinstance(instruction_queue, InstructionQueueItem) else []
+        devices = registry.get_owned_devices(request_id)
+        if isinstance(instruction_queue, InstructionQueueItem) and not devices:
+            return None
+        return devices
 
     def _wait_for_queue_to_appear_in_history(
         self, scan_id, queue, timeout=60

--- a/bec_server/bec_server/scan_server/scan_queue.py
+++ b/bec_server/bec_server/scan_server/scan_queue.py
@@ -274,10 +274,10 @@ class QueueManager:
                 If provided, this ID will be added to the list of stopped requests in the device server to
                 prevent any instructions associated with this ID raising alarms after the stop command is issued.
                 The stop_id can be a scan ID, request ID, or queue ID.
-            devices (list[str] | None): Optional list of devices to stop. If None, all devices are stopped.
+            devices (list[str] | None): Optional list of devices to stop.
+                `None` means stop all devices, while an empty list means stop no devices.
         """
-        # We send an empty list to indicate that all devices should be stopped
-        msg = messages.VariableMessage(value=devices or [], metadata={})
+        msg = messages.VariableMessage(value=devices, metadata={})
         if stop_id is not None:
             msg.metadata["stop_id"] = stop_id
         self.connector.send(MessageEndpoints.stop_devices(), msg)

--- a/bec_server/bec_server/scan_server/scan_server.py
+++ b/bec_server/bec_server/scan_server/scan_server.py
@@ -18,6 +18,7 @@ from bec_server.procedures.manager import ProcedureManager
 from bec_server.procedures.subprocess_worker import SubProcessWorker
 
 from .beamline_state_manager import BeamlineStateManager
+from .device_lock_registry import DeviceLockRegistry
 from .scan_assembler import ScanAssembler
 from .scan_guard import ScanGuard
 from .scan_manager import ScanManager
@@ -32,6 +33,7 @@ logger = bec_logger.logger
 class ScanServer(BECService):
     def __init__(self, config: ServiceConfig, connector_cls: type[RedisConnector]):
         super().__init__(config, connector_cls, unique_service=True)
+        self.device_lock_registry = DeviceLockRegistry()
         self._start_scan_manager()
         self._start_device_manager()
         self._start_queue_manager()

--- a/bec_server/bec_server/scan_server/scans/legacy_scans.py
+++ b/bec_server/bec_server/scan_server/scans/legacy_scans.py
@@ -256,6 +256,7 @@ class RequestBase(ABC):
         *args,
         device_manager: DeviceManagerBase = None,
         monitored: list = None,
+        on_request: list = None,
         parameter: dict = None,
         metadata: dict = None,
         instruction_handler: InstructionHandler = None,
@@ -283,7 +284,7 @@ class RequestBase(ABC):
         self.readout_priority = {
             "monitored": monitored if monitored is not None else [],
             "baseline": [],
-            "on_request": [],
+            "on_request": on_request if on_request is not None else [],
             "async": [],
         }
         self.update_readout_priority()

--- a/bec_server/bec_server/scan_server/scans/move.py
+++ b/bec_server/bec_server/scan_server/scans/move.py
@@ -71,6 +71,8 @@ class MoveScan(ScanBase):
         self.motors = list(self.motor_args_bundles.keys())
         self.relative = relative
 
+        self.actions.acquire_device_lock(self.motors)
+
         # Update the default scan info with provided parameters.
         self.update_scan_info(relative=relative, scan_report_devices=self.motors)
 

--- a/bec_server/bec_server/scan_server/scans/scan_actions.py
+++ b/bec_server/bec_server/scan_server/scans/scan_actions.py
@@ -46,6 +46,9 @@ class ScanActions:
         self._devices_with_required_response = set()
         self._readout_groups_read = False
         self._metadata_suffix = ""
+        self._pending_device_locks: set[str] = set()
+        self._waiting_device_locks: set[str] = set()
+        self._scan_running = False
 
     @property
     def readout_priority(self) -> dict:
@@ -56,7 +59,6 @@ class ScanActions:
         Open the scan.
         We fetch all relevant metadata from the scan object and emit a new scan status.
         """
-        self._acquire_initial_device_locks()
         self._send_scan_status("open")
 
     def stage_all_devices(
@@ -159,7 +161,7 @@ class ScanActions:
 
         # We support str and DeviceBase inputs as well as lists of those.
         # We convert them to a list of device names for easier processing.
-        device_names = self._normalize_device_names(device)
+        device_names = self._normalize_to_root_device_names(device)
         if len(device_names) == 1:
             device_names = device_names[0]
         status = self._create_status(name=status_name or f"stage_{device_names}")
@@ -636,7 +638,7 @@ class ScanActions:
         Returns:
             ScanStubStatus: status object to track the unstaging process
         """
-        device_name = self._normalize_device_name(device)
+        device_name = self._normalize_to_root_device_name(device)
         status = self._create_status(name=f"unstage_{device_name}")
 
         instr = messages.DeviceInstructionMessage(
@@ -948,13 +950,16 @@ class ScanActions:
         request_id = self._scan.scan_info.metadata.get("RID")
         if registry is None or request_id is None:
             return []
-        if isinstance(device, Iterable) and not isinstance(device, (str, DeviceBase)):
-            device_names = self._normalize_device_names(list(device))
-        else:
-            device_names = self._normalize_device_names(device)
+        device_names = self._normalize_to_root_device_names(device)
         device_names = sorted(set(device_names))
+        if not self._scan_running:
+            self._pending_device_locks.update(device_names)
+            return device_names
         return registry.acquire_many(
-            request_id, devices=device_names, interruption_callback=self._interruption_callback
+            request_id,
+            devices=device_names,
+            interruption_callback=self._interruption_callback,
+            wait_state_callback=self._set_device_lock_wait_state,
         )
 
     def release_device_lock(self) -> list[str]:
@@ -1076,6 +1081,28 @@ class ScanActions:
             devices = [devices]
         return [ScanActions._normalize_device_name(dev) for dev in devices]
 
+    @staticmethod
+    def _normalize_to_root_device_name(device: str | DeviceBase) -> str:
+        """
+        Normalize a device lock target to the root device name.
+
+        Device locks are tracked at the root-device level so that sub-devices
+        of the same hardware share one lock.
+        """
+        if isinstance(device, DeviceBase):
+            return device.root.name
+        return device
+
+    @staticmethod
+    def _normalize_to_root_device_names(
+        devices: str | DeviceBase | Iterable[str | DeviceBase],
+    ) -> list[str]:
+        if isinstance(devices, Iterable) and not isinstance(devices, (str, DeviceBase)):
+            devices = list(devices)
+        else:
+            devices = [devices]
+        return [ScanActions._normalize_to_root_device_name(dev) for dev in devices]
+
     def _acquire_initial_device_locks(self) -> None:
         """
         Acquire the device locks for all devices that are on readout priority
@@ -1107,6 +1134,62 @@ class ScanActions:
         self.acquire_device_lock(
             monitored_claimable | async_claimable | pinned_devices | software_triggered_devices
         )
+
+    def _initialize_scan(self) -> list[str]:
+        """
+        Initialize worker-managed scan state before the scan lifecycle starts.
+
+        This helper is intentionally private and should not be called manually
+        from scan implementations. The direct scan worker is responsible for
+        invoking it exactly once before running the scan sequence.
+
+        Returns:
+            list[str]: device names acquired from the pending lock set.
+        """
+        self._acquire_initial_device_locks()
+        acquired = self._flush_pending_device_locks()
+        self._scan_running = True
+        return acquired
+
+    def _flush_pending_device_locks(self) -> list[str]:
+        """
+        Acquire all device locks that were buffered before the scan was initialized.
+
+        Returns:
+            list[str]: device names acquired from the pending lock set.
+        """
+        registry = getattr(self._device_manager.parent, "device_lock_registry", None)
+        request_id = self._scan.scan_info.metadata.get("RID")
+        if registry is None or request_id is None or not self._pending_device_locks:
+            return []
+
+        device_names = sorted(self._pending_device_locks)
+        acquired = registry.acquire_many(
+            request_id, devices=device_names, interruption_callback=self._interruption_callback
+        )
+        self._pending_device_locks.difference_update(device_names)
+        return acquired
+
+    def get_pending_device_locks(self) -> list[str]:
+        """Return device locks this scan is actively waiting to acquire."""
+        return sorted(self._waiting_device_locks)
+
+    def get_queued_device_locks(self) -> list[str]:
+        """Return device locks buffered before scan initialization acquires them."""
+        return sorted(self._pending_device_locks)
+
+    def _set_device_lock_wait_state(self, waiting_devices: list[str]) -> None:
+        """
+        Update the set of device locks this scan is actively waiting to acquire.
+
+        Args:
+            waiting_devices (list[str]): The list of device names this scan is waiting for.
+        """
+        new_waiting_devices = set(waiting_devices)
+        updated = new_waiting_devices != self._waiting_device_locks
+        self._waiting_device_locks = new_waiting_devices
+        if updated and self._update_queue_info_callback is not None:
+            self._update_queue_info_callback()
 
     @staticmethod
     def _device_ownership_mode(device: DeviceBase) -> str:

--- a/bec_server/bec_server/scan_server/scans/scan_actions.py
+++ b/bec_server/bec_server/scan_server/scans/scan_actions.py
@@ -1173,8 +1173,15 @@ class ScanActions:
         software_triggered_devices = {
             dev.root.name for dev in self._device_manager.devices.get_software_triggered_devices()
         }
+        on_request_devices = {
+            dev.root.name
+            for dev in self._device_manager.devices.on_request_devices(
+                readout_priority=self.readout_priority
+            )
+        }
         self.acquire_device_lock(
-            monitored_claimable | async_claimable | pinned_devices | software_triggered_devices
+            (monitored_claimable | async_claimable | pinned_devices | software_triggered_devices)
+            - on_request_devices
         )
 
     def _initialize_scan(self) -> list[str]:

--- a/bec_server/bec_server/scan_server/scans/scan_actions.py
+++ b/bec_server/bec_server/scan_server/scans/scan_actions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import time
 import uuid
+from collections.abc import Iterable
 from string import Template
 from typing import TYPE_CHECKING, Any, Callable, Literal, TypeAlias
 
@@ -55,6 +56,7 @@ class ScanActions:
         Open the scan.
         We fetch all relevant metadata from the scan object and emit a new scan status.
         """
+        self._acquire_initial_device_locks()
         self._send_scan_status("open")
 
     def stage_all_devices(
@@ -78,6 +80,7 @@ class ScanActions:
             ScanStubStatus: status object to track the staging process
         """
         status = self._create_status(is_container=True, name="stage_all_devices")
+        owned_device_names = self._get_owned_device_names()
 
         # We separate the staging of async devices and regular devices to optimize the staging process.
         # Async devices are typically slower to stage and should be staged in parallel.
@@ -106,7 +109,10 @@ class ScanActions:
         if async_devices:
             async_devices = sorted(async_devices, key=lambda x: x.name)
             async_devices = [
-                device for device in async_devices if device.name not in user_excluded_device_names
+                device
+                for device in async_devices
+                if device.name not in user_excluded_device_names
+                and device.root.name in owned_device_names
             ]
 
         for det in async_devices:
@@ -118,7 +124,7 @@ class ScanActions:
         stage_device_names_without_async = [
             dev.root.name
             for dev in self._device_manager.devices.enabled_devices
-            if dev.name not in excluded_device_names
+            if dev.name not in excluded_device_names and dev.root.name in owned_device_names
         ]
 
         if stage_device_names_without_async:
@@ -162,6 +168,7 @@ class ScanActions:
         if len(device_names) == 0:
             status.set_done()
             return status
+        self.acquire_device_lock(device_names)
 
         instr = messages.DeviceInstructionMessage(
             device=device_names,
@@ -202,6 +209,7 @@ class ScanActions:
         if len(device_names) == 0:
             status.set_done()
             return status
+        self.acquire_device_lock(device_names)
 
         instr = messages.DeviceInstructionMessage(
             device=device_names,
@@ -234,8 +242,13 @@ class ScanActions:
             ScanStubStatus: status object to track the pre-scan process
         """
         status = self._create_status(name="pre_scan_all_devices")
+        owned_device_names = self._get_owned_device_names()
 
-        devices = [dev.root.name for dev in self._device_manager.devices.enabled_devices]
+        devices = [
+            dev.root.name
+            for dev in self._device_manager.devices.enabled_devices
+            if dev.root.name in owned_device_names
+        ]
         if exclude is not None:
             excluded_device_names = set(self._normalize_device_names(exclude))
             devices = [
@@ -279,6 +292,7 @@ class ScanActions:
 
         if len(devices) != len(values):
             raise ValueError("The number of devices and values must match.")
+        self.acquire_device_lock(devices)
 
         status = self._create_status(is_container=True, name="set")
         for dev, val in zip(devices, values, strict=False):
@@ -313,6 +327,7 @@ class ScanActions:
             ScanStubStatus: status object to track the kickoff process
         """
         device_name = self._normalize_device_name(device)
+        self.acquire_device_lock(device_name)
         status = self._create_status(name=f"kickoff_{device_name}")
 
         instr = messages.DeviceInstructionMessage(
@@ -340,6 +355,7 @@ class ScanActions:
             ScanStubStatus: status object to track the completion process
         """
         device_name = self._normalize_device_name(device)
+        self.acquire_device_lock(device_name)
         status = self._create_status(name=f"complete_{device_name}")
 
         instr = messages.DeviceInstructionMessage(
@@ -371,7 +387,12 @@ class ScanActions:
             ScanStubStatus: status object to track the completion process
         """
         status = self._create_status(name="complete_all_devices")
-        device_names = [dev.root.name for dev in self._device_manager.devices.enabled_devices]
+        owned_device_names = self._get_owned_device_names()
+        device_names = [
+            dev.root.name
+            for dev in self._device_manager.devices.enabled_devices
+            if dev.root.name in owned_device_names
+        ]
         if exclude is not None:
             excluded_device_names = set(self._normalize_device_names(exclude))
             device_names = [
@@ -577,8 +598,11 @@ class ScanActions:
             wait (bool, optional): if True, wait for the trigger to complete. Defaults to True.
         """
         status = self._create_status(name="trigger_all_devices")
+        owned_device_names = self._get_owned_device_names()
         devices = [
-            dev.root.name for dev in self._device_manager.devices.get_software_triggered_devices()
+            dev.root.name
+            for dev in self._device_manager.devices.get_software_triggered_devices()
+            if dev.root.name in owned_device_names
         ]
         if not devices:
             status.set_done()
@@ -639,9 +663,13 @@ class ScanActions:
             exclude (str | DeviceBase | list[str | DeviceBase] | None, optional):
                 device(s) to exclude from unstaging. Defaults to None.
         """
-
         status = self._create_status(name="unstage_all_devices")
-        staged_devices = [dev.root.name for dev in self._device_manager.devices.enabled_devices]
+        owned_device_names = self._get_owned_device_names()
+        staged_devices = [
+            dev.root.name
+            for dev in self._device_manager.devices.enabled_devices
+            if dev.root.name in owned_device_names
+        ]
         if exclude is not None:
             excluded_device_names = set(self._normalize_device_names(exclude))
             staged_devices = [
@@ -683,6 +711,7 @@ class ScanActions:
         scan_report_instruction = {
             "readback": {"RID": request_id, "devices": device_names, "start": start, "end": stop}
         }
+        self.acquire_device_lock(device_names)
         self.add_device_with_required_response(device_names)
         self._scan.scan_info.scan_report_instructions.append(scan_report_instruction)
         if self._update_queue_info_callback is not None:
@@ -698,6 +727,7 @@ class ScanActions:
             device (str | DeviceBase): name of the device or DeviceBase instance to report
         """
         device_name = self._normalize_device_name(device)
+        self.acquire_device_lock(device_name)
         scan_report_instruction = {"device_progress": [device_name]}
         self._scan.scan_info.scan_report_instructions.append(scan_report_instruction)
         if self._update_queue_info_callback is not None:
@@ -749,6 +779,8 @@ class ScanActions:
 
         if not isinstance(devices, list):
             devices = [devices]
+
+        self.acquire_device_lock(devices)
 
         for device in devices:
             device_name = self._normalize_device_name(device)
@@ -852,6 +884,7 @@ class ScanActions:
             Any | ScanStubStatus: The result of the RPC call or a ScanStubStatus object if the result is a status object.
 
         """
+        self.acquire_device_lock(device)
         rpc_id = str(uuid.uuid4())
         status = self.rpc_call_no_wait(device, func_name, rpc_id, *args, **kwargs)
         status.wait(resolve_on_known_type=True)
@@ -895,6 +928,47 @@ class ScanActions:
         )
         self._send(msg)
         return status
+
+    def acquire_device_lock(
+        self, device: str | DeviceBase | Iterable[str | DeviceBase]
+    ) -> list[str]:
+        """
+        Acquire the lock for one or multiple devices for the current request.
+        A device lock is a mechanism to prevent multiple scans from using the same device at the same time.
+        If a device is already locked by another request, the current request will wait until the lock
+        is released.
+
+        Args:
+            device (str | DeviceBase | Iterable[str | DeviceBase]): device(s) to lock
+
+        Returns:
+            list[str]: acquired device names
+        """
+        registry = getattr(self._device_manager.parent, "device_lock_registry", None)
+        request_id = self._scan.scan_info.metadata.get("RID")
+        if registry is None or request_id is None:
+            return []
+        if isinstance(device, Iterable) and not isinstance(device, (str, DeviceBase)):
+            device_names = self._normalize_device_names(list(device))
+        else:
+            device_names = self._normalize_device_names(device)
+        device_names = sorted(set(device_names))
+        return registry.acquire_many(
+            request_id, devices=device_names, interruption_callback=self._interruption_callback
+        )
+
+    def release_device_lock(self) -> list[str]:
+        """
+        Release all device locks held by the current request.
+
+        Returns:
+            list[str]: released device names
+        """
+        registry = getattr(self._device_manager.parent, "device_lock_registry", None)
+        request_id = self._scan.scan_info.metadata.get("RID")
+        if registry is None or request_id is None:
+            return []
+        return registry.release_all(request_id)
 
     def send_client_info(self, message: str):
         """
@@ -1002,6 +1076,42 @@ class ScanActions:
             devices = [devices]
         return [ScanActions._normalize_device_name(dev) for dev in devices]
 
+    def _acquire_initial_device_locks(self) -> None:
+        """
+        Acquire the device locks for all devices that are on readout priority
+        "monitored" or "async" and have ownership mode "claimable", as well as all devices that are
+        have ownership mode "pinned", and all devices that are software triggered.
+        """
+        monitored_claimable = {
+            dev.root.name
+            for dev in self._device_manager.devices.monitored_devices(
+                readout_priority=self.readout_priority
+            )
+            if self._device_ownership_mode(dev) == "claimable"
+        }
+        async_claimable = {
+            dev.root.name
+            for dev in self._device_manager.devices.async_devices(
+                readout_priority=self.readout_priority
+            )
+            if self._device_ownership_mode(dev) == "claimable"
+        }
+        pinned_devices = {
+            dev.root.name
+            for dev in self._device_manager.devices.enabled_devices
+            if self._device_ownership_mode(dev) == "pinned"
+        }
+        software_triggered_devices = {
+            dev.root.name for dev in self._device_manager.devices.get_software_triggered_devices()
+        }
+        self.acquire_device_lock(
+            monitored_claimable | async_claimable | pinned_devices | software_triggered_devices
+        )
+
+    @staticmethod
+    def _device_ownership_mode(device: DeviceBase) -> str:
+        return device.root._info.get("ownership_mode", "claimable")
+
     def _get_monitored_device_names(self) -> list[str]:
         monitored_devices = [
             _dev.root.name
@@ -1010,6 +1120,13 @@ class ScanActions:
             )
         ]
         return sorted(monitored_devices)
+
+    def _get_owned_device_names(self) -> set[str]:
+        registry = getattr(self._device_manager.parent, "device_lock_registry", None)
+        request_id = self._scan.scan_info.metadata.get("RID")
+        if registry is None or request_id is None:
+            return set()
+        return set(registry.get_owned_devices(request_id))
 
     @staticmethod
     def _normalize_manual_readings(

--- a/bec_server/bec_server/scan_server/scans/scan_actions.py
+++ b/bec_server/bec_server/scan_server/scans/scan_actions.py
@@ -1147,6 +1147,10 @@ class ScanActions:
         "monitored" or "async" and have ownership mode "claimable", as well as all devices that are
         have ownership mode "pinned", and all devices that are software triggered.
         """
+        if not self._scan.is_scan:
+            # If this is not a scan, we don't need to acquire any device locks
+            # apart from the devices that are explicitly requested by the scan definition.
+            return
         monitored_claimable = {
             dev.root.name
             for dev in self._device_manager.devices.monitored_devices(

--- a/bec_server/bec_server/scan_server/scans/scan_actions.py
+++ b/bec_server/bec_server/scan_server/scans/scan_actions.py
@@ -652,7 +652,7 @@ class ScanActions:
         )
         self._send(instr)
         if min_wait is not None:
-            time.sleep(min_wait)
+            self._shutdown_event.wait(min_wait)
         if wait:
             status.wait()
         return status

--- a/bec_server/bec_server/scan_server/scans/scan_actions.py
+++ b/bec_server/bec_server/scan_server/scans/scan_actions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import os
 import time
 import uuid
@@ -28,6 +29,25 @@ logger = bec_logger.logger
 ReadoutPriorityMap: TypeAlias = dict[
     Literal["monitored", "baseline", "async", "continuous", "on_request"], list[str]
 ]
+
+
+def requires_scan_is_running(method):
+    """
+    Guard ``ScanActions`` methods that require the scan to be running.
+    This is mainly to avoid runtime changes to devices just by enqueuing
+    a scan message, which could lead to unexpected behavior and difficult-to-debug issues.
+    """
+
+    @functools.wraps(method)
+    def wrapper(self: ScanActions, *args, **kwargs):
+        if not self._scan_running:
+            raise RuntimeError(
+                f"{method.__name__} can only be used once the scan is running. "
+                "Any setup or configuration should be done in the scan's prepare_scan method."
+            )
+        return method(self, *args, **kwargs)
+
+    return wrapper
 
 
 class ScanActions:
@@ -61,6 +81,7 @@ class ScanActions:
         """
         self._send_scan_status("open")
 
+    @requires_scan_is_running
     def stage_all_devices(
         self, wait=True, exclude: str | DeviceBase | list[str | DeviceBase] | None = None
     ) -> ScanStubStatus:
@@ -138,6 +159,7 @@ class ScanActions:
             status.wait()
         return status
 
+    @requires_scan_is_running
     def stage(
         self,
         device: str | DeviceBase | list[str | DeviceBase],
@@ -183,6 +205,7 @@ class ScanActions:
             status.wait()
         return status
 
+    @requires_scan_is_running
     def pre_scan(
         self,
         device: str | DeviceBase | list[str | DeviceBase],
@@ -224,6 +247,7 @@ class ScanActions:
             status.wait()
         return status
 
+    @requires_scan_is_running
     def pre_scan_all_devices(
         self, wait=True, exclude: str | DeviceBase | list[str | DeviceBase] | None = None
     ) -> ScanStubStatus:
@@ -270,6 +294,7 @@ class ScanActions:
             status.wait()
         return status
 
+    @requires_scan_is_running
     def set(
         self,
         device: str | DeviceBase | list[str | DeviceBase] | list[str] | list[DeviceBase],
@@ -313,6 +338,7 @@ class ScanActions:
             status.wait()
         return status
 
+    @requires_scan_is_running
     def kickoff(
         self, device: str | DeviceBase, parameters: dict | None = None, wait=True
     ) -> ScanStubStatus:
@@ -343,6 +369,7 @@ class ScanActions:
             status.wait()
         return status
 
+    @requires_scan_is_running
     def complete(self, device: str | DeviceBase, wait=True) -> ScanStubStatus:
         """
         Complete a device. This will call the "complete" method on the device.
@@ -371,6 +398,7 @@ class ScanActions:
             status.wait()
         return status
 
+    @requires_scan_is_running
     def complete_all_devices(
         self, wait=True, exclude: str | DeviceBase | list[str | DeviceBase] | None = None
     ) -> ScanStubStatus:
@@ -413,6 +441,7 @@ class ScanActions:
             status.wait()
         return status
 
+    @requires_scan_is_running
     def read_monitored_devices(self, wait=True) -> ScanStubStatus:
         """
         Read from the monitored devices. This will call the "read" method on
@@ -456,6 +485,7 @@ class ScanActions:
             status.wait()
         return status
 
+    @requires_scan_is_running
     def read_manually(
         self, devices: str | DeviceBase | list[str | DeviceBase], wait=True
     ) -> Any | ScanStubStatus:
@@ -500,6 +530,7 @@ class ScanActions:
         status.wait()
         return status.result
 
+    @requires_scan_is_running
     def publish_manual_read(
         self, readings: dict[str, dict] | list[dict], wait=True
     ) -> ScanStubStatus:
@@ -550,6 +581,7 @@ class ScanActions:
         status.set_done_checked()
         return status
 
+    @requires_scan_is_running
     def read_baseline_devices(self, wait=True) -> ScanStubStatus:
         """
         Read from the baseline devices. This will call the "read" method on all devices
@@ -589,6 +621,7 @@ class ScanActions:
             status.wait()
         return status
 
+    @requires_scan_is_running
     def trigger_all_devices(self, min_wait: float | None = None, wait=True) -> ScanStubStatus:
         """
         Trigger all devices for the scan. The list of devices to trigger is determined automatically
@@ -625,6 +658,7 @@ class ScanActions:
             status.wait()
         return status
 
+    @requires_scan_is_running
     def unstage(self, device: str | DeviceBase, wait=True) -> ScanStubStatus:
         """
         Unstage a device for the scan. This will call the "unstage" method on the specified device(s).
@@ -652,6 +686,7 @@ class ScanActions:
             status.wait()
         return status
 
+    @requires_scan_is_running
     def unstage_all_devices(
         self, wait=True, exclude: str | DeviceBase | list[str | DeviceBase] | None = None
     ) -> ScanStubStatus:
@@ -788,6 +823,7 @@ class ScanActions:
             device_name = self._normalize_device_name(device)
             self._scan.scan_info.readout_priority_modification[priority].append(device_name)
 
+    @requires_scan_is_running
     def close_scan(self):
         """Close the scan."""
         # We set the number of monitored readouts to the actual number of monitored
@@ -799,6 +835,7 @@ class ScanActions:
 
         self._send_scan_status("closed")
 
+    @requires_scan_is_running
     def check_for_unchecked_statuses(self):
         """
         Check if there are any unchecked status objects left.
@@ -860,6 +897,7 @@ class ScanActions:
             device_name = self._normalize_device_name(device)
             self._devices_with_required_response.add(device_name)
 
+    @requires_scan_is_running
     def rpc_call(
         self, device: str | DeviceBase, func_name: str, *args, **kwargs
     ) -> Any | ScanStubStatus:
@@ -894,6 +932,7 @@ class ScanActions:
             return status
         return status.result
 
+    @requires_scan_is_running
     def rpc_call_no_wait(
         self, device: str | DeviceBase, func_name: str, rpc_id: str, *args, **kwargs
     ) -> ScanStubStatus:
@@ -975,6 +1014,7 @@ class ScanActions:
             return []
         return registry.release_all(request_id)
 
+    @requires_scan_is_running
     def send_client_info(self, message: str):
         """
         Emit a new client info message.

--- a/bec_server/bec_server/scan_server/scans/scan_actions.py
+++ b/bec_server/bec_server/scan_server/scans/scan_actions.py
@@ -66,8 +66,7 @@ class ScanActions:
         self._devices_with_required_response = set()
         self._readout_groups_read = False
         self._metadata_suffix = ""
-        self._pending_device_locks: set[str] = set()
-        self._waiting_device_locks: set[str] = set()
+        self._queued_device_locks: set[str] = set()
         self._scan_running = False
 
     @property
@@ -992,13 +991,13 @@ class ScanActions:
         device_names = self._normalize_to_root_device_names(device)
         device_names = sorted(set(device_names))
         if not self._scan_running:
-            self._pending_device_locks.update(device_names)
+            self._queued_device_locks.update(device_names)
             return device_names
         return registry.acquire_many(
             request_id,
             devices=device_names,
             interruption_callback=self._interruption_callback,
-            wait_state_callback=self._set_device_lock_wait_state,
+            queue_update_callback=self._update_queue_info_callback,
         )
 
     def release_device_lock(self) -> list[str]:
@@ -1014,7 +1013,6 @@ class ScanActions:
             return []
         return registry.release_all(request_id)
 
-    @requires_scan_is_running
     def send_client_info(self, message: str):
         """
         Emit a new client info message.
@@ -1187,49 +1185,51 @@ class ScanActions:
             list[str]: device names acquired from the pending lock set.
         """
         self._acquire_initial_device_locks()
-        acquired = self._flush_pending_device_locks()
+        acquired = self._flush_queued_device_locks()
         self._scan_running = True
         return acquired
 
-    def _flush_pending_device_locks(self) -> list[str]:
+    def _flush_queued_device_locks(self) -> list[str]:
         """
         Acquire all device locks that were buffered before the scan was initialized.
 
         Returns:
-            list[str]: device names acquired from the pending lock set.
+            list[str]: device names acquired from the queued lock set.
         """
         registry = getattr(self._device_manager.parent, "device_lock_registry", None)
         request_id = self._scan.scan_info.metadata.get("RID")
-        if registry is None or request_id is None or not self._pending_device_locks:
+        if registry is None or request_id is None or not self._queued_device_locks:
             return []
 
-        device_names = sorted(self._pending_device_locks)
+        device_names = sorted(self._queued_device_locks)
         acquired = registry.acquire_many(
-            request_id, devices=device_names, interruption_callback=self._interruption_callback
+            request_id,
+            devices=device_names,
+            interruption_callback=self._interruption_callback,
+            queue_update_callback=self._update_queue_info_callback,
         )
-        self._pending_device_locks.difference_update(device_names)
+        self._queued_device_locks.difference_update(device_names)
         return acquired
 
     def get_pending_device_locks(self) -> list[str]:
         """Return device locks this scan is actively waiting to acquire."""
-        return sorted(self._waiting_device_locks)
+        registry = getattr(self._device_manager.parent, "device_lock_registry", None)
+        request_id = self._scan.scan_info.metadata.get("RID")
+        if registry is None or request_id is None:
+            return []
+        return registry.get_pending_devices(request_id)
+
+    def get_owned_device_locks(self) -> list[str]:
+        """Return device locks this scan has already acquired."""
+        registry = getattr(self._device_manager.parent, "device_lock_registry", None)
+        request_id = self._scan.scan_info.metadata.get("RID")
+        if registry is None or request_id is None:
+            return []
+        return sorted(registry.get_owned_devices(request_id))
 
     def get_queued_device_locks(self) -> list[str]:
         """Return device locks buffered before scan initialization acquires them."""
-        return sorted(self._pending_device_locks)
-
-    def _set_device_lock_wait_state(self, waiting_devices: list[str]) -> None:
-        """
-        Update the set of device locks this scan is actively waiting to acquire.
-
-        Args:
-            waiting_devices (list[str]): The list of device names this scan is waiting for.
-        """
-        new_waiting_devices = set(waiting_devices)
-        updated = new_waiting_devices != self._waiting_device_locks
-        self._waiting_device_locks = new_waiting_devices
-        if updated and self._update_queue_info_callback is not None:
-            self._update_queue_info_callback()
+        return sorted(self._queued_device_locks)
 
     @staticmethod
     def _device_ownership_mode(device: DeviceBase) -> str:

--- a/bec_server/bec_server/scan_server/scans/scan_base.py
+++ b/bec_server/bec_server/scan_server/scans/scan_base.py
@@ -173,6 +173,8 @@ class ScanBase(ABC):
         instruction_handler: InstructionHandler,
         request_inputs: dict,
         system_config: dict,
+        monitored: list[str] | None = None,
+        on_request: list[str] | None = None,
         scan_modifier: Type[ScanModifier] | None = None,
         user_metadata: dict | None = None,
         metadata: dict | None = None,
@@ -203,6 +205,8 @@ class ScanBase(ABC):
         self.scan_info = ScanInfo(
             scan_name=self.scan_name, scan_id=scan_id, scan_type=self.scan_type, **optional_kwargs
         )
+        self.update_scan_info(monitored=monitored, on_request=on_request)
+
         self.scan_info.request_inputs = request_inputs
         self.scan_info.system_config = system_config
         self._baseline_readout_status = None
@@ -227,6 +231,8 @@ class ScanBase(ABC):
         relative: bool | None = None,
         run_on_exception_hook: bool | None = None,
         scan_report_devices: Sequence[str | DeviceBase] | None = None,
+        monitored: Sequence[str | DeviceBase] | None = None,
+        on_request: Sequence[str | DeviceBase] | None = None,
         **kwargs,
     ):
         """
@@ -249,6 +255,8 @@ class ScanBase(ABC):
             run_on_exception_hook (bool, optional): Whether to run the on_exception hook if the scan is interrupted. Defaults to None.
             scan_report_devices (Sequence[str | DeviceBase], optional): Devices to report
                 during the scan. Device objects are stored by name. Defaults to None.
+            monitored (Sequence[str | DeviceBase], optional): Devices to be put on the readout priority `monitored`. Defaults to None.
+            on_request (Sequence[str | DeviceBase], optional): Devices to be put on the readout priority `on_request`. Defaults to None.
             **kwargs: Keyword arguments to update the scan info with.
         """
         for attr_name, value in [
@@ -271,6 +279,14 @@ class ScanBase(ABC):
                 setattr(self.scan_info, key, value)
             else:
                 self.scan_info.additional_scan_parameters[key] = value
+        if monitored is not None:
+            self.scan_info.readout_priority_modification["monitored"] = [
+                device.name if isinstance(device, DeviceBase) else device for device in monitored
+            ]
+        if on_request is not None:
+            self.scan_info.readout_priority_modification["on_request"] = [
+                device.name if isinstance(device, DeviceBase) else device for device in on_request
+            ]
 
     @scan_hook
     @abstractmethod

--- a/bec_server/bec_server/scan_server/scans/updated_move.py
+++ b/bec_server/bec_server/scan_server/scans/updated_move.py
@@ -71,6 +71,8 @@ class UpdatedMoveScan(ScanBase):
         self.motors = list(self.motor_args_bundles.keys())
         self.relative = relative
 
+        self.actions.acquire_device_lock(self.motors)
+
         # Update the default scan info with provided parameters.
         self.update_scan_info(relative=relative, scan_report_devices=self.motors)
 

--- a/bec_server/bec_server/scan_server/tests/scan_fixtures.py
+++ b/bec_server/bec_server/scan_server/tests/scan_fixtures.py
@@ -1,6 +1,7 @@
 import copy
 import inspect
 from collections.abc import Iterator
+from contextlib import nullcontext
 from types import SimpleNamespace, UnionType
 from typing import Annotated, Any, get_args, get_origin, get_type_hints
 from unittest import mock
@@ -396,7 +397,9 @@ def v4_scan_assembler(readout_priority: ReadoutPriorityContainer, device_manager
             devices[name] = _MockDevice(name)
         for name, device in custom_devices.items():
             devices[name] = device
-        scan_device_manager = SimpleNamespace(devices=devices, connector=connector)
+        scan_device_manager = SimpleNamespace(
+            devices=devices, connector=connector, _rpc_method=lambda _rpc_call: nullcontext()
+        )
         resolved_scan_kwargs = {"system_config": {}, **scan_kwargs}
 
         parent = mock.MagicMock()
@@ -423,6 +426,7 @@ def v4_scan_assembler(readout_priority: ReadoutPriorityContainer, device_manager
         scan.actions._get_file_base_path = mock.MagicMock(
             return_value=str(tmpdir / "p12345" / "data")
         )
+        scan.actions._scan_running = True
 
         scan._test = SimpleNamespace(
             connector=connector,

--- a/bec_server/bec_server/scan_server/tests/scan_fixtures.py
+++ b/bec_server/bec_server/scan_server/tests/scan_fixtures.py
@@ -400,6 +400,7 @@ def v4_scan_assembler(readout_priority: ReadoutPriorityContainer, device_manager
         resolved_scan_kwargs = {"system_config": {}, **scan_kwargs}
 
         parent = mock.MagicMock()
+        scan_device_manager.parent = parent
         parent.device_manager = scan_device_manager
         parent.connector = connector
         parent.queue_manager.instruction_handler = instruction_handler

--- a/bec_server/tests/tests_device_server/test_device_serializer.py
+++ b/bec_server/tests/tests_device_server/test_device_serializer.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 from ophyd import Component as Cpt
 from ophyd import Device, EpicsSignal, Signal
+from ophyd_devices import PSIDeviceBase
 
 from bec_lib.bec_errors import DeviceConfigError
 from bec_server.device_server.devices.device_serializer import get_device_info
@@ -84,6 +85,26 @@ class DummyDeviceWithAliasedSignalNames(Device):
     signal_alias = signal = Cpt(Signal, value=1)
 
 
+class DummyReadOnlySignal(Signal):
+    @property
+    def write_access(self):
+        return False
+
+
+class DummyWritableSignal(Signal):
+    @property
+    def write_access(self):
+        return True
+
+
+class DummyExplicitOwnershipDevice(Device):
+    ownership_mode = "free"
+
+
+class DummyPSIDevice(PSIDeviceBase):
+    pass
+
+
 @pytest.mark.parametrize(
     "obj",
     [
@@ -132,3 +153,35 @@ def test_get_device_info_allows_aliased_signal_names():
 
     assert info["device_info"]["signals"]["signal"]["obj_name"] == "test_signal"
     assert info["device_info"]["signals"]["signal_alias"]["obj_name"] == "test_signal"
+
+
+def test_get_device_info_marks_read_only_plain_signal_as_free():
+    signal = DummyReadOnlySignal(name="test")
+
+    info = get_device_info(signal, connect=False)
+
+    assert info["device_info"]["ownership_mode"] == "free"
+
+
+def test_get_device_info_marks_writable_plain_signal_as_claimable():
+    signal = DummyWritableSignal(name="test")
+
+    info = get_device_info(signal, connect=False)
+
+    assert info["device_info"]["ownership_mode"] == "claimable"
+
+
+def test_get_device_info_marks_psi_devices_as_pinned():
+    device = DummyPSIDevice(name="test")
+
+    info = get_device_info(device, connect=False)
+
+    assert info["device_info"]["ownership_mode"] == "pinned"
+
+
+def test_get_device_info_prefers_explicit_class_ownership_mode():
+    device = DummyExplicitOwnershipDevice(name="test")
+
+    info = get_device_info(device, connect=False)
+
+    assert info["device_info"]["ownership_mode"] == "free"

--- a/bec_server/tests/tests_device_server/test_device_serializer.py
+++ b/bec_server/tests/tests_device_server/test_device_serializer.py
@@ -101,6 +101,10 @@ class DummyExplicitOwnershipDevice(Device):
     ownership_mode = "free"
 
 
+class DummyInvalidOwnershipDevice(Device):
+    ownership_mode = "not-a-mode"
+
+
 class DummyPSIDevice(PSIDeviceBase):
     pass
 
@@ -185,3 +189,13 @@ def test_get_device_info_prefers_explicit_class_ownership_mode():
     info = get_device_info(device, connect=False)
 
     assert info["device_info"]["ownership_mode"] == "free"
+
+
+def test_get_device_info_raises_device_config_error_for_invalid_explicit_ownership_mode():
+    device = DummyInvalidOwnershipDevice(name="test")
+
+    with pytest.raises(
+        DeviceConfigError,
+        match="Invalid ownership_mode 'not-a-mode' configured on DummyInvalidOwnershipDevice",
+    ):
+        get_device_info(device, connect=False)

--- a/bec_server/tests/tests_device_server/test_device_server.py
+++ b/bec_server/tests/tests_device_server/test_device_server.py
@@ -234,12 +234,22 @@ def test_stop_devices(device_server_mock):
 
 @pytest.mark.parametrize("device_manager_class", [DeviceManagerDS])
 def test_on_stop_devices(device_server_mock):
-    msg = messages.VariableMessage(value=[], metadata={})
+    msg = messages.VariableMessage(value=None, metadata={})
     msg_obj = MessageObject(topic="internal/queue/stop_devices", value=msg)
     device_server = device_server_mock
     with mock.patch.object(device_server, "stop_devices") as stop:
         device_server.on_stop_devices(msg_obj, parent=device_server)
         stop.assert_called_once_with()
+
+
+@pytest.mark.parametrize("device_manager_class", [DeviceManagerDS])
+def test_on_stop_devices_with_empty_list(device_server_mock):
+    msg = messages.VariableMessage(value=[], metadata={})
+    msg_obj = MessageObject(topic="internal/queue/stop_devices", value=msg)
+    device_server = device_server_mock
+    with mock.patch.object(device_server, "stop_devices") as stop:
+        device_server.on_stop_devices(msg_obj, parent=device_server)
+        stop.assert_not_called()
 
 
 @pytest.mark.parametrize("device_manager_class", [DeviceManagerDS])
@@ -1144,7 +1154,7 @@ def test_request_handler_ignores_response_if_stop_id(device_server_mock, stop_id
             device_server.on_stop_devices(
                 MessageObject(
                     topic=MessageEndpoints.stop_devices().endpoint,
-                    value=messages.VariableMessage(value=[], metadata={"stop_id": stop_id}),
+                    value=messages.VariableMessage(value=None, metadata={"stop_id": stop_id}),
                 )
             )
             stop_mock.assert_called()

--- a/bec_server/tests/tests_scan_server/scans_v4/test_scan_actions.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_scan_actions.py
@@ -191,6 +191,27 @@ def test_open_close_scan_send_scan_status(action_context):
 
 def test_open_scan_acquires_initial_device_locks(action_context):
     ctx = action_context()
+    ctx.actions._send_scan_status = mock.MagicMock()
+
+    ctx.actions.open_scan()
+
+    ctx.actions._send_scan_status.assert_called_once_with("open")
+
+
+def test_acquire_device_lock_queues_normalized_names_before_open(action_context):
+    ctx = action_context()
+    ctx.scan.scan_info.metadata["RID"] = "rid-123"
+    ctx.device_manager.parent.device_lock_registry = mock.MagicMock()
+
+    acquired = ctx.actions.acquire_device_lock([ctx.device_manager.devices.samx, "samy"])
+
+    assert acquired == ["samx", "samy"]
+    ctx.device_manager.parent.device_lock_registry.acquire_many.assert_not_called()
+    assert ctx.actions._pending_device_locks == {"samx", "samy"}
+
+
+def test_initialize_scan_flushes_pre_open_queued_locks(action_context):
+    ctx = action_context()
     _set_readout_priority(ctx, monitored=["samx", "samy"], **{"async": ["samz"]})
     _set_software_triggered(ctx, "samy")
     ctx.scan.scan_info.metadata["RID"] = "rid-123"
@@ -199,30 +220,76 @@ def test_open_scan_acquires_initial_device_locks(action_context):
     ctx.device_manager.devices.samz._info["ownership_mode"] = "claimable"
     ctx.device_manager.devices.bpm4i._info["ownership_mode"] = "pinned"
     ctx.device_manager.parent.device_lock_registry = mock.MagicMock()
-    ctx.actions._send_scan_status = mock.MagicMock()
-
-    ctx.actions.open_scan()
-
-    ctx.device_manager.parent.device_lock_registry.acquire_many.assert_called_once_with(
-        "rid-123",
-        devices=["bpm4i", "samx", "samy", "samz"],
-        interruption_callback=ctx.actions._interruption_callback,
+    ctx.device_manager.parent.device_lock_registry.acquire_many.side_effect = (
+        lambda *args, **kwargs: (sorted(ctx.actions.get_queued_device_locks()), kwargs["devices"])[
+            1
+        ]
     )
-    ctx.actions._send_scan_status.assert_called_once_with("open")
+
+    ctx.actions.acquire_device_lock([ctx.device_manager.devices.samx, "samy"])
+    ctx.actions._initialize_scan()
+
+    ctx.device_manager.parent.device_lock_registry.acquire_many.assert_called_once()
+    acquire_args, acquire_kwargs = (
+        ctx.device_manager.parent.device_lock_registry.acquire_many.call_args
+    )
+    assert acquire_args == ("rid-123",)
+    assert acquire_kwargs["interruption_callback"] == ctx.actions._interruption_callback
+    assert {"samx", "samy"}.issubset(set(acquire_kwargs["devices"]))
+    assert ctx.actions._pending_device_locks == set()
+    assert ctx.actions._scan_running is True
 
 
-def test_acquire_device_lock_uses_request_id_and_normalized_names(action_context):
+def test_acquire_device_lock_uses_request_id_and_normalized_names_after_open(action_context):
+    ctx = action_context()
+    ctx.scan.scan_info.metadata["RID"] = "rid-123"
+    ctx.device_manager.parent.device_lock_registry = mock.MagicMock()
+    ctx.actions._scan_running = True
+
+    ctx.actions.acquire_device_lock([ctx.device_manager.devices.samx, "samy"])
+
+    ctx.device_manager.parent.device_lock_registry.acquire_many.assert_called_once()
+    acquire_args, acquire_kwargs = (
+        ctx.device_manager.parent.device_lock_registry.acquire_many.call_args
+    )
+    assert acquire_args == ("rid-123",)
+    assert acquire_kwargs["devices"] == ["samx", "samy"]
+    assert acquire_kwargs["interruption_callback"] == ctx.actions._interruption_callback
+    assert acquire_kwargs["wait_state_callback"] == ctx.actions._set_device_lock_wait_state
+
+
+def test_acquire_device_lock_uses_root_device_name_for_nested_devices(action_context):
     ctx = action_context()
     ctx.scan.scan_info.metadata["RID"] = "rid-123"
     ctx.device_manager.parent.device_lock_registry = mock.MagicMock()
 
-    ctx.actions.acquire_device_lock([ctx.device_manager.devices.samx, "samy"])
-
-    ctx.device_manager.parent.device_lock_registry.acquire_many.assert_called_once_with(
-        "rid-123",
-        devices=["samx", "samy"],
-        interruption_callback=ctx.actions._interruption_callback,
+    ctx.actions.acquire_device_lock(
+        [ctx.device_manager.devices.samx.setpoint, ctx.device_manager.devices.samx.readback]
     )
+
+    ctx.device_manager.parent.device_lock_registry.acquire_many.assert_called_once()
+    acquire_args, acquire_kwargs = (
+        ctx.device_manager.parent.device_lock_registry.acquire_many.call_args
+    )
+    assert acquire_args == ("rid-123",)
+    assert acquire_kwargs["devices"] == ["samx"]
+
+
+def test_get_pending_device_locks_includes_runtime_waits(action_context):
+    ctx = action_context()
+    ctx.actions._update_queue_info_callback = mock.MagicMock()
+    ctx.actions._pending_device_locks.update({"samy"})
+
+    ctx.actions._set_device_lock_wait_state(["samx"])
+
+    assert ctx.actions.get_pending_device_locks() == ["samx"]
+    assert ctx.actions.get_queued_device_locks() == ["samy"]
+    ctx.actions._update_queue_info_callback.assert_called_once_with()
+
+    ctx.actions._set_device_lock_wait_state([])
+
+    assert ctx.actions.get_pending_device_locks() == []
+    assert ctx.actions._update_queue_info_callback.call_count == 2
 
 
 def test_device_specific_actions_acquire_device_locks(action_context):
@@ -337,13 +404,13 @@ def test_device_instruction_actions_use_dotted_name_for_nested_devices(action_co
     complete_msg = _last_device_instruction(ctx, "complete")
     unstage_msg = _last_device_instruction(ctx, "unstage")
 
-    assert stage_msg.device == "samx.setpoint"
+    assert stage_msg.device == "samx"
     assert stage_msg.metadata["device_instr_id"] == stage_status._device_instr_id
     assert kickoff_msg.device == "samx.setpoint"
     assert kickoff_msg.metadata["device_instr_id"] == kickoff_status._device_instr_id
     assert complete_msg.device == "samx.readback"
     assert complete_msg.metadata["device_instr_id"] == complete_status._device_instr_id
-    assert unstage_msg.device == "samx.readback"
+    assert unstage_msg.device == "samx"
     assert unstage_msg.metadata["device_instr_id"] == unstage_status._device_instr_id
 
 

--- a/bec_server/tests/tests_scan_server/scans_v4/test_scan_actions.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_scan_actions.py
@@ -68,7 +68,7 @@ class _TestParent:
 
 @pytest.fixture
 def action_context(dm_with_devices):
-    def _build(connector=None):
+    def _build(connector=None, running=True):
         connector = connector or ConnectorMock("")
         instruction_handler = InstructionHandler(connector)
         dm_with_devices.connector = connector
@@ -80,6 +80,7 @@ def action_context(dm_with_devices):
             device_manager=dm_with_devices,
             instruction_handler=instruction_handler,
         )
+        scan.actions._scan_running = running
         return _ActionContext(
             actions=scan.actions, connector=connector, device_manager=dm_with_devices, scan=scan
         )
@@ -199,7 +200,7 @@ def test_open_scan_acquires_initial_device_locks(action_context):
 
 
 def test_acquire_device_lock_queues_normalized_names_before_open(action_context):
-    ctx = action_context()
+    ctx = action_context(running=False)
     ctx.scan.scan_info.metadata["RID"] = "rid-123"
     ctx.device_manager.parent.device_lock_registry = mock.MagicMock()
 
@@ -211,7 +212,7 @@ def test_acquire_device_lock_queues_normalized_names_before_open(action_context)
 
 
 def test_initialize_scan_flushes_pre_open_queued_locks(action_context):
-    ctx = action_context()
+    ctx = action_context(running=False)
     _set_readout_priority(ctx, monitored=["samx", "samy"], **{"async": ["samz"]})
     _set_software_triggered(ctx, "samy")
     ctx.scan.scan_info.metadata["RID"] = "rid-123"
@@ -244,8 +245,6 @@ def test_acquire_device_lock_uses_request_id_and_normalized_names_after_open(act
     ctx = action_context()
     ctx.scan.scan_info.metadata["RID"] = "rid-123"
     ctx.device_manager.parent.device_lock_registry = mock.MagicMock()
-    ctx.actions._scan_running = True
-
     ctx.actions.acquire_device_lock([ctx.device_manager.devices.samx, "samy"])
 
     ctx.device_manager.parent.device_lock_registry.acquire_many.assert_called_once()
@@ -290,6 +289,36 @@ def test_get_pending_device_locks_includes_runtime_waits(action_context):
 
     assert ctx.actions.get_pending_device_locks() == []
     assert ctx.actions._update_queue_info_callback.call_count == 2
+
+
+@pytest.mark.parametrize(
+    ("method_name", "args", "kwargs"),
+    [
+        ("stage_all_devices", (), {"wait": False}),
+        ("stage", ("samx",), {"wait": False}),
+        ("pre_scan", ("samx",), {"wait": False}),
+        ("pre_scan_all_devices", (), {"wait": False}),
+        ("set", (["samx"], [1.0]), {"wait": False}),
+        ("kickoff", ("samx",), {"wait": False}),
+        ("complete", ("samx",), {"wait": False}),
+        ("complete_all_devices", (), {"wait": False}),
+        ("read_monitored_devices", (), {"wait": False}),
+        ("read_manually", (["samx"],), {"wait": False}),
+        ("publish_manual_read", ([{}],), {"wait": False}),
+        ("read_baseline_devices", (), {"wait": False}),
+        ("trigger_all_devices", (), {"wait": False}),
+        ("unstage", ("samx",), {"wait": False}),
+        ("unstage_all_devices", (), {"wait": False}),
+        ("rpc_call", ("samx", "foo"), {}),
+        ("rpc_call_no_wait", ("samx", "foo", "rpc-id"), {}),
+        ("send_client_info", ("test message",), {}),
+    ],
+)
+def test_requires_scan_is_running_guard(action_context, method_name, args, kwargs):
+    ctx = action_context(running=False)
+
+    with pytest.raises(RuntimeError, match="can only be used once the scan is running"):
+        getattr(ctx.actions, method_name)(*args, **kwargs)
 
 
 def test_device_specific_actions_acquire_device_locks(action_context):

--- a/bec_server/tests/tests_scan_server/scans_v4/test_scan_actions.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_scan_actions.py
@@ -208,7 +208,7 @@ def test_acquire_device_lock_queues_normalized_names_before_open(action_context)
 
     assert acquired == ["samx", "samy"]
     ctx.device_manager.parent.device_lock_registry.acquire_many.assert_not_called()
-    assert ctx.actions._pending_device_locks == {"samx", "samy"}
+    assert ctx.actions._queued_device_locks == {"samx", "samy"}
 
 
 def test_initialize_scan_flushes_pre_open_queued_locks(action_context):
@@ -237,7 +237,7 @@ def test_initialize_scan_flushes_pre_open_queued_locks(action_context):
     assert acquire_args == ("rid-123",)
     assert acquire_kwargs["interruption_callback"] == ctx.actions._interruption_callback
     assert {"samx", "samy"}.issubset(set(acquire_kwargs["devices"]))
-    assert ctx.actions._pending_device_locks == set()
+    assert ctx.actions._queued_device_locks == set()
     assert ctx.actions._scan_running is True
 
 
@@ -254,7 +254,7 @@ def test_acquire_device_lock_uses_request_id_and_normalized_names_after_open(act
     assert acquire_args == ("rid-123",)
     assert acquire_kwargs["devices"] == ["samx", "samy"]
     assert acquire_kwargs["interruption_callback"] == ctx.actions._interruption_callback
-    assert acquire_kwargs["wait_state_callback"] == ctx.actions._set_device_lock_wait_state
+    assert acquire_kwargs["queue_update_callback"] == ctx.actions._update_queue_info_callback
 
 
 def test_acquire_device_lock_uses_root_device_name_for_nested_devices(action_context):
@@ -276,16 +276,23 @@ def test_acquire_device_lock_uses_root_device_name_for_nested_devices(action_con
 
 def test_get_pending_device_locks_includes_runtime_waits(action_context):
     ctx = action_context()
+    ctx.scan.scan_info.metadata["RID"] = "rid-123"
     ctx.actions._update_queue_info_callback = mock.MagicMock()
-    ctx.actions._pending_device_locks.update({"samy"})
+    ctx.actions._queued_device_locks.update({"samy"})
+    ctx.device_manager.parent.device_lock_registry = mock.MagicMock()
+    ctx.device_manager.parent.device_lock_registry.get_pending_devices.return_value = ["samx"]
 
-    ctx.actions._set_device_lock_wait_state(["samx"])
+    ctx.actions._update_queue_info_callback()
 
     assert ctx.actions.get_pending_device_locks() == ["samx"]
     assert ctx.actions.get_queued_device_locks() == ["samy"]
     ctx.actions._update_queue_info_callback.assert_called_once_with()
+    ctx.device_manager.parent.device_lock_registry.get_pending_devices.assert_called_once_with(
+        "rid-123"
+    )
 
-    ctx.actions._set_device_lock_wait_state([])
+    ctx.device_manager.parent.device_lock_registry.get_pending_devices.return_value = []
+    ctx.actions._update_queue_info_callback()
 
     assert ctx.actions.get_pending_device_locks() == []
     assert ctx.actions._update_queue_info_callback.call_count == 2
@@ -311,7 +318,6 @@ def test_get_pending_device_locks_includes_runtime_waits(action_context):
         ("unstage_all_devices", (), {"wait": False}),
         ("rpc_call", ("samx", "foo"), {}),
         ("rpc_call_no_wait", ("samx", "foo", "rpc-id"), {}),
-        ("send_client_info", ("test message",), {}),
     ],
 )
 def test_requires_scan_is_running_guard(action_context, method_name, args, kwargs):

--- a/bec_server/tests/tests_scan_server/scans_v4/test_scan_actions.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_scan_actions.py
@@ -241,6 +241,22 @@ def test_initialize_scan_flushes_pre_open_queued_locks(action_context):
     assert ctx.actions._scan_running is True
 
 
+def test_initialize_scan_excludes_on_request_devices_from_initial_locks(action_context):
+    ctx = action_context(running=False)
+    _set_readout_priority(ctx, monitored=["samx"], on_request=["bpm4i"])
+    ctx.scan.scan_info.metadata["RID"] = "rid-123"
+    ctx.device_manager.devices.samx._info["ownership_mode"] = "claimable"
+    ctx.device_manager.devices.bpm4i._info["ownership_mode"] = "pinned"
+    ctx.device_manager.parent.device_lock_registry = mock.MagicMock()
+
+    ctx.actions._initialize_scan()
+
+    ctx.device_manager.parent.device_lock_registry.acquire_many.assert_called_once()
+    _, acquire_kwargs = ctx.device_manager.parent.device_lock_registry.acquire_many.call_args
+    assert "samx" in acquire_kwargs["devices"]
+    assert "bpm4i" not in acquire_kwargs["devices"]
+
+
 def test_acquire_device_lock_uses_request_id_and_normalized_names_after_open(action_context):
     ctx = action_context()
     ctx.scan.scan_info.metadata["RID"] = "rid-123"

--- a/bec_server/tests/tests_scan_server/scans_v4/test_scan_actions.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_scan_actions.py
@@ -189,6 +189,73 @@ def test_open_close_scan_send_scan_status(action_context):
     ctx.actions.check_for_unchecked_statuses.assert_called_once_with()
 
 
+def test_open_scan_acquires_initial_device_locks(action_context):
+    ctx = action_context()
+    _set_readout_priority(ctx, monitored=["samx", "samy"], **{"async": ["samz"]})
+    _set_software_triggered(ctx, "samy")
+    ctx.scan.scan_info.metadata["RID"] = "rid-123"
+    ctx.device_manager.devices.samx._info["ownership_mode"] = "claimable"
+    ctx.device_manager.devices.samy._info["ownership_mode"] = "free"
+    ctx.device_manager.devices.samz._info["ownership_mode"] = "claimable"
+    ctx.device_manager.devices.bpm4i._info["ownership_mode"] = "pinned"
+    ctx.device_manager.parent.device_lock_registry = mock.MagicMock()
+    ctx.actions._send_scan_status = mock.MagicMock()
+
+    ctx.actions.open_scan()
+
+    ctx.device_manager.parent.device_lock_registry.acquire_many.assert_called_once_with(
+        "rid-123",
+        devices=["bpm4i", "samx", "samy", "samz"],
+        interruption_callback=ctx.actions._interruption_callback,
+    )
+    ctx.actions._send_scan_status.assert_called_once_with("open")
+
+
+def test_acquire_device_lock_uses_request_id_and_normalized_names(action_context):
+    ctx = action_context()
+    ctx.scan.scan_info.metadata["RID"] = "rid-123"
+    ctx.device_manager.parent.device_lock_registry = mock.MagicMock()
+
+    ctx.actions.acquire_device_lock([ctx.device_manager.devices.samx, "samy"])
+
+    ctx.device_manager.parent.device_lock_registry.acquire_many.assert_called_once_with(
+        "rid-123",
+        devices=["samx", "samy"],
+        interruption_callback=ctx.actions._interruption_callback,
+    )
+
+
+def test_device_specific_actions_acquire_device_locks(action_context):
+    ctx = action_context()
+    ctx.actions.acquire_device_lock = mock.MagicMock()
+
+    ctx.actions.stage(["samx", "samy"], wait=False)
+    ctx.actions.pre_scan("samx", wait=False)
+    ctx.actions.set(["samx", "samy"], [1.0, 2.0], wait=False)
+    ctx.actions.kickoff("samx", wait=False)
+    ctx.actions.complete("samy", wait=False)
+    ctx.actions.read_manually(["samx", "samy"], wait=False)
+    ctx.actions.unstage("samz", wait=False)
+
+    assert ctx.actions.acquire_device_lock.call_args_list == [
+        mock.call(["samx", "samy"]),
+        mock.call("samx"),
+        mock.call(["samx", "samy"]),
+        mock.call("samx"),
+        mock.call("samy"),
+    ]
+
+
+def test_release_device_lock_uses_request_id(action_context):
+    ctx = action_context()
+    ctx.scan.scan_info.metadata["RID"] = "rid-123"
+    ctx.device_manager.parent.device_lock_registry = mock.MagicMock(return_value=None)
+
+    ctx.actions.release_device_lock()
+
+    ctx.device_manager.parent.device_lock_registry.release_all.assert_called_once_with("rid-123")
+
+
 def test_build_scan_status_message(action_context):
     ctx = action_context()
     _set_readout_priority(
@@ -222,6 +289,10 @@ def test_device_instruction_actions_emit_expected_messages(action_context):
     ctx = action_context()
     ctx.scan.scan_info.metadata["RID"] = "rid-123"
     ctx.scan.scan_info.metadata["queue_id"] = "queue-123"
+    ctx.device_manager.parent.device_lock_registry = mock.MagicMock()
+    ctx.device_manager.parent.device_lock_registry.get_owned_devices.return_value = (
+        _enabled_device_names(ctx)
+    )
 
     stage_status = ctx.actions.stage("samx", wait=False)
     pre_scan_status = ctx.actions.pre_scan_all_devices(wait=False)
@@ -354,13 +425,14 @@ def test_pre_scan_emits_expected_messages(action_context):
 
 def test_pre_scan_all_devices_respects_exclude(action_context):
     ctx = action_context()
+    ctx.scan.scan_info.metadata["RID"] = "rid-123"
+    ctx.device_manager.parent.device_lock_registry = mock.MagicMock()
+    ctx.device_manager.parent.device_lock_registry.get_owned_devices.return_value = ["samy", "samz"]
 
     status = ctx.actions.pre_scan_all_devices(wait=False, exclude=["samx"])
 
     pre_scan_msg = _last_device_instruction(ctx, "pre_scan")
-    assert pre_scan_msg.device == sorted(
-        [device_name for device_name in _enabled_device_names(ctx) if device_name != "samx"]
-    )
+    assert pre_scan_msg.device == ["samy", "samz"]
     assert pre_scan_msg.metadata["device_instr_id"] == status._device_instr_id
 
 
@@ -388,6 +460,9 @@ def test_read_actions_emit_expected_messages_and_point_ids(action_context):
 
 def test_empty_read_and_trigger_actions_return_done_status(action_context):
     ctx = action_context()
+    ctx.scan.scan_info.metadata["RID"] = "rid-123"
+    ctx.device_manager.parent.device_lock_registry = mock.MagicMock()
+    ctx.device_manager.parent.device_lock_registry.get_owned_devices.return_value = []
     _set_readout_priority(ctx)
     _set_software_triggered(ctx)
 
@@ -404,6 +479,9 @@ def test_empty_read_and_trigger_actions_return_done_status(action_context):
 
 def test_trigger_all_devices_emits_software_triggered_devices(action_context):
     ctx = action_context()
+    ctx.scan.scan_info.metadata["RID"] = "rid-123"
+    ctx.device_manager.parent.device_lock_registry = mock.MagicMock()
+    ctx.device_manager.parent.device_lock_registry.get_owned_devices.return_value = ["samx", "samy"]
     _set_software_triggered(ctx, "samy", "samx")
 
     status = ctx.actions.trigger_all_devices(wait=False)
@@ -415,6 +493,11 @@ def test_trigger_all_devices_emits_software_triggered_devices(action_context):
 
 def test_complete_and_unstage_all_devices_emit_enabled_devices(action_context):
     ctx = action_context()
+    ctx.scan.scan_info.metadata["RID"] = "rid-123"
+    ctx.device_manager.parent.device_lock_registry = mock.MagicMock()
+    ctx.device_manager.parent.device_lock_registry.get_owned_devices.return_value = (
+        _enabled_device_names(ctx)
+    )
 
     complete_status = ctx.actions.complete_all_devices(wait=False)
     unstage_status = ctx.actions.unstage_all_devices(wait=False)
@@ -429,6 +512,11 @@ def test_complete_and_unstage_all_devices_emit_enabled_devices(action_context):
 
 def test_complete_and_unstage_all_devices_respect_exclude(action_context):
     ctx = action_context()
+    ctx.scan.scan_info.metadata["RID"] = "rid-123"
+    ctx.device_manager.parent.device_lock_registry = mock.MagicMock()
+    ctx.device_manager.parent.device_lock_registry.get_owned_devices.return_value = (
+        _enabled_device_names(ctx)
+    )
 
     complete_status = ctx.actions.complete_all_devices(wait=False, exclude=["samx"])
     unstage_status = ctx.actions.unstage_all_devices(wait=False, exclude="samy")
@@ -445,8 +533,28 @@ def test_complete_and_unstage_all_devices_respect_exclude(action_context):
     assert unstage_msg.metadata["device_instr_id"] == unstage_status._device_instr_id
 
 
+def test_complete_and_unstage_all_devices_only_resolve_owned_devices(action_context):
+    ctx = action_context()
+    ctx.scan.scan_info.metadata["RID"] = "rid-123"
+    ctx.device_manager.parent.device_lock_registry = mock.MagicMock()
+    ctx.device_manager.parent.device_lock_registry.get_owned_devices.return_value = ["samy"]
+
+    complete_status = ctx.actions.complete_all_devices(wait=False)
+    unstage_status = ctx.actions.unstage_all_devices(wait=False)
+
+    complete_msg = _last_device_instruction(ctx, "complete")
+    unstage_msg = _last_device_instruction(ctx, "unstage")
+    assert complete_msg.device == ["samy"]
+    assert complete_msg.metadata["device_instr_id"] == complete_status._device_instr_id
+    assert unstage_msg.device == ["samy"]
+    assert unstage_msg.metadata["device_instr_id"] == unstage_status._device_instr_id
+
+
 def test_stage_all_devices_stages_async_and_sync_devices(action_context):
     ctx = action_context()
+    ctx.scan.scan_info.metadata["RID"] = "rid-123"
+    ctx.device_manager.parent.device_lock_registry = mock.MagicMock()
+    ctx.device_manager.parent.device_lock_registry.get_owned_devices.return_value = ["samx", "samy"]
     async_dev = ctx.device_manager.devices["samx"]
     on_request_dev = ctx.device_manager.devices["bpm4i"]
     continuous_dev = ctx.device_manager.devices["samz"]
@@ -514,6 +622,9 @@ def test_stage_all_devices_stages_async_and_sync_devices(action_context):
 
 def test_stage_all_devices_respects_exclude(action_context):
     ctx = action_context()
+    ctx.scan.scan_info.metadata["RID"] = "rid-123"
+    ctx.device_manager.parent.device_lock_registry = mock.MagicMock()
+    ctx.device_manager.parent.device_lock_registry.get_owned_devices.return_value = ["samx", "samy"]
     async_dev = ctx.device_manager.devices["samx"]
     on_request_dev = ctx.device_manager.devices["bpm4i"]
     continuous_dev = ctx.device_manager.devices["samz"]
@@ -558,6 +669,62 @@ def test_stage_all_devices_respects_exclude(action_context):
         ),
     ):
         status = ctx.actions.stage_all_devices(wait=False, exclude="samx")
+
+    assert status is container_status
+    assert ctx.actions.stage.mock_calls == [
+        mock.call(["samy"], status_name="stage_sync_devices", wait=False)
+    ]
+
+
+def test_stage_all_devices_only_resolves_owned_devices(action_context):
+    ctx = action_context()
+    ctx.scan.scan_info.metadata["RID"] = "rid-123"
+    ctx.device_manager.parent.device_lock_registry = mock.MagicMock()
+    ctx.device_manager.parent.device_lock_registry.get_owned_devices.return_value = ["samy"]
+    async_dev = ctx.device_manager.devices["samx"]
+    on_request_dev = ctx.device_manager.devices["bpm4i"]
+    continuous_dev = ctx.device_manager.devices["samz"]
+    enabled_devices = [
+        ctx.device_manager.devices["samx"],
+        ctx.device_manager.devices["samy"],
+        ctx.device_manager.devices["samz"],
+        ctx.device_manager.devices["bpm4i"],
+    ]
+    container_status = ScanStubStatus(
+        ctx.scan._instruction_handler,
+        shutdown_event=threading.Event(),
+        registry={},
+        is_container=True,
+        name="stage_all_devices",
+    )
+    sync_status = ScanStubStatus(
+        ctx.scan._instruction_handler,
+        shutdown_event=threading.Event(),
+        registry={},
+        name="stage_sync_devices",
+    )
+
+    ctx.actions._create_status = mock.MagicMock(return_value=container_status)
+    ctx.actions.stage = mock.MagicMock(return_value=sync_status)
+
+    with (
+        mock.patch.object(
+            type(ctx.device_manager.devices), "async_devices", return_value=[async_dev]
+        ),
+        mock.patch.object(
+            type(ctx.device_manager.devices), "on_request_devices", return_value=[on_request_dev]
+        ),
+        mock.patch.object(
+            type(ctx.device_manager.devices), "continuous_devices", return_value=[continuous_dev]
+        ),
+        mock.patch.object(
+            type(ctx.device_manager.devices),
+            "enabled_devices",
+            new_callable=mock.PropertyMock,
+            return_value=enabled_devices,
+        ),
+    ):
+        status = ctx.actions.stage_all_devices(wait=False)
 
     assert status is container_status
     assert ctx.actions.stage.mock_calls == [
@@ -610,11 +777,13 @@ def test_rpc_call_returns_result_or_status(action_context):
     status.wait = mock.MagicMock()
     status._result_is_status = False
     ctx.actions._create_status = mock.MagicMock(return_value=status)
+    ctx.actions.acquire_device_lock = mock.MagicMock()
     ctx.actions._send = mock.MagicMock()
 
     result = ctx.actions.rpc_call("samx", "kickoff", 1, test=True)
 
     assert result == {"ok": True}
+    ctx.actions.acquire_device_lock.assert_called_with("samx")
     sent_msg = ctx.actions._send.call_args.args[0]
     assert sent_msg.device == "samx"
     assert sent_msg.action == "rpc"
@@ -632,6 +801,7 @@ def test_rpc_call_returns_result_or_status(action_context):
     result = ctx.actions.rpc_call("samx", "kickoff")
 
     assert result is status
+    ctx.actions.acquire_device_lock.assert_called_with("samx")
     status.wait.assert_called_once_with(resolve_on_known_type=True)
 
 

--- a/bec_server/tests/tests_scan_server/test_device_lock_registry.py
+++ b/bec_server/tests/tests_scan_server/test_device_lock_registry.py
@@ -34,7 +34,51 @@ def test_device_lock_registry_logs_when_waiting_for_device():
 
     log_info.assert_called_once()
     assert "waiting for device lock" in log_info.call_args.args[0]
-    assert log_info.call_args.args[2] == "samx"
+
+
+def test_device_lock_registry_wait_log_is_throttled():
+    registry = DeviceLockRegistry()
+    with mock.patch("bec_server.scan_server.device_lock_registry.logger.info") as log_info:
+        next_log_time = 0.0
+        with mock.patch("bec_server.scan_server.device_lock_registry.time.monotonic") as monotonic:
+            monotonic.side_effect = [10.0, 12.0, 16.0]
+            next_log_time = registry._log_waiting_for_device_lock(
+                request_id="scan-2", blocked_owners={"samx": "scan-1"}, next_log_time=next_log_time
+            )
+            next_log_time = registry._log_waiting_for_device_lock(
+                request_id="scan-2", blocked_owners={"samx": "scan-1"}, next_log_time=next_log_time
+            )
+            registry._log_waiting_for_device_lock(
+                request_id="scan-2", blocked_owners={"samx": "scan-1"}, next_log_time=next_log_time
+            )
+
+    assert log_info.call_count == 2
+
+
+def test_device_lock_registry_logs_all_waiting_devices():
+    registry = DeviceLockRegistry()
+    registry.acquire("scan-1", "samx")
+    registry.acquire("scan-2", "samy")
+    wait_logged = threading.Event()
+
+    def release_after_wait_logged():
+        assert wait_logged.wait(timeout=1)
+        registry.release_all("scan-1")
+        registry.release_all("scan-2")
+
+    releaser = threading.Thread(target=release_after_wait_logged, daemon=True)
+    releaser.start()
+
+    with mock.patch("bec_server.scan_server.device_lock_registry.logger.info") as log_info:
+        log_info.side_effect = lambda *args, **kwargs: wait_logged.set()
+        registry.acquire_many("request-3", ["samx", "samz", "samy"])
+
+    releaser.join(timeout=1)
+
+    log_info.assert_called_once()
+    assert "samx, samy" in log_info.call_args.args[0]
+    assert "samx held by scan-1" in log_info.call_args.args[0]
+    assert "samy held by scan-2" in log_info.call_args.args[0]
 
 
 def test_device_lock_registry_runs_interruption_callback_outside_condition():
@@ -56,3 +100,59 @@ def test_device_lock_registry_runs_interruption_callback_outside_condition():
 
     assert callback_states
     assert callback_states == [False] * len(callback_states)
+
+
+def test_device_lock_registry_notifies_wait_state_callback_on_wait_transition():
+    registry = DeviceLockRegistry()
+    registry.acquire("scan-1", "samx")
+    wait_logged = threading.Event()
+    wait_states = []
+
+    def wait_state_callback(waiting_devices):
+        wait_states.append(waiting_devices)
+        if waiting_devices:
+            wait_logged.set()
+
+    releaser = threading.Thread(
+        target=lambda: (wait_logged.wait(timeout=1), registry.release_all("scan-1")), daemon=True
+    )
+    releaser.start()
+
+    registry.acquire("request-2", "samx", wait_state_callback=wait_state_callback)
+
+    releaser.join(timeout=1)
+
+    assert wait_states == [["samx"], []]
+
+
+def test_device_lock_registry_acquire_many_bundles_wait_state_updates():
+    registry = DeviceLockRegistry()
+    registry.acquire("scan-1", "samx")
+    registry.acquire("scan-2", "samy")
+    wait_logged = threading.Event()
+    wait_states = []
+
+    def wait_state_callback(waiting_devices):
+        wait_states.append(waiting_devices)
+        assert registry._condition._is_owned() is False
+        if waiting_devices:
+            wait_logged.set()
+
+    releaser = threading.Thread(
+        target=lambda: (
+            wait_logged.wait(timeout=1),
+            registry.release_all("scan-1"),
+            registry.release_all("scan-2"),
+        ),
+        daemon=True,
+    )
+    releaser.start()
+
+    acquired = registry.acquire_many(
+        "request-3", ["samx", "samz", "samy"], wait_state_callback=wait_state_callback
+    )
+
+    releaser.join(timeout=1)
+
+    assert acquired == ["samx", "samy", "samz"]
+    assert wait_states == [["samx", "samy"], []]

--- a/bec_server/tests/tests_scan_server/test_device_lock_registry.py
+++ b/bec_server/tests/tests_scan_server/test_device_lock_registry.py
@@ -102,15 +102,15 @@ def test_device_lock_registry_runs_interruption_callback_outside_condition():
     assert callback_states == [False] * len(callback_states)
 
 
-def test_device_lock_registry_notifies_wait_state_callback_on_wait_transition():
+def test_device_lock_registry_notifies_queue_update_callback_on_wait_transition():
     registry = DeviceLockRegistry()
     registry.acquire("scan-1", "samx")
     wait_logged = threading.Event()
     wait_states = []
 
-    def wait_state_callback(waiting_devices):
-        wait_states.append(waiting_devices)
-        if waiting_devices:
+    def queue_update_callback():
+        wait_states.append(registry.get_pending_devices("request-2"))
+        if wait_states[-1]:
             wait_logged.set()
 
     releaser = threading.Thread(
@@ -118,24 +118,24 @@ def test_device_lock_registry_notifies_wait_state_callback_on_wait_transition():
     )
     releaser.start()
 
-    registry.acquire("request-2", "samx", wait_state_callback=wait_state_callback)
+    registry.acquire("request-2", "samx", queue_update_callback=queue_update_callback)
 
     releaser.join(timeout=1)
 
     assert wait_states == [["samx"], []]
 
 
-def test_device_lock_registry_acquire_many_bundles_wait_state_updates():
+def test_device_lock_registry_acquire_many_bundles_queue_update_callback():
     registry = DeviceLockRegistry()
     registry.acquire("scan-1", "samx")
     registry.acquire("scan-2", "samy")
     wait_logged = threading.Event()
     wait_states = []
 
-    def wait_state_callback(waiting_devices):
-        wait_states.append(waiting_devices)
+    def queue_update_callback():
+        wait_states.append(registry.get_pending_devices("request-3"))
         assert registry._condition._is_owned() is False
-        if waiting_devices:
+        if wait_states[-1]:
             wait_logged.set()
 
     releaser = threading.Thread(
@@ -149,7 +149,7 @@ def test_device_lock_registry_acquire_many_bundles_wait_state_updates():
     releaser.start()
 
     acquired = registry.acquire_many(
-        "request-3", ["samx", "samz", "samy"], wait_state_callback=wait_state_callback
+        "request-3", ["samx", "samz", "samy"], queue_update_callback=queue_update_callback
     )
 
     releaser.join(timeout=1)

--- a/bec_server/tests/tests_scan_server/test_device_lock_registry.py
+++ b/bec_server/tests/tests_scan_server/test_device_lock_registry.py
@@ -1,0 +1,33 @@
+import threading
+import time
+from unittest import mock
+
+from bec_server.scan_server.device_lock_registry import DeviceLockRegistry
+
+
+def test_device_lock_registry_acquire_and_release():
+    registry = DeviceLockRegistry()
+
+    acquired = registry.acquire_many("scan-1", {"samx", "samy"})
+
+    assert acquired == ["samx", "samy"]
+    assert registry.release_all("scan-1") == ["samx", "samy"]
+
+
+def test_device_lock_registry_logs_when_waiting_for_device():
+    registry = DeviceLockRegistry()
+    registry.acquire("scan-1", "samx")
+
+    releaser = threading.Thread(
+        target=lambda: (time.sleep(0.05), registry.release_all("scan-1")), daemon=True
+    )
+    releaser.start()
+
+    with mock.patch("bec_server.scan_server.device_lock_registry.logger.info") as log_info:
+        registry.acquire("request-2", "samx")
+
+    releaser.join(timeout=1)
+
+    log_info.assert_called_once()
+    assert "waiting for device lock" in log_info.call_args.args[0]
+    assert log_info.call_args.args[2] == "samx"

--- a/bec_server/tests/tests_scan_server/test_device_lock_registry.py
+++ b/bec_server/tests/tests_scan_server/test_device_lock_registry.py
@@ -31,3 +31,24 @@ def test_device_lock_registry_logs_when_waiting_for_device():
     log_info.assert_called_once()
     assert "waiting for device lock" in log_info.call_args.args[0]
     assert log_info.call_args.args[2] == "samx"
+
+
+def test_device_lock_registry_runs_interruption_callback_outside_condition():
+    registry = DeviceLockRegistry()
+    registry.acquire("scan-1", "samx")
+    callback_states = []
+
+    def interruption_callback():
+        callback_states.append(registry._condition._is_owned())
+
+    releaser = threading.Thread(
+        target=lambda: (time.sleep(0.05), registry.release_all("scan-1")), daemon=True
+    )
+    releaser.start()
+
+    registry.acquire("request-2", "samx", interruption_callback=interruption_callback)
+
+    releaser.join(timeout=1)
+
+    assert callback_states
+    assert callback_states == [False] * len(callback_states)

--- a/bec_server/tests/tests_scan_server/test_device_lock_registry.py
+++ b/bec_server/tests/tests_scan_server/test_device_lock_registry.py
@@ -17,13 +17,17 @@ def test_device_lock_registry_acquire_and_release():
 def test_device_lock_registry_logs_when_waiting_for_device():
     registry = DeviceLockRegistry()
     registry.acquire("scan-1", "samx")
+    wait_logged = threading.Event()
 
-    releaser = threading.Thread(
-        target=lambda: (time.sleep(0.05), registry.release_all("scan-1")), daemon=True
-    )
+    def release_after_wait_logged():
+        assert wait_logged.wait(timeout=1)
+        registry.release_all("scan-1")
+
+    releaser = threading.Thread(target=release_after_wait_logged, daemon=True)
     releaser.start()
 
     with mock.patch("bec_server.scan_server.device_lock_registry.logger.info") as log_info:
+        log_info.side_effect = lambda *args, **kwargs: wait_logged.set()
         registry.acquire("request-2", "samx")
 
     releaser.join(timeout=1)

--- a/bec_server/tests/tests_scan_server/test_direct_scan_worker.py
+++ b/bec_server/tests/tests_scan_server/test_direct_scan_worker.py
@@ -170,6 +170,7 @@ def make_scan(direct_worker_context):
             called_steps=called_steps,
             fail_step=fail_step,
         )
+        scan.scan_info.metadata["RID"] = "rid-1"
         scan.actions._send_scan_status = mock.MagicMock()
         scan.actions.send_client_info = mock.MagicMock()
         scan._shutdown_event = mock.MagicMock()
@@ -342,6 +343,20 @@ def test_run_executes_modifier_hooks_in_order(direct_worker_context, make_scan):
         "close_scan",
         "modifier:after_close_scan",
     ]
+
+
+def test_run_releases_scan_locks_on_success(direct_worker_context, make_scan):
+    scan = make_scan()
+    direct_worker_context.queue.active_scan = scan
+    direct_worker_context.scan_worker.current_instruction_queue_item = direct_worker_context.queue
+    direct_worker_context.device_manager._rpc_method = mock.MagicMock(return_value=mock.MagicMock())
+    direct_worker_context.scan_server.device_lock_registry.release_all = mock.MagicMock()
+
+    direct_worker_context.direct_worker.run(scan)
+
+    direct_worker_context.scan_server.device_lock_registry.release_all.assert_called_once_with(
+        "rid-1"
+    )
 
 
 def test_run_returns_early_when_signal_event_is_set(direct_worker_context, make_scan):
@@ -649,6 +664,7 @@ def test_handle_scan_abortion_sends_abort_status_via_scan_actions(direct_worker_
     direct_worker_context.queue.run_on_exception_hook = True
     direct_worker_context.direct_worker.scan = scan
     direct_worker_context.direct_worker.reset = mock.MagicMock()
+    direct_worker_context.scan_server.device_lock_registry.release_all = mock.MagicMock()
 
     direct_worker_context.direct_worker._handle_scan_abortion(
         direct_worker_context.queue, ScanAbortion()
@@ -658,6 +674,9 @@ def test_handle_scan_abortion_sends_abort_status_via_scan_actions(direct_worker_
     assert direct_worker_context.queue.status == InstructionQueueStatus.STOPPED
     direct_worker_context.queue.append_to_queue_history.assert_called_once_with()
     direct_worker_context.queue_state.abort.assert_called_once_with()
+    direct_worker_context.scan_server.device_lock_registry.release_all.assert_called_once_with(
+        "rid-1"
+    )
     direct_worker_context.direct_worker.reset.assert_called_once_with()
     assert direct_worker_context.scan_worker.status == InstructionQueueStatus.RUNNING
 

--- a/bec_server/tests/tests_scan_server/test_direct_scan_worker.py
+++ b/bec_server/tests/tests_scan_server/test_direct_scan_worker.py
@@ -271,6 +271,7 @@ def test_run_executes_full_scan_sequence_in_order(direct_worker_context, make_sc
     direct_worker_context.scan_worker.current_instruction_queue_item = direct_worker_context.queue
     rpc_cm = mock.MagicMock()
     direct_worker_context.device_manager._rpc_method = mock.MagicMock(return_value=rpc_cm)
+    scan.actions._initialize_scan = mock.MagicMock()
 
     direct_worker_context.direct_worker.run(scan)
 
@@ -282,6 +283,7 @@ def test_run_executes_full_scan_sequence_in_order(direct_worker_context, make_sc
         scan.actions._update_queue_info_callback
         == direct_worker_context.direct_worker.update_queue_info
     )
+    scan.actions._initialize_scan.assert_called_once_with()
     direct_worker_context.device_manager._rpc_method.assert_called_once_with(scan.actions.rpc_call)
     assert called_steps == [
         "prepare_scan",
@@ -297,6 +299,23 @@ def test_run_executes_full_scan_sequence_in_order(direct_worker_context, make_sc
     assert direct_worker_context.queue.status == InstructionQueueStatus.COMPLETED
     assert direct_worker_context.scan_worker.current_instruction_queue_item is None
     assert direct_worker_context.direct_worker.scan is None
+
+
+def test_run_initializes_scan_before_scan_sequence(direct_worker_context, make_scan):
+    called_steps = []
+    scan = make_scan(called_steps=called_steps)
+    direct_worker_context.queue.active_scan = scan
+    direct_worker_context.scan_worker.current_instruction_queue_item = direct_worker_context.queue
+    direct_worker_context.device_manager._rpc_method = mock.MagicMock(return_value=mock.MagicMock())
+
+    def initialize_scan():
+        called_steps.append("_initialize_scan")
+
+    scan.actions._initialize_scan = mock.MagicMock(side_effect=initialize_scan)
+
+    direct_worker_context.direct_worker.run(scan)
+
+    assert called_steps[:2] == ["_initialize_scan", "prepare_scan"]
 
 
 def test_run_executes_modifier_hooks_in_order(direct_worker_context, make_scan):

--- a/bec_server/tests/tests_scan_server/test_scan_assembler.py
+++ b/bec_server/tests/tests_scan_server/test_scan_assembler.py
@@ -12,6 +12,7 @@ from bec_server.scan_server.scan_assembler import ScanAssembler
 from bec_server.scan_server.scans import ScanArgType
 from bec_server.scan_server.scans.acquire import Acquire
 from bec_server.scan_server.scans.legacy_scans import FermatSpiralScan, LineScan, RequestBase
+from bec_server.scan_server.scans.scan_argument_modifier import scan_signature_with_modifiers
 from bec_server.scan_server.tests.utils import NoopScan
 
 
@@ -326,6 +327,40 @@ def test_scan_assembler_assemble_direct_scan_resolves_device_args(dm_with_device
         2,
     )
     assert request.scan_info.request_inputs["arg_bundle"] == ["samx", 1, "samy", 2]
+
+
+def test_scan_assembler_assemble_direct_scan_propagates_monitored_kwarg(dm_with_devices):
+    parent = mock.MagicMock()
+    parent.device_manager = dm_with_devices
+    parent.connector = mock.MagicMock()
+    parent.queue_manager.instruction_handler = mock.MagicMock()
+    assembler = ScanAssembler(parent=parent)
+    scan_info = {
+        "arg_input": assembler._serialize_arg_input(CustomDirectScan.arg_input),
+        "required_kwargs": [],
+        "arg_bundle_size": CustomDirectScan.arg_bundle_size,
+        "doc": CustomDirectScan.__doc__ or CustomDirectScan.__init__.__doc__,
+        "signature": scan_signature_with_modifiers(CustomDirectScan),
+        "base_class": "ScanBaseV4",
+    }
+
+    class MockScanManager:
+        available_scans = {"custom_direct_scan": scan_info}
+        scan_dict = {"custom_direct_scan": CustomDirectScan}
+
+    msg = messages.ScanQueueMessage(
+        scan_type="custom_direct_scan",
+        parameter={
+            "args": {"samx": (1,)},
+            "kwargs": {"system_config": {"file_directory": "/tmp/data"}, "monitored": ["bpm4i"]},
+        },
+        queue="primary",
+    )
+
+    with mock.patch.object(assembler, "scan_manager", MockScanManager()):
+        request = assembler.assemble_direct_scan(msg, "scan_id")
+
+    assert request.scan_info.readout_priority_modification["monitored"] == ["bpm4i"]
 
 
 def test_scan_assembler_assemble_direct_scan_resolves_annotated_device_args(dm_with_devices):

--- a/bec_server/tests/tests_scan_server/test_scan_server_queue.py
+++ b/bec_server/tests/tests_scan_server/test_scan_server_queue.py
@@ -618,6 +618,9 @@ def test_set_continue(queuemanager_mock):
 def test_set_abort(queuemanager_mock):
     queue_manager = queuemanager_mock()
     queue_manager.connector.message_sent = []
+    queue_manager.parent.device_lock_registry.get_owned_devices = mock.MagicMock(
+        return_value=["samx"]
+    )
     msg = messages.ScanQueueMessage(
         scan_type="mv",
         parameter={"args": {"samx": (1,)}, "kwargs": {}},
@@ -636,7 +639,7 @@ def test_set_abort(queuemanager_mock):
         time.sleep(0.1)
     assert {
         "queue": MessageEndpoints.stop_devices(),
-        "msg": messages.VariableMessage(value=[], metadata={"stop_id": queue_id}),
+        "msg": messages.VariableMessage(value=["samx"], metadata={"stop_id": queue_id}),
     } in queue_manager.connector.message_sent
     assert (
         queue_manager.connector.message_sent[0].get("queue") == MessageEndpoints.scan_queue_status()
@@ -647,6 +650,9 @@ def test_set_abort(queuemanager_mock):
 def test_set_abort_with_scan_id(queuemanager_mock):
     queue_manager = queuemanager_mock()
     queue_manager.connector.message_sent = []
+    queue_manager.parent.device_lock_registry.get_owned_devices = mock.MagicMock(
+        return_value=["samx", "samy"]
+    )
     msg = messages.ScanQueueMessage(
         scan_type="line_scan",
         parameter={"args": {"samx": (-1, 1)}, "kwargs": {"steps": 10, "relative": False}},
@@ -665,7 +671,9 @@ def test_set_abort_with_scan_id(queuemanager_mock):
         time.sleep(0.1)
     assert {
         "queue": MessageEndpoints.stop_devices(),
-        "msg": messages.VariableMessage(value=[], metadata={"stop_id": [scan_id_abort]}),
+        "msg": messages.VariableMessage(
+            value=["samx", "samy"], metadata={"stop_id": [scan_id_abort]}
+        ),
     } in queue_manager.connector.message_sent
     assert (
         queue_manager.connector.message_sent[0].get("queue") == MessageEndpoints.scan_queue_status()

--- a/bec_server/tests/tests_scan_server/test_scan_server_queue.py
+++ b/bec_server/tests/tests_scan_server/test_scan_server_queue.py
@@ -341,9 +341,6 @@ def test_direct_instruction_queue_describe_active_scan_returns_none_when_missing
 
 def test_direct_instruction_queue_describe_active_scan_returns_request_block(queuemanager_mock):
     queue_manager = queuemanager_mock()
-    queue_manager.parent.device_lock_registry.get_owned_devices = mock.MagicMock(
-        return_value=["samx"]
-    )
     queue = DirectInstructionQueueItem(
         queue_manager.queues["primary"],
         mock.MagicMock(),
@@ -362,7 +359,9 @@ def test_direct_instruction_queue_describe_active_scan_returns_request_block(que
     queue.scan_msgs = [msg]
     scan.scan_info.metadata["RID"] = "rid-1"
     queue.active_scan = scan
-    scan.actions._pending_device_locks.update({"samx", "samy"})
+    scan.device_manager.parent.device_lock_registry = mock.MagicMock()
+    scan.device_manager.parent.device_lock_registry.get_owned_devices.return_value = ["samx"]
+    scan.actions._queued_device_locks.update({"samx", "samy"})
 
     info = queue.describe_active_scan()
 

--- a/bec_server/tests/tests_scan_server/test_scan_server_queue.py
+++ b/bec_server/tests/tests_scan_server/test_scan_server_queue.py
@@ -813,7 +813,7 @@ def test_stop_all_devices_preserves_empty_list_for_stop_none(queuemanager_mock):
 
 
 @pytest.mark.timeout(5)
-def test_set_abort_with_no_owned_devices_sends_stop_none(queuemanager_mock):
+def test_set_abort_with_no_owned_devices_sends_stop_all_for_legacy_queue(queuemanager_mock):
     queue_manager = queuemanager_mock()
     queue_manager.connector.message_sent = []
     queue_manager.parent.device_lock_registry.get_owned_devices = mock.MagicMock(return_value=[])
@@ -834,7 +834,7 @@ def test_set_abort_with_no_owned_devices_sends_stop_none(queuemanager_mock):
 
     assert {
         "queue": MessageEndpoints.stop_devices(),
-        "msg": messages.VariableMessage(value=[], metadata={"stop_id": queue_id}),
+        "msg": messages.VariableMessage(value=None, metadata={"stop_id": queue_id}),
     } in queue_manager.connector.message_sent
 
 
@@ -1583,7 +1583,9 @@ def test_queue_manager_get_active_scan_id_wo_rbl_returns_None(queuemanager_mock)
     assert queue_manager._get_active_scan_id("primary") == None
 
 
-def test_get_owned_devices_for_instruction_queue_returns_empty_without_registry(queuemanager_mock):
+def test_get_owned_devices_for_instruction_queue_returns_none_without_registry_for_legacy_queue(
+    queuemanager_mock,
+):
     queue_manager = queuemanager_mock()
     instruction_queue = InstructionQueueItem(
         queue_manager.queues["primary"], mock.MagicMock(), mock.MagicMock()
@@ -1591,7 +1593,7 @@ def test_get_owned_devices_for_instruction_queue_returns_empty_without_registry(
 
     queue_manager.parent.device_lock_registry = None
 
-    assert queue_manager._get_owned_devices_for_instruction_queue(instruction_queue) == []
+    assert queue_manager._get_owned_devices_for_instruction_queue(instruction_queue) is None
 
 
 def test_get_owned_devices_for_instruction_queue_uses_request_block_rid(queuemanager_mock):
@@ -1621,7 +1623,32 @@ def test_get_owned_devices_for_instruction_queue_uses_request_block_rid(queueman
     queue_manager.parent.device_lock_registry.get_owned_devices.assert_called_once_with("rid-123")
 
 
-def test_get_owned_devices_for_instruction_queue_returns_empty_without_request_block(
+def test_get_owned_devices_for_instruction_queue_returns_none_for_legacy_queue_without_locks(
+    queuemanager_mock,
+):
+    queue_manager = queuemanager_mock()
+    instruction_queue = InstructionQueueItem(
+        queue_manager.queues["primary"], mock.MagicMock(), mock.MagicMock()
+    )
+    msg = messages.ScanQueueMessage(
+        scan_type="mv",
+        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        queue="primary",
+        metadata={"RID": "rid-123"},
+    )
+    assembler = mock.MagicMock()
+    assembler.is_scan_message.return_value = False
+    assembler.assemble_device_instructions.return_value = mock.MagicMock(
+        run=mock.MagicMock(return_value=iter(())), readout_priority={}
+    )
+    instruction_queue.queue.active_rb = RequestBlock(msg, assembler, instruction_queue.queue)
+    queue_manager.parent.device_lock_registry.get_owned_devices = mock.MagicMock(return_value=[])
+
+    assert queue_manager._get_owned_devices_for_instruction_queue(instruction_queue) is None
+    queue_manager.parent.device_lock_registry.get_owned_devices.assert_called_once_with("rid-123")
+
+
+def test_get_owned_devices_for_instruction_queue_returns_none_without_request_block(
     queuemanager_mock,
 ):
     queue_manager = queuemanager_mock()
@@ -1631,7 +1658,7 @@ def test_get_owned_devices_for_instruction_queue_returns_empty_without_request_b
     instruction_queue.queue.active_rb = None
     queue_manager.parent.device_lock_registry.get_owned_devices = mock.MagicMock()
 
-    assert queue_manager._get_owned_devices_for_instruction_queue(instruction_queue) == []
+    assert queue_manager._get_owned_devices_for_instruction_queue(instruction_queue) is None
     queue_manager.parent.device_lock_registry.get_owned_devices.assert_not_called()
 
 

--- a/bec_server/tests/tests_scan_server/test_scan_server_queue.py
+++ b/bec_server/tests/tests_scan_server/test_scan_server_queue.py
@@ -777,6 +777,60 @@ def test_set_abort_with_empty_queue(queuemanager_mock):
     assert len(queue_manager.connector.message_sent) == 0
 
 
+def test_stop_all_devices_preserves_none_for_stop_all(queuemanager_mock):
+    queue_manager = queuemanager_mock()
+    queue_manager.connector.message_sent = []
+
+    queue_manager.stop_all_devices(stop_id="stop-all")
+
+    assert queue_manager.connector.message_sent == [
+        {
+            "queue": MessageEndpoints.stop_devices(),
+            "msg": messages.VariableMessage(value=None, metadata={"stop_id": "stop-all"}),
+        }
+    ]
+
+
+def test_stop_all_devices_preserves_empty_list_for_stop_none(queuemanager_mock):
+    queue_manager = queuemanager_mock()
+    queue_manager.connector.message_sent = []
+
+    queue_manager.stop_all_devices(stop_id="stop-none", devices=[])
+
+    assert queue_manager.connector.message_sent == [
+        {
+            "queue": MessageEndpoints.stop_devices(),
+            "msg": messages.VariableMessage(value=[], metadata={"stop_id": "stop-none"}),
+        }
+    ]
+
+
+@pytest.mark.timeout(5)
+def test_set_abort_with_no_owned_devices_sends_stop_none(queuemanager_mock):
+    queue_manager = queuemanager_mock()
+    queue_manager.connector.message_sent = []
+    queue_manager.parent.device_lock_registry.get_owned_devices = mock.MagicMock(return_value=[])
+    msg = messages.ScanQueueMessage(
+        scan_type="mv",
+        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        queue="primary",
+        metadata={"RID": "something"},
+    )
+    queue_manager.add_to_queue(scan_queue="primary", msg=msg)
+    scan_queue = queue_manager.queues["primary"]
+    while scan_queue.scan_worker.current_instruction_queue_item is None:
+        time.sleep(0.1)
+
+    queue_id = scan_queue.queue[0].queue_id
+    queue_manager.set_abort(queue="primary")
+    wait_to_reach_state(queue_manager, "primary", ScanQueueStatus.PAUSED)
+
+    assert {
+        "queue": MessageEndpoints.stop_devices(),
+        "msg": messages.VariableMessage(value=[], metadata={"stop_id": queue_id}),
+    } in queue_manager.connector.message_sent
+
+
 @pytest.mark.timeout(5)
 def test_set_clear_sends_message(queuemanager_mock):
     queue_manager = queuemanager_mock()

--- a/bec_server/tests/tests_scan_server/test_scan_server_queue.py
+++ b/bec_server/tests/tests_scan_server/test_scan_server_queue.py
@@ -329,6 +329,7 @@ def test_direct_instruction_queue_describe_active_scan_returns_none_when_missing
         mock.MagicMock(),
         queue_manager.queues["primary"].scan_worker,
     )
+    queue_manager.queues["primary"].queue.append(queue)
     scan = _build_dummy_v4_scan("scan-id-test")
 
     assert queue.describe_active_scan() is None
@@ -340,6 +341,9 @@ def test_direct_instruction_queue_describe_active_scan_returns_none_when_missing
 
 def test_direct_instruction_queue_describe_active_scan_returns_request_block(queuemanager_mock):
     queue_manager = queuemanager_mock()
+    queue_manager.parent.device_lock_registry.get_owned_devices = mock.MagicMock(
+        return_value=["samx"]
+    )
     queue = DirectInstructionQueueItem(
         queue_manager.queues["primary"],
         mock.MagicMock(),
@@ -356,7 +360,9 @@ def test_direct_instruction_queue_describe_active_scan_returns_request_block(que
     )
     queue.scans = [scan]
     queue.scan_msgs = [msg]
+    scan.scan_info.metadata["RID"] = "rid-1"
     queue.active_scan = scan
+    scan.actions._pending_device_locks.update({"samx", "samy"})
 
     info = queue.describe_active_scan()
 
@@ -364,6 +370,8 @@ def test_direct_instruction_queue_describe_active_scan_returns_request_block(que
     assert info.RID == "rid-1"
     assert info.report_instructions == [{"device": "samx"}]
     assert info.scan_id == "scan-id-test"
+    assert info.owned_device_locks == ["samx"]
+    assert info.pending_device_locks == []
 
 
 def test_direct_instruction_queue_move_to_next_scan_activates_and_assigns_numbers(

--- a/bec_server/tests/tests_scan_server/test_scan_server_queue.py
+++ b/bec_server/tests/tests_scan_server/test_scan_server_queue.py
@@ -1514,6 +1514,92 @@ def test_queue_manager_get_active_scan_id_wo_rbl_returns_None(queuemanager_mock)
     assert queue_manager._get_active_scan_id("primary") == None
 
 
+def test_get_owned_devices_for_instruction_queue_returns_empty_without_registry(queuemanager_mock):
+    queue_manager = queuemanager_mock()
+    instruction_queue = InstructionQueueItem(
+        queue_manager.queues["primary"], mock.MagicMock(), mock.MagicMock()
+    )
+
+    queue_manager.parent.device_lock_registry = None
+
+    assert queue_manager._get_owned_devices_for_instruction_queue(instruction_queue) == []
+
+
+def test_get_owned_devices_for_instruction_queue_uses_request_block_rid(queuemanager_mock):
+    queue_manager = queuemanager_mock()
+    instruction_queue = InstructionQueueItem(
+        queue_manager.queues["primary"], mock.MagicMock(), mock.MagicMock()
+    )
+    msg = messages.ScanQueueMessage(
+        scan_type="mv",
+        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        queue="primary",
+        metadata={"RID": "rid-123"},
+    )
+    assembler = mock.MagicMock()
+    assembler.is_scan_message.return_value = False
+    assembler.assemble_device_instructions.return_value = mock.MagicMock(
+        run=mock.MagicMock(return_value=iter(())), readout_priority={}
+    )
+    instruction_queue.queue.active_rb = RequestBlock(msg, assembler, instruction_queue.queue)
+    queue_manager.parent.device_lock_registry.get_owned_devices = mock.MagicMock(
+        return_value=["samx", "samy"]
+    )
+
+    owned_devices = queue_manager._get_owned_devices_for_instruction_queue(instruction_queue)
+
+    assert owned_devices == ["samx", "samy"]
+    queue_manager.parent.device_lock_registry.get_owned_devices.assert_called_once_with("rid-123")
+
+
+def test_get_owned_devices_for_instruction_queue_returns_empty_without_request_block(
+    queuemanager_mock,
+):
+    queue_manager = queuemanager_mock()
+    instruction_queue = InstructionQueueItem(
+        queue_manager.queues["primary"], mock.MagicMock(), mock.MagicMock()
+    )
+    instruction_queue.queue.active_rb = None
+    queue_manager.parent.device_lock_registry.get_owned_devices = mock.MagicMock()
+
+    assert queue_manager._get_owned_devices_for_instruction_queue(instruction_queue) == []
+    queue_manager.parent.device_lock_registry.get_owned_devices.assert_not_called()
+
+
+def test_get_owned_devices_for_instruction_queue_uses_active_scan_rid_for_direct_item(
+    queuemanager_mock,
+):
+    queue_manager = queuemanager_mock()
+    instruction_queue = DirectInstructionQueueItem(
+        queue_manager.queues["primary"], mock.MagicMock(), mock.MagicMock()
+    )
+    instruction_queue.active_scan = _build_dummy_v4_scan("scan-id")
+    instruction_queue.active_scan.scan_info.metadata["RID"] = "rid-456"
+    queue_manager.parent.device_lock_registry.get_owned_devices = mock.MagicMock(
+        return_value=["samz"]
+    )
+
+    owned_devices = queue_manager._get_owned_devices_for_instruction_queue(instruction_queue)
+
+    assert owned_devices == ["samz"]
+    queue_manager.parent.device_lock_registry.get_owned_devices.assert_called_once_with("rid-456")
+
+
+@pytest.mark.parametrize("active_scan", [None, _build_dummy_v4_scan("scan-id-without-rid")])
+def test_get_owned_devices_for_instruction_queue_returns_empty_for_direct_item_without_rid(
+    queuemanager_mock, active_scan
+):
+    queue_manager = queuemanager_mock()
+    instruction_queue = DirectInstructionQueueItem(
+        queue_manager.queues["primary"], mock.MagicMock(), mock.MagicMock()
+    )
+    instruction_queue.active_scan = active_scan
+    queue_manager.parent.device_lock_registry.get_owned_devices = mock.MagicMock()
+
+    assert queue_manager._get_owned_devices_for_instruction_queue(instruction_queue) == []
+    queue_manager.parent.device_lock_registry.get_owned_devices.assert_not_called()
+
+
 def test_request_block_queue_next():
     req_block_queue = RequestBlockQueue(mock.MagicMock(), mock.MagicMock())
     msg = messages.ScanQueueMessage(


### PR DESCRIPTION
## Description

This PR adds an ownership model to the device serializer and uses the ownership modes to determine whether a scan should acquire a lock for the duration of the scan. Moreover, only owned devices are used in stateful operations, such as stage, unstage and stop_all_devices. 

These changes are only applied to v4-type scans.


## Definition of Done
- [ ] Documentation is up-to-date.

