### PR TITLE
Fix potential bug in bl_states

### DIFF
--- a/bec_lib/bec_lib/bl_state_manager.py
+++ b/bec_lib/bec_lib/bl_state_manager.py
@@ -44,6 +44,26 @@ def build_signature_from_model(model: BaseModel, skip: set[str] | None = None) -
     return Signature(parameters)
 
 
+def _state_class_for_state_type(state_type: str) -> type[bl_states.BeamlineState]:
+    """
+    Resolve and validate a serialized beamline state type.
+
+    The state type identifies the concrete runtime state class that will be
+    started by the scan server.
+    """
+    state_class = getattr(bl_states, state_type, None)
+    if (
+        not inspect.isclass(state_class)
+        or not issubclass(state_class, bl_states.BeamlineState)
+        or inspect.isabstract(state_class)
+    ):
+        raise ValueError(f"State type {state_type!r} is not a concrete beamline state.")
+    if getattr(state_class, "CONFIG_CLASS", None) is None:
+        raise ValueError(f"State type {state_type!r} does not define a config class.")
+
+    return state_class
+
+
 class BeamlineStateGet(TypedDict):
     """
     TypedDict for the return value of the get method of a beamline state client.
@@ -154,10 +174,11 @@ class BeamlineStateManager:
         self, state: messages.BeamlineStateConfig | bl_states.BeamlineStateConfig
     ) -> None:
         if isinstance(state, messages.BeamlineStateConfig):
-            state_class = getattr(bl_states, state.state_type)
+            state_class = _state_class_for_state_type(state.state_type)
             model_cls = state_class.CONFIG_CLASS
             model_instance = model_cls(**state.parameters)
         else:
+            _state_class_for_state_type(state.state_type)
             model_instance = state
         instance = BeamlineStateClientBase(manager=self, state=model_instance)
         setattr(self, state.name, instance)

--- a/bec_lib/bec_lib/bl_states.py
+++ b/bec_lib/bec_lib/bl_states.py
@@ -194,6 +194,14 @@ class DeviceWithinLimitsStateConfig(DeviceStateConfig):
         return self
 
 
+class ShutterStateConfig(DeviceStateConfig):
+    """
+    Configuration for a shutter state.
+    """
+
+    state_type: ClassVar[str] = "ShutterState"
+
+
 C = TypeVar("C", bound=BeamlineStateConfig)
 D = TypeVar("D", bound=DeviceStateConfig)
 
@@ -408,19 +416,19 @@ class DeviceBeamlineState(BeamlineState[D], Generic[D]):
         return self.evaluate(msg)
 
 
-class ShutterState(DeviceBeamlineState[DeviceStateConfig]):
+class ShutterState(DeviceBeamlineState[ShutterStateConfig]):
     """
     A state that checks if the shutter is open.
 
     Example:
-        shutter_state = DeviceStateConfig(
+        shutter_state = ShutterStateConfig(
             name="shutter_open",
             device="shutter1",
         )
         bec.beamline_states.add(shutter_state)
     """
 
-    CONFIG_CLASS = DeviceStateConfig
+    CONFIG_CLASS = ShutterStateConfig
 
     def evaluate(
         self, msg: messages.DeviceMessage, *args, **kwargs

--- a/bec_lib/bec_lib/bl_states.py
+++ b/bec_lib/bec_lib/bl_states.py
@@ -194,14 +194,6 @@ class DeviceWithinLimitsStateConfig(DeviceStateConfig):
         return self
 
 
-class ShutterStateConfig(DeviceStateConfig):
-    """
-    Configuration for a shutter state.
-    """
-
-    state_type: ClassVar[str] = "ShutterState"
-
-
 C = TypeVar("C", bound=BeamlineStateConfig)
 D = TypeVar("D", bound=DeviceStateConfig)
 
@@ -414,33 +406,6 @@ class DeviceBeamlineState(BeamlineState[D], Generic[D]):
         """
         msg: messages.DeviceMessage = msg_obj.value  # type: ignore ; we know it's a DeviceMessage
         return self.evaluate(msg)
-
-
-class ShutterState(DeviceBeamlineState[ShutterStateConfig]):
-    """
-    A state that checks if the shutter is open.
-
-    Example:
-        shutter_state = ShutterStateConfig(
-            name="shutter_open",
-            device="shutter1",
-        )
-        bec.beamline_states.add(shutter_state)
-    """
-
-    CONFIG_CLASS = ShutterStateConfig
-
-    def evaluate(
-        self, msg: messages.DeviceMessage, *args, **kwargs
-    ) -> messages.BeamlineStateMessage:
-        val = msg.signals.get(self.signal_name, {}).get("value", "").lower()
-        if val == "open":
-            return messages.BeamlineStateMessage(
-                name=self.config.name, status="valid", label="Shutter is open."
-            )
-        return messages.BeamlineStateMessage(
-            name=self.config.name, status="invalid", label="Shutter is closed."
-        )
 
 
 class DeviceWithinLimitsState(DeviceBeamlineState[DeviceWithinLimitsStateConfig]):

--- a/bec_lib/tests/test_beamline_states.py
+++ b/bec_lib/tests/test_beamline_states.py
@@ -271,6 +271,23 @@ class TestBeamlineStateManager:
         assert "shutter_open" in manager._states
         assert isinstance(getattr(manager, "shutter_open"), BeamlineStateClientBase)
 
+    def test_manager_rejects_abstract_state_type_on_init(self, connected_connector):
+        config = messages.BeamlineStateConfig(
+            name="shutter_open",
+            state_type="DeviceBeamlineState",
+            parameters={"name": "shutter_open", "device": "samy"},
+        )
+        connected_connector.xadd(
+            MessageEndpoints.available_beamline_states(),
+            {"data": messages.AvailableBeamlineStatesMessage(states=[config])},
+            max_size=1,
+        )
+        client = mock.MagicMock()
+        client.connector = connected_connector
+
+        with pytest.raises(ValueError, match="not a concrete beamline state"):
+            BeamlineStateManager(client)
+
     def test_on_state_update_creates_client_attribute(self, state_manager):
         config = messages.BeamlineStateConfig(
             name="shutter_open",
@@ -282,7 +299,7 @@ class TestBeamlineStateManager:
         state_manager._on_state_update({"data": update}, parent=state_manager)
 
         assert "shutter_open" in state_manager._states
-        assert isinstance(state_manager._states["shutter_open"], bl_states.DeviceStateConfig)
+        assert isinstance(state_manager._states["shutter_open"], bl_states.ShutterStateConfig)
         assert isinstance(getattr(state_manager, "shutter_open"), BeamlineStateClientBase)
 
     def test_update_parameters_from_client_updates_state_and_publishes(self, state_manager):
@@ -371,7 +388,7 @@ class TestBeamlineStateManager:
         assert result == {"status": "valid", "label": "ok"}
 
     def test_add_waits_for_initial_state_message(self, state_manager):
-        state = bl_states.DeviceStateConfig(name="shutter_open", device="samy")
+        state = bl_states.ShutterStateConfig(name="shutter_open", device="samy")
 
         def publish_initial_state():
             time.sleep(0.05)
@@ -394,8 +411,14 @@ class TestBeamlineStateManager:
 
         assert state_manager.shutter_open.get() == {"status": "valid", "label": "ok"}
 
-    def test_add_and_delete_publish_updates(self, state_manager):
+    def test_add_rejects_abstract_device_state_config(self, state_manager):
         state = bl_states.DeviceStateConfig(name="shutter_open", device="samy")
+
+        with pytest.raises(ValueError, match="not a concrete beamline state"):
+            state_manager.add(state)
+
+    def test_add_and_delete_publish_updates(self, state_manager):
+        state = bl_states.ShutterStateConfig(name="shutter_open", device="samy")
 
         with mock.patch.object(state_manager, "_wait_for_initial_state"):
             state_manager.add(state)
@@ -418,7 +441,7 @@ class TestBeamlineStateManager:
         assert "shutter_open" not in state_manager._states
 
     def test_show_all_prints_table(self, state_manager, capsys):
-        state = bl_states.DeviceStateConfig(name="shutter_open", device="samy")
+        state = bl_states.ShutterStateConfig(name="shutter_open", device="samy")
         with mock.patch.object(state_manager, "_wait_for_initial_state"):
             state_manager.add(state)
 

--- a/bec_lib/tests/test_beamline_states.py
+++ b/bec_lib/tests/test_beamline_states.py
@@ -44,8 +44,8 @@ class TestHelpers:
 
 class TestConfigModels:
     def test_beamline_state_config_valid_name(self):
-        config = bl_states.BeamlineStateConfig(name="shutter_open")
-        assert config.name == "shutter_open"
+        config = bl_states.BeamlineStateConfig(name="sample_x_limits")
+        assert config.name == "sample_x_limits"
 
     @pytest.mark.parametrize("invalid_name", ["state-name", "class", "add", "remove", "show_all"])
     def test_beamline_state_config_invalid_name(self, invalid_name):
@@ -91,18 +91,25 @@ class TestBeamlineStateBase:
 
 class TestDeviceBeamlineState:
     def test_start_requires_connector(self, dm_with_devices):
-        state = bl_states.ShutterState(
-            name="shutter_open", device="samy", signal="samy", device_manager=dm_with_devices
+        state = bl_states.DeviceWithinLimitsState(
+            name="sample_y_limits",
+            device="samy",
+            signal="samy",
+            low_limit=0.0,
+            high_limit=10.0,
+            device_manager=dm_with_devices,
         )
 
         with pytest.raises(RuntimeError, match="Redis connector is not set"):
             state.start()
 
     def test_start_registers_device_callback(self, connected_connector, dm_with_devices):
-        state = bl_states.ShutterState(
-            name="shutter_open",
+        state = bl_states.DeviceWithinLimitsState(
+            name="sample_x_limits",
             device="samx",
             signal="samx",
+            low_limit=0.0,
+            high_limit=10.0,
             redis_connector=connected_connector,
             device_manager=dm_with_devices,
         )
@@ -115,10 +122,12 @@ class TestDeviceBeamlineState:
         )
 
     def test_stop_unregisters_device_callback(self, connected_connector, dm_with_devices):
-        state = bl_states.ShutterState(
-            name="shutter_open",
+        state = bl_states.DeviceWithinLimitsState(
+            name="sample_x_limits",
             device="samx",
             signal="samx",
+            low_limit=0.0,
+            high_limit=10.0,
             redis_connector=connected_connector,
             device_manager=dm_with_devices,
         )
@@ -134,50 +143,55 @@ class TestDeviceBeamlineState:
     def test_update_device_state_publishes_when_state_changes(
         self, connected_connector, dm_with_devices
     ):
-        state = bl_states.ShutterState(
-            name="shutter_open",
+        state = bl_states.DeviceWithinLimitsState(
+            name="sample_x_limits",
             device="samx",
             signal="samx",
+            low_limit=0.0,
+            high_limit=10.0,
             redis_connector=connected_connector,
             device_manager=dm_with_devices,
         )
 
         msg = messages.DeviceMessage(
-            signals={"samx": {"value": "open", "timestamp": 1.0}}, metadata={"stream": "primary"}
+            signals={"samx": {"value": 5.0, "timestamp": 1.0}}, metadata={"stream": "primary"}
         )
-        msg_obj = MessageObject(value=msg, topic="test")
 
         state._update_device_state(MessageObject(value=msg, topic="test"))
 
         assert state._last_state is not None
         assert state._last_state.status == "valid"
         out = connected_connector.xread(
-            MessageEndpoints.beamline_state("shutter_open"), from_start=True
+            MessageEndpoints.beamline_state("sample_x_limits"), from_start=True
         )
         assert out is not None
         assert out[0]["data"].status == "valid"
 
 
 class TestConcreteStates:
-    def test_shutter_state_open_and_closed(self, connected_connector, dm_with_devices):
-        state = bl_states.ShutterState(
-            name="shutter_open",
+    def test_device_within_limits_state_valid_and_invalid(
+        self, connected_connector, dm_with_devices
+    ):
+        state = bl_states.DeviceWithinLimitsState(
+            name="sample_x_limits",
             device="samx",
             signal="samx",
+            low_limit=0.0,
+            high_limit=10.0,
             redis_connector=connected_connector,
             device_manager=dm_with_devices,
         )
         state.start()
 
-        open_msg = messages.DeviceMessage(
-            signals={"samx": {"value": "OPEN", "timestamp": 1.0}}, metadata={"stream": "primary"}
+        valid_msg = messages.DeviceMessage(
+            signals={"samx": {"value": 5.0, "timestamp": 1.0}}, metadata={"stream": "primary"}
         )
-        closed_msg = messages.DeviceMessage(
-            signals={"samx": {"value": "closed", "timestamp": 2.0}}, metadata={"stream": "primary"}
+        invalid_msg = messages.DeviceMessage(
+            signals={"samx": {"value": 11.0, "timestamp": 2.0}}, metadata={"stream": "primary"}
         )
 
-        assert state.evaluate(open_msg).status == "valid"
-        assert state.evaluate(closed_msg).status == "invalid"
+        assert state.evaluate(valid_msg).status == "valid"
+        assert state.evaluate(invalid_msg).status == "invalid"
 
     def test_device_within_limits_state(self, connected_connector, dm_with_devices):
         state = bl_states.DeviceWithinLimitsState(
@@ -253,9 +267,14 @@ class TestBeamlineStateManager:
 
     def test_manager_loads_existing_state_update_on_init(self, connected_connector):
         config = messages.BeamlineStateConfig(
-            name="shutter_open",
-            state_type="ShutterState",
-            parameters={"name": "shutter_open", "device": "samy"},
+            name="sample_y_limits",
+            state_type="DeviceWithinLimitsState",
+            parameters={
+                "name": "sample_y_limits",
+                "device": "samy",
+                "low_limit": 0.0,
+                "high_limit": 10.0,
+            },
         )
         connected_connector.xadd(
             MessageEndpoints.available_beamline_states(),
@@ -268,14 +287,14 @@ class TestBeamlineStateManager:
         manager = BeamlineStateManager(client)
 
         assert manager.ready is True
-        assert "shutter_open" in manager._states
-        assert isinstance(getattr(manager, "shutter_open"), BeamlineStateClientBase)
+        assert "sample_y_limits" in manager._states
+        assert isinstance(getattr(manager, "sample_y_limits"), BeamlineStateClientBase)
 
     def test_manager_rejects_abstract_state_type_on_init(self, connected_connector):
         config = messages.BeamlineStateConfig(
-            name="shutter_open",
+            name="generic_device_state",
             state_type="DeviceBeamlineState",
-            parameters={"name": "shutter_open", "device": "samy"},
+            parameters={"name": "generic_device_state", "device": "samy"},
         )
         connected_connector.xadd(
             MessageEndpoints.available_beamline_states(),
@@ -290,17 +309,24 @@ class TestBeamlineStateManager:
 
     def test_on_state_update_creates_client_attribute(self, state_manager):
         config = messages.BeamlineStateConfig(
-            name="shutter_open",
-            state_type="ShutterState",
-            parameters={"name": "shutter_open", "device": "samy"},
+            name="sample_y_limits",
+            state_type="DeviceWithinLimitsState",
+            parameters={
+                "name": "sample_y_limits",
+                "device": "samy",
+                "low_limit": 0.0,
+                "high_limit": 10.0,
+            },
         )
         update = messages.AvailableBeamlineStatesMessage(states=[config])
 
         state_manager._on_state_update({"data": update}, parent=state_manager)
 
-        assert "shutter_open" in state_manager._states
-        assert isinstance(state_manager._states["shutter_open"], bl_states.ShutterStateConfig)
-        assert isinstance(getattr(state_manager, "shutter_open"), BeamlineStateClientBase)
+        assert "sample_y_limits" in state_manager._states
+        assert isinstance(
+            state_manager._states["sample_y_limits"], bl_states.DeviceWithinLimitsStateConfig
+        )
+        assert isinstance(getattr(state_manager, "sample_y_limits"), BeamlineStateClientBase)
 
     def test_update_parameters_from_client_updates_state_and_publishes(self, state_manager):
         config = messages.BeamlineStateConfig(
@@ -355,48 +381,60 @@ class TestBeamlineStateManager:
 
     def test_client_get_returns_unknown_without_status_message(self, state_manager):
         config = messages.BeamlineStateConfig(
-            name="shutter_open",
-            state_type="ShutterState",
-            parameters={"name": "shutter_open", "device": "samy"},
+            name="sample_y_limits",
+            state_type="DeviceWithinLimitsState",
+            parameters={
+                "name": "sample_y_limits",
+                "device": "samy",
+                "low_limit": 0.0,
+                "high_limit": 10.0,
+            },
         )
         update = messages.AvailableBeamlineStatesMessage(states=[config])
         state_manager._on_state_update({"data": update}, parent=state_manager)
 
-        result = state_manager.shutter_open.get()
+        result = state_manager.sample_y_limits.get()
         assert result == {"status": "unknown", "label": "No state information available."}
 
     def test_client_get_returns_latest_status_message(self, state_manager):
         config = messages.BeamlineStateConfig(
-            name="shutter_open",
-            state_type="ShutterState",
-            parameters={"name": "shutter_open", "device": "samy"},
+            name="sample_y_limits",
+            state_type="DeviceWithinLimitsState",
+            parameters={
+                "name": "sample_y_limits",
+                "device": "samy",
+                "low_limit": 0.0,
+                "high_limit": 10.0,
+            },
         )
         update = messages.AvailableBeamlineStatesMessage(states=[config])
         state_manager._on_state_update({"data": update}, parent=state_manager)
 
         state_manager._connector.xadd(
-            MessageEndpoints.beamline_state("shutter_open"),
+            MessageEndpoints.beamline_state("sample_y_limits"),
             {
                 "data": messages.BeamlineStateMessage(
-                    name="shutter_open", status="valid", label="ok"
+                    name="sample_y_limits", status="valid", label="ok"
                 )
             },
             max_size=1,
         )
 
-        result = state_manager.shutter_open.get()
+        result = state_manager.sample_y_limits.get()
         assert result == {"status": "valid", "label": "ok"}
 
     def test_add_waits_for_initial_state_message(self, state_manager):
-        state = bl_states.ShutterStateConfig(name="shutter_open", device="samy")
+        state = bl_states.DeviceWithinLimitsStateConfig(
+            name="sample_y_limits", device="samy", low_limit=0.0, high_limit=10.0
+        )
 
         def publish_initial_state():
             time.sleep(0.05)
             state_manager._connector.xadd(
-                MessageEndpoints.beamline_state("shutter_open"),
+                MessageEndpoints.beamline_state("sample_y_limits"),
                 {
                     "data": messages.BeamlineStateMessage(
-                        name="shutter_open", status="valid", label="ok"
+                        name="sample_y_limits", status="valid", label="ok"
                     )
                 },
                 max_size=1,
@@ -409,43 +447,52 @@ class TestBeamlineStateManager:
         finally:
             publisher.join()
 
-        assert state_manager.shutter_open.get() == {"status": "valid", "label": "ok"}
+        assert state_manager.sample_y_limits.get() == {"status": "valid", "label": "ok"}
 
     def test_add_rejects_abstract_device_state_config(self, state_manager):
-        state = bl_states.DeviceStateConfig(name="shutter_open", device="samy")
+        state = bl_states.DeviceStateConfig(name="generic_device_state", device="samy")
 
         with pytest.raises(ValueError, match="not a concrete beamline state"):
             state_manager.add(state)
 
     def test_add_and_delete_publish_updates(self, state_manager):
-        state = bl_states.ShutterStateConfig(name="shutter_open", device="samy")
+        state = bl_states.DeviceWithinLimitsStateConfig(
+            name="sample_y_limits", device="samy", low_limit=0.0, high_limit=10.0
+        )
 
         with mock.patch.object(state_manager, "_wait_for_initial_state"):
             state_manager.add(state)
-        assert "shutter_open" in state_manager._states
+        assert "sample_y_limits" in state_manager._states
 
-        state_manager.delete("shutter_open")
-        assert "shutter_open" not in state_manager._states
+        state_manager.delete("sample_y_limits")
+        assert "sample_y_limits" not in state_manager._states
 
     def test_client_remove_state(self, state_manager):
         config = messages.BeamlineStateConfig(
-            name="shutter_open",
-            state_type="ShutterState",
-            parameters={"name": "shutter_open", "device": "samy"},
+            name="sample_y_limits",
+            state_type="DeviceWithinLimitsState",
+            parameters={
+                "name": "sample_y_limits",
+                "device": "samy",
+                "low_limit": 0.0,
+                "high_limit": 10.0,
+            },
         )
         update = messages.AvailableBeamlineStatesMessage(states=[config])
         state_manager._on_state_update({"data": update}, parent=state_manager)
 
-        state_manager.shutter_open.remove()
+        state_manager.sample_y_limits.remove()
 
-        assert "shutter_open" not in state_manager._states
+        assert "sample_y_limits" not in state_manager._states
 
     def test_show_all_prints_table(self, state_manager, capsys):
-        state = bl_states.ShutterStateConfig(name="shutter_open", device="samy")
+        state = bl_states.DeviceWithinLimitsStateConfig(
+            name="sample_y_limits", device="samy", low_limit=0.0, high_limit=10.0
+        )
         with mock.patch.object(state_manager, "_wait_for_initial_state"):
             state_manager.add(state)
 
         state_manager.show_all()
 
         captured = capsys.readouterr()
-        assert "shutter_open" in (captured.out + captured.err)
+        assert "sample_y_limits" in (captured.out + captured.err)

--- a/bec_server/bec_server/scan_server/beamline_state_manager.py
+++ b/bec_server/bec_server/scan_server/beamline_state_manager.py
@@ -1,29 +1,14 @@
 from __future__ import annotations
 
-import inspect
 import traceback
 
 from bec_lib import bl_states, messages
 from bec_lib.alarm_handler import Alarms
+from bec_lib.bl_state_manager import _state_class_for_state_type
 from bec_lib.devicemanager import DeviceManagerBase
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.messages import ErrorInfo
 from bec_lib.redis_connector import RedisConnector
-
-
-def _state_class_for_state_type(state_type: str) -> type[bl_states.BeamlineState]:
-    """Resolve and validate the concrete runtime class for a beamline state type."""
-    state_class = getattr(bl_states, state_type, None)
-    if (
-        not inspect.isclass(state_class)
-        or not issubclass(state_class, bl_states.BeamlineState)
-        or inspect.isabstract(state_class)
-    ):
-        raise ValueError(f"State type {state_type!r} is not a concrete beamline state.")
-    if getattr(state_class, "CONFIG_CLASS", None) is None:
-        raise ValueError(f"State type {state_type!r} does not define a config class.")
-
-    return state_class
 
 
 class BeamlineStateManager:

--- a/bec_server/bec_server/scan_server/beamline_state_manager.py
+++ b/bec_server/bec_server/scan_server/beamline_state_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import traceback
 
 from bec_lib import bl_states, messages
@@ -8,6 +9,21 @@ from bec_lib.devicemanager import DeviceManagerBase
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.messages import ErrorInfo
 from bec_lib.redis_connector import RedisConnector
+
+
+def _state_class_for_state_type(state_type: str) -> type[bl_states.BeamlineState]:
+    """Resolve and validate the concrete runtime class for a beamline state type."""
+    state_class = getattr(bl_states, state_type, None)
+    if (
+        not inspect.isclass(state_class)
+        or not issubclass(state_class, bl_states.BeamlineState)
+        or inspect.isabstract(state_class)
+    ):
+        raise ValueError(f"State type {state_type!r} is not a concrete beamline state.")
+    if getattr(state_class, "CONFIG_CLASS", None) is None:
+        raise ValueError(f"State type {state_type!r} does not define a config class.")
+
+    return state_class
 
 
 class BeamlineStateManager:
@@ -75,9 +91,7 @@ class BeamlineStateManager:
                     self.connector.raise_alarm(severity=Alarms.WARNING, info=info)
 
         for state_name, state in added_states.items():
-            state_class = getattr(bl_states, state.state_type)
-            if not issubclass(state_class, bl_states.BeamlineState):
-                raise ValueError(f"State type {state.state_type} not found in beamline states.")
+            state_class = _state_class_for_state_type(state.state_type)
             model_cls = state_class.CONFIG_CLASS
             model_instance = model_cls(**state.parameters)
             state_instance = state_class(

--- a/bec_server/tests/tests_file_writer/test_file_writer_manager.py
+++ b/bec_server/tests/tests_file_writer/test_file_writer_manager.py
@@ -317,8 +317,13 @@ def test_file_writer_manager_update_available_beamline_states(file_writer_manage
         states=[
             messages.BeamlineStateConfig(
                 name="State1",
-                state_type="ShutterState",
-                parameters={"name": "State1", "device": "shutter1"},
+                state_type="DeviceWithinLimitsState",
+                parameters={
+                    "name": "State1",
+                    "device": "samx",
+                    "low_limit": 0.0,
+                    "high_limit": 10.0,
+                },
             )
         ]
     )
@@ -330,8 +335,13 @@ def test_file_writer_manager_update_available_beamline_states(file_writer_manage
         states=[
             messages.BeamlineStateConfig(
                 name="State2",
-                state_type="ShutterState",
-                parameters={"name": "State2", "device": "shutter1"},
+                state_type="DeviceWithinLimitsState",
+                parameters={
+                    "name": "State2",
+                    "device": "samx",
+                    "low_limit": 0.0,
+                    "high_limit": 10.0,
+                },
             )
         ]
     )
@@ -349,7 +359,7 @@ def test_file_writer_manager_updates_scan_storage_with_state(file_writer_manager
     scan_storage.metadata["status"] = "open"
     file_manager.scan_storage["scan_id"] = scan_storage
 
-    state_msg = messages.BeamlineStateMessage(name="State1", status="valid", label="Shutter")
+    state_msg = messages.BeamlineStateMessage(name="State1", status="valid", label="Within limits")
 
     file_manager.update_beamline_state(state_msg)
     assert file_manager.scan_storage["scan_id"].beamline_states["State1"] == [state_msg]
@@ -357,7 +367,7 @@ def test_file_writer_manager_updates_scan_storage_with_state(file_writer_manager
     # verify that the latest state is kept in the file writer manager
     assert file_manager.beamline_states["State1"] == state_msg
 
-    state_msg2 = messages.BeamlineStateMessage(name="State1", status="valid", label="Shutter")
+    state_msg2 = messages.BeamlineStateMessage(name="State1", status="valid", label="Within limits")
     file_manager.update_beamline_state(state_msg2)
     assert file_manager.scan_storage["scan_id"].beamline_states["State1"] == [state_msg, state_msg2]
     assert file_manager.beamline_states["State1"] == state_msg2
@@ -375,15 +385,20 @@ def test_file_writer_manager_removes_beamline_state_subscription(file_writer_man
         states=[
             messages.BeamlineStateConfig(
                 name="State1",
-                state_type="ShutterState",
-                parameters={"name": "State1", "device": "shutter1"},
+                state_type="DeviceWithinLimitsState",
+                parameters={
+                    "name": "State1",
+                    "device": "samx",
+                    "low_limit": 0.0,
+                    "high_limit": 10.0,
+                },
             )
         ]
     )
     file_manager._update_available_beamline_states({"data": msg})
     assert "State1" in file_manager.beamline_state_subscriptions
 
-    state_msg = messages.BeamlineStateMessage(name="State1", status="valid", label="Shutter")
+    state_msg = messages.BeamlineStateMessage(name="State1", status="valid", label="Within limits")
 
     file_manager.update_beamline_state(state_msg)
     assert file_manager.scan_storage["scan_id"].beamline_states["State1"] == [state_msg]

--- a/bec_server/tests/tests_scan_server/test_beamline_state_manager.py
+++ b/bec_server/tests/tests_scan_server/test_beamline_state_manager.py
@@ -18,8 +18,8 @@ def state_manager(connected_connector, dm_with_devices):
 
 @pytest.fixture
 def fake_bl_states(monkeypatch):
-    class FakeState(bl_states.BeamlineState[bl_states.DeviceStateConfig]):
-        CONFIG_CLASS = bl_states.DeviceStateConfig
+    class FakeState(bl_states.BeamlineState[bl_states.ShutterStateConfig]):
+        CONFIG_CLASS = bl_states.ShutterStateConfig
 
         def __init__(self, config=None, redis_connector=None, **kwargs):
             super().__init__(config=config, redis_connector=redis_connector, **kwargs)
@@ -126,6 +126,21 @@ def test_state_manager_updates_states(state_manager, connected_connector, fake_b
 
     assert len(state_manager._states) == 1
     assert "State2" in state_manager._states
+
+
+def test_state_manager_rejects_abstract_state_type(state_manager):
+    msg = messages.AvailableBeamlineStatesMessage(
+        states=[
+            messages.BeamlineStateConfig(
+                name="State1",
+                state_type="DeviceBeamlineState",
+                parameters={"name": "State1", "device": "shutter1"},
+            )
+        ]
+    )
+
+    with pytest.raises(ValueError, match="not a concrete beamline state"):
+        state_manager.update_states(msg)
 
 
 @pytest.mark.timeout(5)

--- a/bec_server/tests/tests_scan_server/test_beamline_state_manager.py
+++ b/bec_server/tests/tests_scan_server/test_beamline_state_manager.py
@@ -18,8 +18,8 @@ def state_manager(connected_connector, dm_with_devices):
 
 @pytest.fixture
 def fake_bl_states(monkeypatch):
-    class FakeState(bl_states.BeamlineState[bl_states.ShutterStateConfig]):
-        CONFIG_CLASS = bl_states.ShutterStateConfig
+    class FakeState(bl_states.BeamlineState[bl_states.DeviceWithinLimitsStateConfig]):
+        CONFIG_CLASS = bl_states.DeviceWithinLimitsStateConfig
 
         def __init__(self, config=None, redis_connector=None, **kwargs):
             super().__init__(config=config, redis_connector=redis_connector, **kwargs)
@@ -35,7 +35,7 @@ def fake_bl_states(monkeypatch):
         def restart(self):
             self.restart_count += 1
 
-    monkeypatch.setattr(beamline_state_manager.bl_states, "ShutterState", FakeState)
+    monkeypatch.setattr(beamline_state_manager.bl_states, "DeviceWithinLimitsState", FakeState)
     return FakeState
 
 
@@ -71,8 +71,13 @@ def test_state_manager_updates_states(state_manager, connected_connector, fake_b
         states=[
             messages.BeamlineStateConfig(
                 name="State1",
-                state_type="ShutterState",
-                parameters={"name": "State1", "device": "shutter1"},
+                state_type="DeviceWithinLimitsState",
+                parameters={
+                    "name": "State1",
+                    "device": "samx",
+                    "low_limit": 0.0,
+                    "high_limit": 10.0,
+                },
             )
         ]
     )
@@ -89,13 +94,23 @@ def test_state_manager_updates_states(state_manager, connected_connector, fake_b
         states=[
             messages.BeamlineStateConfig(
                 name="State1",
-                state_type="ShutterState",
-                parameters={"name": "State1", "device": "shutter1"},
+                state_type="DeviceWithinLimitsState",
+                parameters={
+                    "name": "State1",
+                    "device": "samx",
+                    "low_limit": 0.0,
+                    "high_limit": 10.0,
+                },
             ),
             messages.BeamlineStateConfig(
                 name="State2",
-                state_type="ShutterState",
-                parameters={"name": "State2", "device": "shutter2"},
+                state_type="DeviceWithinLimitsState",
+                parameters={
+                    "name": "State2",
+                    "device": "samy",
+                    "low_limit": 0.0,
+                    "high_limit": 10.0,
+                },
             ),
         ]
     )
@@ -112,8 +127,13 @@ def test_state_manager_updates_states(state_manager, connected_connector, fake_b
         states=[
             messages.BeamlineStateConfig(
                 name="State2",
-                state_type="ShutterState",
-                parameters={"name": "State2", "device": "shutter2"},
+                state_type="DeviceWithinLimitsState",
+                parameters={
+                    "name": "State2",
+                    "device": "samy",
+                    "low_limit": 0.0,
+                    "high_limit": 10.0,
+                },
             )
         ]
     )
@@ -134,7 +154,7 @@ def test_state_manager_rejects_abstract_state_type(state_manager):
             messages.BeamlineStateConfig(
                 name="State1",
                 state_type="DeviceBeamlineState",
-                parameters={"name": "State1", "device": "shutter1"},
+                parameters={"name": "State1", "device": "samx"},
             )
         ]
     )


### PR DESCRIPTION
In the previous implementation, the `DeviceStateConfig` was a valid input to initialize a state. However, the `DeviceStateConfig` points to the `DeviceBeamlineState`, which in return is still an ABC. This created the risk of failing the initialization of a state with this config on the server side. This PR fixes this issue by implementing additional checks for the initialization of the state, and in addition make an explicit implementation of a ShutterStateConfig. 



Any BL already operating a ShutterState base on a `DeviceStateConfig` might fail now as the `CONFIG_CLASS` from the ShutterState is now `ShutterStateConfig`. However, I believe this is a required fix.