### PR TITLE
feat(storage_copy): implement beamline storage copy functionality and…

### DIFF
--- a/bec_lib/bec_lib/client.py
+++ b/bec_lib/bec_lib/client.py
@@ -27,9 +27,10 @@ from bec_lib.config_helper import ConfigHelperUser
 from bec_lib.dap_plugins import DAPPlugins
 from bec_lib.devicemanager import DeviceManagerBase
 from bec_lib.endpoints import MessageEndpoints
+from bec_lib.file_utils import sanitize_relative_subdir
 from bec_lib.logger import bec_logger
 from bec_lib.messaging_services import MessagingContainer
-from bec_lib.plugin_helper import _get_available_plugins
+from bec_lib.plugin_helper import _get_available_plugins, get_file_writer_storage_copy_plugin
 from bec_lib.procedures.hli import ProcedureHli
 from bec_lib.scan_history import ScanHistory
 from bec_lib.script_executor import ScriptExecutor
@@ -40,7 +41,12 @@ from bec_lib.utils.import_utils import lazy_import_from
 logger = bec_logger.logger
 
 if TYPE_CHECKING:  # pragma: no cover
-    from bec_lib.messages import BECStatus, ServiceRequestMessage, VariableMessage
+    from bec_lib.messages import (
+        BECStatus,
+        ServiceRequestMessage,
+        StorageCopyRequestMessage,
+        VariableMessage,
+    )
     from bec_lib.redis_connector import RedisConnector
     from bec_lib.scan_manager import ScanManager
     from bec_lib.scans import Scans
@@ -52,6 +58,7 @@ else:
     ScanManager = lazy_import_from("bec_lib.scan_manager", ("ScanManager",))
     Scans = lazy_import_from("bec_lib.scans", ("Scans",))
     ServiceRequestMessage = lazy_import_from("bec_lib.messages", ("ServiceRequestMessage",))
+    StorageCopyRequestMessage = lazy_import_from("bec_lib.messages", ("StorageCopyRequestMessage",))
 
 
 class SystemConfig(BaseModel):
@@ -254,6 +261,29 @@ class BECClient(BECService):
     def clear_all_alarms(self):
         """remove all alarms from stack"""
         self.alarm_handler.clear()
+
+    def beamline_storage_copy(
+        self, source_file: str, scope: str, subdir: str | None = None
+    ) -> None:
+        """
+        Request a file transfer via the installed beamline storage-copy plugin.
+
+        Args:
+            source_file (str): Path to the source file.
+            scope (str): Beamline-defined transfer scope.
+            subdir (str | None): Optional relative destination subdirectory.
+
+        Raises:
+            RuntimeError: If no storage-copy plugin is installed.
+        """
+        if get_file_writer_storage_copy_plugin() is None:
+            raise RuntimeError("No file-writer storage copy plugin is installed.")
+        self.connector.send(
+            MessageEndpoints.storage_copy_request(),
+            StorageCopyRequestMessage(
+                source_file=source_file, scope=scope, subdir=sanitize_relative_subdir(subdir)
+            ),
+        )
 
     @property
     def pre_scan_macros(self):

--- a/bec_lib/bec_lib/endpoints.py
+++ b/bec_lib/bec_lib/endpoints.py
@@ -1074,6 +1074,22 @@ class MessageEndpoints:
             message_op=MessageOp.SET_PUBLISH,
         )
 
+    @staticmethod
+    def storage_copy_request():
+        """
+        Endpoint for storage copy request. This endpoint is used to request a copy of a file
+        from one storage location to another using a messages.StorageCopyRequestMessage message.
+
+        Returns:
+            EndpointInfo: Endpoint for storage copy request.
+        """
+        endpoint = f"{EndpointType.USER.value}/storage/copy_request"
+        return EndpointInfo(
+            endpoint=endpoint,
+            message_type=messages.StorageCopyRequestMessage,
+            message_op=MessageOp.SEND,
+        )
+
     # log
     @staticmethod
     def log():

--- a/bec_lib/bec_lib/file_utils.py
+++ b/bec_lib/bec_lib/file_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import time
 import warnings
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
 
 from bec_lib.bec_errors import ServiceConfigError
@@ -120,6 +121,44 @@ class DeviceConfigWriter:
 
 class FileWriterError(Exception):
     """Exception for errors in the file writer"""
+
+
+def sanitize_relative_subdir(subdir: str | None) -> str | None:
+    """
+    Normalize an optional relative subdirectory and strip path traversal parts.
+
+    Args:
+        subdir (str | None): User-provided relative subdirectory.
+
+    Returns:
+        str | None: A normalized safe relative path, or ``None`` if nothing remains.
+    """
+    if subdir is None:
+        return None
+
+    normalized = subdir.replace("\\", "/").strip()
+    if not normalized:
+        return None
+
+    safe_parts = []
+    for part in PurePosixPath(normalized).parts:
+        if part in ("", ".", ".."):
+            continue
+        part = part.strip("/")
+        if not part:
+            continue
+        if set(part) == {"."}:
+            continue
+        part = part.lstrip("~")
+        if not part:
+            continue
+        if part.endswith(":"):
+            continue
+        safe_parts.append(part)
+
+    if not safe_parts:
+        return None
+    return "/".join(safe_parts)
 
 
 def compile_file_components(

--- a/bec_lib/bec_lib/messages.py
+++ b/bec_lib/bec_lib/messages.py
@@ -1264,6 +1264,22 @@ class FileContentMessage(BECMessage):
     scan_info: dict
 
 
+class StorageCopyRequestMessage(BECMessage):
+    """Message to request a copy of a file to a storage location
+
+    Args:
+        source_file (str): Path to the source file.
+        scope (str): Scope of the copy request.
+        subdir (str | None): Optional relative destination subdirectory.
+        metadata (dict, optional): Additional metadata. Defaults to None.
+    """
+
+    msg_type: ClassVar[str] = "storage_copy_request_message"
+    source_file: str
+    scope: str
+    subdir: str | None = None
+
+
 class VariableMessage(BECMessage):
     """Message to inform about a global variable
 

--- a/bec_lib/bec_lib/plugin_helper.py
+++ b/bec_lib/bec_lib/plugin_helper.py
@@ -7,7 +7,7 @@ import json
 import pkgutil
 import sys
 from functools import cache, lru_cache
-from typing import TYPE_CHECKING, Any, Literal, Type
+from typing import TYPE_CHECKING, Any, Callable, Literal, Type
 
 from bec_lib.logger import bec_logger
 
@@ -148,6 +148,43 @@ def get_file_writer_plugins() -> dict:
 
 
 @cache
+def get_file_writer_storage_copy_plugin() -> Callable[[str, str, str, str | None], None] | None:
+    """
+    Load the storage-copy hook exposed by the installed plugin repository.
+
+    Returns:
+        Callable[[str, str, str, str | None], None] | None:
+            A callable accepting ``source_file``, ``scope``, ``active_account`` and ``subdir``,
+            or ``None`` if no hook is installed.
+    """
+    group = "bec.file_writer.storage_copy"
+    target = "plugin_storage_copy"
+    entry_points = [entry_point for entry_point in importlib.metadata.entry_points(group=group)]
+    matching_entry_points = [
+        entry_point for entry_point in entry_points if entry_point.name == target
+    ]
+
+    if not matching_entry_points:
+        return None
+
+    if len(matching_entry_points) > 1:
+        logger.warning(
+            f"Multiple storage copy plugins discovered for {group!r}. Using the first {target!r} entry point."
+        )
+
+    try:
+        plugin = matching_entry_points[0].load()
+    except Exception as exc:
+        logger.error(f"Error loading storage copy plugin {target}: {exc}")
+        return None
+
+    if not callable(plugin):
+        logger.error(f"Storage copy plugin {target} is not callable: {plugin!r}")
+        return None
+    return plugin
+
+
+@cache
 def get_metadata_schema_registry() -> tuple[dict, type[BasicScanMetadata]]:
     module = _get_available_plugins("bec.scans.metadata_schema")
     if len(module) == 0:
@@ -221,6 +258,7 @@ def reload_plugin_modules() -> None:
     logger.info("Reloading plugin modules...")
     _get_available_plugins.cache_clear()
     _import_module.cache_clear()
+    get_file_writer_storage_copy_plugin.cache_clear()
     get_metadata_schema_registry.cache_clear()
     try:
         _plugin_package_name = plugin_package_name()

--- a/bec_lib/tests/test_bec_messages.py
+++ b/bec_lib/tests/test_bec_messages.py
@@ -230,6 +230,18 @@ def test_ScanBaselineMessage():
     assert res_loaded == msg
 
 
+def test_StorageCopyRequestMessage():
+    msg = messages.StorageCopyRequestMessage(
+        source_file="/tmp/source.h5",
+        scope="flomni_alignment",
+        subdir="results/nested",
+        metadata={"RID": "1234"},
+    )
+    res = MsgpackSerialization.dumps(msg)
+    res_loaded = MsgpackSerialization.loads(res)
+    assert res_loaded == msg
+
+
 @pytest.mark.parametrize(
     "action,valid",
     [("add", True), ("set", True), ("update", True), ("reload", True), ("wrong_action", False)],

--- a/bec_lib/tests/test_client.py
+++ b/bec_lib/tests/test_client.py
@@ -1,10 +1,13 @@
 """This module tests the bec_lib.client module."""
 
+from unittest import mock
+
 import pytest
 
 from bec_lib import messages
 from bec_lib.client import SystemConfig
 from bec_lib.endpoints import MessageEndpoints
+from bec_lib.file_utils import sanitize_relative_subdir
 from bec_lib.tests.fixtures import bec_client_mock
 
 
@@ -50,3 +53,56 @@ def test_request_scan_reload_requires_initialized_client(bec_client_mock):
 
     with pytest.raises(RuntimeError, match="Client not initialized. Cannot reload scans."):
         client._request_scan_reload()
+
+
+def test_beamline_storage_copy(bec_client_mock):
+    client = bec_client_mock
+
+    with mock.patch("bec_lib.client.get_file_writer_storage_copy_plugin", return_value=mock.Mock()):
+        client.beamline_storage_copy("/tmp/test.h5", "flomni_alignment")
+
+    client.connector.send.assert_called_once_with(
+        MessageEndpoints.storage_copy_request(),
+        messages.StorageCopyRequestMessage(
+            source_file="/tmp/test.h5", scope="flomni_alignment", subdir=None
+        ),
+    )
+
+
+def test_beamline_storage_copy_sanitizes_subdir(bec_client_mock):
+    client = bec_client_mock
+
+    with mock.patch("bec_lib.client.get_file_writer_storage_copy_plugin", return_value=mock.Mock()):
+        client.beamline_storage_copy("/tmp/test.h5", "flomni_alignment", "../results/./nested")
+
+    client.connector.send.assert_called_once_with(
+        MessageEndpoints.storage_copy_request(),
+        messages.StorageCopyRequestMessage(
+            source_file="/tmp/test.h5", scope="flomni_alignment", subdir="results/nested"
+        ),
+    )
+
+
+def test_beamline_storage_copy_requires_plugin(bec_client_mock):
+    client = bec_client_mock
+
+    with mock.patch("bec_lib.client.get_file_writer_storage_copy_plugin", return_value=None):
+        with pytest.raises(RuntimeError, match="No file-writer storage copy plugin is installed."):
+            client.beamline_storage_copy("/tmp/test.h5", "flomni_alignment")
+
+    client.connector.send.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "subdir, expected",
+    [
+        (None, None),
+        ("", None),
+        ("../foo", "foo"),
+        ("/absolute/path", "absolute/path"),
+        ("..\\windows\\path", "windows/path"),
+        ("safe/dir", "safe/dir"),
+    ],
+)
+def test_sanitize_relative_subdir(subdir, expected):
+    assert sanitize_relative_subdir(subdir) == expected

--- a/bec_lib/tests/test_file_utils.py
+++ b/bec_lib/tests/test_file_utils.py
@@ -17,6 +17,7 @@ from bec_lib.file_utils import (
     LogWriter,
     compile_file_components,
     get_full_path,
+    sanitize_relative_subdir,
     wait_for_directory,
 )
 from bec_lib.messages import ScanStatusMessage
@@ -260,6 +261,36 @@ def test_compile_file_components_valid_paths(kwargs, expected_path, description)
     file_path, extension = compile_file_components(base_path="/tmp", scan_nr=10, **kwargs)
     assert extension == "h5", description
     assert file_path == expected_path, description
+
+
+@pytest.mark.parametrize(
+    "subdir, expected",
+    [
+        (None, None),
+        ("", None),
+        ("   ", None),
+        (".", None),
+        ("./", None),
+        ("../..", None),
+        ("../foo", "foo"),
+        ("../../foo/../bar", "foo/bar"),
+        ("foo/../../bar/./baz", "foo/bar/baz"),
+        ("/absolute/path", "absolute/path"),
+        ("//network/share/results", "network/share/results"),
+        ("~/results", "results"),
+        ("~/../results", "results"),
+        ("~user/shared/output", "user/shared/output"),
+        ("folder//nested///result", "folder/nested/result"),
+        ("folder/./nested/../result", "folder/nested/result"),
+        (".../not-parent", "not-parent"),
+        ("C:/beamline/results", "beamline/results"),
+        ("~/", None),
+        ("....", None),
+        ("safe/dir", "safe/dir"),
+    ],
+)
+def test_sanitize_relative_subdir(subdir, expected):
+    assert sanitize_relative_subdir(subdir) == expected
 
 
 def test_wait_for_directory_returns_when_directory_appears(tmpdir):

--- a/bec_lib/tests/test_plugin_helper.py
+++ b/bec_lib/tests/test_plugin_helper.py
@@ -123,3 +123,81 @@ def test_get_scan_component_plugins(monkeypatch):
     result = plugin_helper.get_scan_component_plugins()
 
     assert result == [plugin_components]
+
+
+def test_get_file_writer_storage_copy_plugin(monkeypatch):
+    handler = mock.Mock()
+
+    monkeypatch.setattr(
+        plugin_helper.importlib.metadata,
+        "entry_points",
+        lambda group: [SimpleNamespace(name="plugin_storage_copy", load=lambda: handler)],
+    )
+    plugin_helper.get_file_writer_storage_copy_plugin.cache_clear()
+
+    result = plugin_helper.get_file_writer_storage_copy_plugin()
+
+    assert result is handler
+
+
+def test_get_file_writer_storage_copy_plugin_returns_none_without_match(monkeypatch):
+    monkeypatch.setattr(plugin_helper.importlib.metadata, "entry_points", lambda group: [])
+    plugin_helper.get_file_writer_storage_copy_plugin.cache_clear()
+
+    result = plugin_helper.get_file_writer_storage_copy_plugin()
+
+    assert result is None
+
+
+def test_get_file_writer_storage_copy_plugin_warns_for_multiple_matches(monkeypatch):
+    first_handler = mock.Mock()
+    second_handler = mock.Mock()
+
+    monkeypatch.setattr(
+        plugin_helper.importlib.metadata,
+        "entry_points",
+        lambda group: [
+            SimpleNamespace(name="plugin_storage_copy", load=lambda: first_handler),
+            SimpleNamespace(name="plugin_storage_copy", load=lambda: second_handler),
+        ],
+    )
+    plugin_helper.get_file_writer_storage_copy_plugin.cache_clear()
+
+    with mock.patch("bec_lib.plugin_helper.logger.warning") as mock_warning:
+        result = plugin_helper.get_file_writer_storage_copy_plugin()
+
+    assert result is first_handler
+    mock_warning.assert_called_once()
+
+
+def test_get_file_writer_storage_copy_plugin_returns_none_on_load_error(monkeypatch):
+    def _load():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        plugin_helper.importlib.metadata,
+        "entry_points",
+        lambda group: [SimpleNamespace(name="plugin_storage_copy", load=_load)],
+    )
+    plugin_helper.get_file_writer_storage_copy_plugin.cache_clear()
+
+    with mock.patch("bec_lib.plugin_helper.logger.error") as mock_error:
+        result = plugin_helper.get_file_writer_storage_copy_plugin()
+
+    assert result is None
+    mock_error.assert_called_once()
+
+
+def test_get_file_writer_storage_copy_plugin_returns_none_for_noncallable(monkeypatch):
+    monkeypatch.setattr(
+        plugin_helper.importlib.metadata,
+        "entry_points",
+        lambda group: [SimpleNamespace(name="plugin_storage_copy", load=lambda: "not-callable")],
+    )
+    plugin_helper.get_file_writer_storage_copy_plugin.cache_clear()
+
+    with mock.patch("bec_lib.plugin_helper.logger.error") as mock_error:
+        result = plugin_helper.get_file_writer_storage_copy_plugin()
+
+    assert result is None
+    mock_error.assert_called_once()

--- a/bec_server/bec_server/file_writer/file_writer_manager.py
+++ b/bec_server/bec_server/file_writer/file_writer_manager.py
@@ -6,13 +6,13 @@ import time
 import traceback
 from collections import defaultdict
 
-from bec_lib import messages
+from bec_lib import messages, plugin_helper
 from bec_lib.alarm_handler import Alarms
 from bec_lib.bec_service import BECService
 from bec_lib.callback_handler import CallbackHandler, EventType
 from bec_lib.devicemanager import DeviceManagerBase
 from bec_lib.endpoints import MessageEndpoints
-from bec_lib.file_utils import get_full_path
+from bec_lib.file_utils import get_full_path, sanitize_relative_subdir
 from bec_lib.logger import bec_logger
 from bec_lib.redis_connector import MessageObject, RedisConnector
 from bec_lib.service_config import ServiceConfig
@@ -115,6 +115,10 @@ class FileWriterManager(BECService):
             cb=self._update_available_beamline_states,
             from_start=True,
         )
+        self.connector.register(
+            MessageEndpoints.storage_copy_request(), cb=self._storage_copy_request_callback
+        )
+        self._run_storage_copy_plugin = self._load_storage_copy_plugin()
         self.async_writer = None
         self.scan_storage: dict[str, ScanStorage] = {}
         self.file_writer = HDF5FileWriter(self)
@@ -139,6 +143,30 @@ class FileWriterManager(BECService):
         topic, msg = msg.topic, msg.value
         device = topic.split("/")[-1]
         self.update_device_configuration(device, msg)
+
+    def _storage_copy_request_callback(self, msg_obj: MessageObject):
+        msg = msg_obj.value
+        if not isinstance(msg, messages.StorageCopyRequestMessage):
+            logger.error(f"Received invalid storage copy request message: {msg}")
+            return
+        if self._run_storage_copy_plugin is None:
+            logger.error("Storage copy request received but no storage copy plugin is installed.")
+            return
+        self._run_storage_copy_plugin(msg)
+
+    def _load_storage_copy_plugin(self):
+        plugin = plugin_helper.get_file_writer_storage_copy_plugin()
+        if plugin is None:
+            return None
+
+        def _run_storage_copy_plugin(msg: messages.StorageCopyRequestMessage) -> None:
+            current_account_msg = self.connector.get_last(MessageEndpoints.account(), "data")
+            active_account = ""
+            if current_account_msg is not None and isinstance(current_account_msg.value, str):
+                active_account = current_account_msg.value
+            plugin(msg.source_file, msg.scope, active_account, sanitize_relative_subdir(msg.subdir))
+
+        return _run_storage_copy_plugin
 
     def _update_available_beamline_states(
         self, msg: dict[str, messages.AvailableBeamlineStatesMessage]

--- a/bec_server/tests/tests_file_writer/test_file_writer_manager.py
+++ b/bec_server/tests/tests_file_writer/test_file_writer_manager.py
@@ -98,6 +98,103 @@ def test_scan_status_callback(file_writer_manager_mock):
         assert file_manager.scan_storage["scan_id"].scan_finished is True
 
 
+def test_storage_copy_request_callback_invokes_plugin(file_writer_manager_mock):
+    file_manager = file_writer_manager_mock
+    file_manager._run_storage_copy_plugin = mock.Mock()
+    msg = messages.StorageCopyRequestMessage(
+        source_file="/tmp/source.h5", scope="alignment", subdir="safe/path"
+    )
+    msg_raw = MessageObject(value=msg, topic="storage/copy_request")
+
+    file_manager._storage_copy_request_callback(msg_raw)
+
+    file_manager._run_storage_copy_plugin.assert_called_once_with(msg)
+
+
+def test_storage_copy_request_callback_ignores_invalid_message(file_writer_manager_mock):
+    file_manager = file_writer_manager_mock
+    file_manager._run_storage_copy_plugin = mock.Mock()
+    msg_raw = MessageObject(value="bad-message", topic="storage/copy_request")
+
+    with mock.patch("bec_server.file_writer.file_writer_manager.logger.error") as mock_error:
+        file_manager._storage_copy_request_callback(msg_raw)
+
+    file_manager._run_storage_copy_plugin.assert_not_called()
+    mock_error.assert_called_once()
+
+
+def test_storage_copy_request_callback_skips_when_plugin_runner_missing(file_writer_manager_mock):
+    file_manager = file_writer_manager_mock
+    file_manager._run_storage_copy_plugin = None
+    msg = messages.StorageCopyRequestMessage(
+        source_file="/tmp/source.h5", scope="alignment", subdir="safe/path"
+    )
+    msg_raw = MessageObject(value=msg, topic="storage/copy_request")
+
+    with mock.patch("bec_server.file_writer.file_writer_manager.logger.error") as mock_error:
+        file_manager._storage_copy_request_callback(msg_raw)
+
+    mock_error.assert_called_once_with(
+        "Storage copy request received but no storage copy plugin is installed."
+    )
+
+
+def test_load_storage_copy_plugin_uses_active_account(file_writer_manager_mock):
+    file_manager = file_writer_manager_mock
+    plugin = mock.Mock()
+
+    with mock.patch(
+        "bec_server.file_writer.file_writer_manager.plugin_helper.get_file_writer_storage_copy_plugin",
+        return_value=plugin,
+    ):
+        runner = file_manager._load_storage_copy_plugin()
+
+    with mock.patch.object(
+        file_manager.connector, "get_last", return_value=messages.VariableMessage(value="p12345")
+    ) as mock_get_last:
+        runner(
+            messages.StorageCopyRequestMessage(
+                source_file="/tmp/source.h5", scope="alignment", subdir="../unsafe/folder"
+            )
+        )
+
+    mock_get_last.assert_called_once_with(MessageEndpoints.account(), "data")
+    plugin.assert_called_once_with("/tmp/source.h5", "alignment", "p12345", "unsafe/folder")
+
+
+def test_load_storage_copy_plugin_returns_none_when_unavailable(file_writer_manager_mock):
+    file_manager = file_writer_manager_mock
+
+    with mock.patch(
+        "bec_server.file_writer.file_writer_manager.plugin_helper.get_file_writer_storage_copy_plugin",
+        return_value=None,
+    ):
+        runner = file_manager._load_storage_copy_plugin()
+
+    assert runner is None
+
+
+@pytest.mark.parametrize("account_msg", [None, messages.VariableMessage(value=1234)])
+def test_load_storage_copy_plugin_defaults_empty_account(file_writer_manager_mock, account_msg):
+    file_manager = file_writer_manager_mock
+    plugin = mock.Mock()
+
+    with mock.patch(
+        "bec_server.file_writer.file_writer_manager.plugin_helper.get_file_writer_storage_copy_plugin",
+        return_value=plugin,
+    ):
+        runner = file_manager._load_storage_copy_plugin()
+
+    with mock.patch.object(file_manager.connector, "get_last", return_value=account_msg):
+        runner(
+            messages.StorageCopyRequestMessage(
+                source_file="/tmp/source.h5", scope="alignment", subdir="~/results"
+            )
+        )
+
+    plugin.assert_called_once_with("/tmp/source.h5", "alignment", "", "results")
+
+
 def test_check_storage_status(file_writer_manager_mock, scan_storage_mock):
     file_manager = file_writer_manager_mock
     file_manager.scan_storage["scan_id"] = scan_storage_mock


### PR DESCRIPTION
## Description
Adds beamline storage copy support by introducing a client request path, a file-writer handler for storage-copy messages, and plugin-based execution for the actual transfer. It also sanitizes optional destination subdirectories and adds targeted unit coverage for the new behavior.


## How to test
- Run the storage-copy related unit tests
- Verify the new message flow from client request to file-writer plugin callback

