### PR TITLE
feat(scan): v4 scan parity with v3

### DIFF
--- a/bec_ipython_client/bec_ipython_client/callbacks/ipython_live_updates.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/ipython_live_updates.py
@@ -322,9 +322,10 @@ class IPythonLiveUpdates:
         if not available_blocks:
             return False
         req_block = available_blocks[self._request_block_index[req_id]]
-        if (
-            req_block.msg.scan_type == "mv"
-        ):  # TODO: make this more general for scans without report instructions
+        if req_block.msg.scan_type in [
+            "mv",
+            "_v4_mv",
+        ]:  # TODO: make this more general for all scan types that don't have report instructions
             return True
 
         report_instructions = req_block.report_instructions or []

--- a/bec_ipython_client/bec_ipython_client/callbacks/live_table.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/live_table.py
@@ -45,6 +45,8 @@ class LiveUpdatesTable(LiveUpdatesBase):
 
     MAX_DEVICES = 10
     REPORT_TYPE = "scan_progress"
+    STEP_SCAN_TYPES = {"step", "software_triggered", "hardware_triggered"}
+    FLY_SCAN_TYPES = {"fly"}
 
     def __init__(
         self,
@@ -118,9 +120,9 @@ class LiveUpdatesTable(LiveUpdatesBase):
     @property
     def devices(self):
         """get the devices for the callback"""
-        if self.point_data.metadata["scan_type"] == "step":
+        if self.point_data.metadata["scan_type"] in self.STEP_SCAN_TYPES:
             return self.get_devices_from_scan_data(self.scan_item.live_data[0])
-        if self.point_data.metadata["scan_type"] == "fly":
+        if self.point_data.metadata["scan_type"] in self.FLY_SCAN_TYPES:
             devices = list(self.point_data.content["data"].keys())
             if len(devices) > self.MAX_DEVICES:
                 return devices[0 : self.MAX_DEVICES]

--- a/bec_ipython_client/tests/client_tests/test_live_table.py
+++ b/bec_ipython_client/tests/client_tests/test_live_table.py
@@ -251,6 +251,48 @@ class TestLiveTable:
             live_update.print_table_data()
             assert mock_client_msgs.called
 
+    def test_print_table_data_with_v4_software_triggered_scan(self, client_with_grid_scan):
+        client, request_msg = client_with_grid_scan
+        response_msg = messages.RequestResponseMessage(
+            accepted=True, message={"msg": ""}, metadata={"RID": "something"}
+        )
+        client.queue.request_storage.update_with_request(request_msg)
+        client.queue.request_storage.update_with_response(response_msg)
+        live_update = LiveUpdatesTable(
+            client, {"scan_progress": {"points": 10, "show_table": True}}, request_msg
+        )
+        live_update.point_data = messages.ScanMessage(
+            point_id=0,
+            scan_id="",
+            data={"samx": {"samx": {"value": 0}}},
+            metadata={"scan_report_devices": ["samx"], "scan_type": "software_triggered"},
+        )
+        live_update.scan_item = ScanItemMock(live_data={0: live_update.point_data})
+        with mock.patch.object(live_update, "_print_client_msgs_asap") as mock_client_msgs:
+            live_update.print_table_data()
+            assert mock_client_msgs.called
+
+    def test_print_table_data_with_v4_hardware_triggered_scan(self, client_with_grid_scan):
+        client, request_msg = client_with_grid_scan
+        response_msg = messages.RequestResponseMessage(
+            accepted=True, message={"msg": ""}, metadata={"RID": "something"}
+        )
+        client.queue.request_storage.update_with_request(request_msg)
+        client.queue.request_storage.update_with_response(response_msg)
+        live_update = LiveUpdatesTable(
+            client, {"scan_progress": {"points": 10, "show_table": True}}, request_msg
+        )
+        live_update.point_data = messages.ScanMessage(
+            point_id=0,
+            scan_id="",
+            data={"samx": {"samx": {"value": 0}}},
+            metadata={"scan_report_devices": ["samx"], "scan_type": "hardware_triggered"},
+        )
+        live_update.scan_item = ScanItemMock(live_data={0: live_update.point_data})
+        with mock.patch.object(live_update, "_print_client_msgs_asap") as mock_client_msgs:
+            live_update.print_table_data()
+            assert mock_client_msgs.called
+
     def test_print_table_data_lamni_flyer(self, client_with_grid_scan):
         client, request_msg = client_with_grid_scan
         response_msg = messages.RequestResponseMessage(

--- a/bec_ipython_client/tests/end-2-end/test_scans_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_scans_e2e.py
@@ -67,7 +67,7 @@ def test_fermat_scan(capsys, bec_ipython_client_fixture, scan_name):
         optim_trajectory="corridor",
     )
     if scan_name == "_v4_fermat_scan":
-        # NOTE: v4 scan calculates the the angle more accurately, which results in a slightly different number of points
+        # NOTE: v4 scan calculates the angle more accurately, which results in a slightly different number of points
         assert len(status.scan.live_data) == 400
         assert status.scan.num_points == 400
     else:

--- a/bec_ipython_client/tests/end-2-end/test_scans_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_scans_e2e.py
@@ -31,13 +31,16 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 @pytest.mark.timeout(100)
-def test_grid_scan(capsys, bec_ipython_client_fixture):
+@pytest.mark.parametrize("scan_name", ["grid_scan", "_v4_grid_scan"])
+def test_grid_scan(capsys, bec_ipython_client_fixture, scan_name):
     bec = bec_ipython_client_fixture
     scans = bec.scans
     bec.metadata.update({"unit_test": "test_grid_scan"})
     dev = bec.device_manager.devices
     scans.umv(dev.samx, 0, dev.samy, 0, relative=False)
-    status = scans.grid_scan(dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=0.01, relative=True)
+    status = getattr(scans, scan_name)(
+        dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=0.01, relative=True
+    )
     assert len(status.scan.live_data) == 100
     assert status.scan.num_points == 100
     captured = capsys.readouterr()
@@ -45,12 +48,13 @@ def test_grid_scan(capsys, bec_ipython_client_fixture):
 
 
 @pytest.mark.timeout(100)
-def test_fermat_scan(capsys, bec_ipython_client_fixture):
+@pytest.mark.parametrize("scan_name", ["fermat_scan", "_v4_fermat_scan"])
+def test_fermat_scan(capsys, bec_ipython_client_fixture, scan_name):
     bec = bec_ipython_client_fixture
     scans = bec.scans
     bec.metadata.update({"unit_test": "test_fermat_scan"})
     dev = bec.device_manager.devices
-    status = scans.fermat_scan(
+    status = getattr(scans, scan_name)(
         dev.samx,
         -5,
         5,
@@ -62,19 +66,27 @@ def test_fermat_scan(capsys, bec_ipython_client_fixture):
         relative=True,
         optim_trajectory="corridor",
     )
-    assert len(status.scan.live_data) == 393
-    assert status.scan.num_points == 393
+    if scan_name == "_v4_fermat_scan":
+        # NOTE: v4 scan calculates the the angle more accurately, which results in a slightly different number of points
+        assert len(status.scan.live_data) == 400
+        assert status.scan.num_points == 400
+    else:
+        assert len(status.scan.live_data) == 393
+        assert status.scan.num_points == 393
     captured = capsys.readouterr()
     assert "finished. Scan ID" in captured.out
 
 
 @pytest.mark.timeout(100)
-def test_line_scan(capsys, bec_ipython_client_fixture):
+@pytest.mark.parametrize("scan_name", ["line_scan", "_v4_line_scan"])
+def test_line_scan(capsys, bec_ipython_client_fixture, scan_name):
     bec = bec_ipython_client_fixture
     scans = bec.scans
     bec.metadata.update({"unit_test": "test_line_scan"})
     dev = bec.device_manager.devices
-    status = scans.line_scan(dev.samx, -5, 5, steps=10, exp_time=0.01, relative=True)
+    status = getattr(scans, scan_name)(
+        dev.samx, -5, 5, dev.samy, -5, 5, steps=10, exp_time=0.01, relative=True
+    )
     assert len(status.scan.live_data) == 10
     assert status.scan.num_points == 10
     captured = capsys.readouterr()
@@ -83,12 +95,13 @@ def test_line_scan(capsys, bec_ipython_client_fixture):
 
 @pytest.mark.flaky  # marked as flaky as the simulation might return a new readback value within the tolerance
 @pytest.mark.timeout(100)
-def test_mv_scan(capsys, bec_ipython_client_fixture):
+@pytest.mark.parametrize("scan_name", [("mv", "umv"), ("_v4_mv", "_v4_umv")])
+def test_mv_scan(capsys, bec_ipython_client_fixture, scan_name):
     bec = bec_ipython_client_fixture
     scans = bec.scans
     bec.metadata.update({"unit_test": "test_mv_scan"})
     dev = bec.device_manager.devices
-    scans.mv(dev.samx, 10, dev.samy, 20, relative=False).wait()
+    getattr(scans, scan_name[0])(dev.samx, 10, dev.samy, 20, relative=False).wait()
     current_pos_samx = dev.samx.read(cached=True)["samx"]["value"]
     current_pos_samy = dev.samy.read(cached=True)["samy"]["value"]
     assert np.isclose(
@@ -97,7 +110,7 @@ def test_mv_scan(capsys, bec_ipython_client_fixture):
     assert np.isclose(
         current_pos_samy, 20, atol=dev.samy._config["deviceConfig"].get("tolerance", 0.05)
     )
-    scans.umv(dev.samx, 10, dev.samy, 20, relative=False)
+    getattr(scans, scan_name[1])(dev.samx, 10, dev.samy, 20, relative=False)
     current_pos_samx = dev.samx.read(cached=True)["samx"]["value"]
     current_pos_samy = dev.samy.read(cached=True)["samy"]["value"]
     captured = capsys.readouterr()
@@ -109,12 +122,13 @@ def test_mv_scan(capsys, bec_ipython_client_fixture):
 
 @pytest.mark.flaky  # marked as flaky as the simulation might return a new readback value within the tolerance
 @pytest.mark.timeout(100)
-def test_mv_scan_nested_device(capsys, bec_ipython_client_fixture):
+@pytest.mark.parametrize("scan_name", [("mv", "umv"), ("_v4_mv", "_v4_umv")])
+def test_mv_scan_nested_device(capsys, bec_ipython_client_fixture, scan_name):
     bec = bec_ipython_client_fixture
     scans = bec.scans
     bec.metadata.update({"unit_test": "test_mv_scan_nested_device"})
     dev = bec.device_manager.devices
-    scans.mv(dev.hexapod.x, 10, dev.hexapod.y, 20, relative=False).wait()
+    getattr(scans, scan_name[0])(dev.hexapod.x, 10, dev.hexapod.y, 20, relative=False).wait()
     if not bec.connector._managed_connection._message_callbacks_queue.empty():
         print("Waiting for messages to be processed")
         time.sleep(0.5)
@@ -126,7 +140,7 @@ def test_mv_scan_nested_device(capsys, bec_ipython_client_fixture):
     assert np.isclose(
         current_pos_hexapod_y, 20, atol=dev.hexapod._config["deviceConfig"].get("tolerance", 0.5)
     )
-    scans.umv(dev.hexapod.x, 10, dev.hexapod.y, 20, relative=False)
+    getattr(scans, scan_name[1])(dev.hexapod.x, 10, dev.hexapod.y, 20, relative=False)
     if not bec.connector._managed_connection._message_callbacks_queue.empty():
         print("Waiting for messages to be processed")
         time.sleep(0.5)
@@ -145,7 +159,8 @@ def test_mv_scan_nested_device(capsys, bec_ipython_client_fixture):
 
 
 @pytest.mark.timeout(100)
-def test_mv_scan_mv(bec_ipython_client_fixture):
+@pytest.mark.parametrize("scan_name", [("umv", "grid_scan"), ("_v4_umv", "_v4_grid_scan")])
+def test_mv_scan_mv(bec_ipython_client_fixture, scan_name):
     bec = bec_ipython_client_fixture
     scans = bec.scans
     bec.metadata.update({"unit_test": "test_mv_scan_mv"})
@@ -154,7 +169,7 @@ def test_mv_scan_mv(bec_ipython_client_fixture):
 
     dev.samx.limits = [-50, 50]
     dev.samy.limits = [-50, 50]
-    scans.umv(dev.samx, 10, dev.samy, 20, relative=False)
+    getattr(scans, scan_name[0])(dev.samx, 10, dev.samy, 20, relative=False)
     tolerance_samx = dev.samx._config["deviceConfig"].get("tolerance", 0.05)
     tolerance_samy = dev.samy._config["deviceConfig"].get("tolerance", 0.05)
     current_pos_samx = dev.samx.read()["samx"]["value"]
@@ -164,7 +179,9 @@ def test_mv_scan_mv(bec_ipython_client_fixture):
     assert np.isclose(current_pos_samx, 10, atol=tolerance_samx)
     assert np.isclose(current_pos_samy, 20, atol=tolerance_samy)
 
-    status = scans.grid_scan(dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=0.01, relative=True)
+    status = getattr(scans, scan_name[1])(
+        dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=0.01, relative=True
+    )
 
     # make sure the scan completed the expected number of positions
     assert len(status.scan.live_data) == 100
@@ -184,7 +201,7 @@ def test_mv_scan_mv(bec_ipython_client_fixture):
     assert np.isclose(current_pos_samx, 10, atol=tolerance_samx * 2)
     assert np.isclose(current_pos_samy, 20, atol=tolerance_samy * 2)
 
-    scans.umv(dev.samx, 20, dev.samy, -20, relative=False)
+    getattr(scans, scan_name[0])(dev.samx, 20, dev.samy, -20, relative=False)
     current_pos_samx = dev.samx.read()["samx"]["value"]
     current_pos_samy = dev.samy.read()["samy"]["value"]
 
@@ -192,7 +209,7 @@ def test_mv_scan_mv(bec_ipython_client_fixture):
     assert np.isclose(current_pos_samx, 20, atol=tolerance_samx)
     assert np.isclose(current_pos_samy, -20, atol=tolerance_samy)
 
-    status = scans.grid_scan(
+    status = getattr(scans, scan_name[1])(
         dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=0.01, relative=False
     )
 
@@ -209,7 +226,8 @@ def test_mv_scan_mv(bec_ipython_client_fixture):
 
 
 @pytest.mark.timeout(100)
-def test_scan_abort(bec_ipython_client_fixture: BECIPythonClient):
+@pytest.mark.parametrize("scan_name", ["line_scan", "_v4_line_scan"])
+def test_scan_abort(bec_ipython_client_fixture: BECIPythonClient, scan_name: str):
     def send_abort(bec):
         while True:
             current_scan_info = bec.queue.scan_storage.current_scan_info
@@ -238,7 +256,7 @@ def test_scan_abort(bec_ipython_client_fixture: BECIPythonClient):
     aborted_scan = False
     try:
         threading.Thread(target=send_abort, args=(bec,), daemon=True).start()
-        scans.line_scan(dev.samx, -5, 5, steps=200, exp_time=0.1, relative=True)
+        getattr(scans, scan_name)(dev.samx, -5, 5, steps=200, exp_time=0.1, relative=True)
     except ScanInterruption:
         logger.info("Raised ScanInterruption")
         time.sleep(2)
@@ -255,7 +273,7 @@ def test_scan_abort(bec_ipython_client_fixture: BECIPythonClient):
 
     assert len(bec.queue.scan_storage.storage[-1].live_data) < 200
 
-    scans.line_scan(dev.samx, -5, 5, steps=10, exp_time=0.1, relative=True)
+    getattr(scans, scan_name)(dev.samx, -5, 5, steps=10, exp_time=0.1, relative=True)
     scan_number_end = bec.queue.next_scan_number
     assert scan_number_end == scan_number_start + 2
 
@@ -301,8 +319,8 @@ def test_umv_ctrl_c_stops_motion(bec_ipython_client_fixture: BECIPythonClient):
         dev.samx.velocity.set(original_velocity).wait()
 
 
-@pytest.mark.timeout(100)
-def test_limit_error(bec_ipython_client_fixture):
+@pytest.mark.parametrize("scan_name", [("line_scan", "umv"), ("_v4_line_scan", "_v4_umv")])
+def test_limit_error(bec_ipython_client_fixture, scan_name):
     bec = bec_ipython_client_fixture
     bec.metadata.update({"unit_test": "test_limit_error"})
     scan_number_start = bec.queue.next_scan_number
@@ -311,7 +329,7 @@ def test_limit_error(bec_ipython_client_fixture):
     aborted_scan = False
     dev.samx.limits = [-50, 50]
     try:
-        scans.line_scan(dev.samx, -520, 5, steps=200, exp_time=0.1, relative=False)
+        getattr(scans, scan_name[0])(dev.samx, -520, 5, steps=200, exp_time=0.1, relative=False)
     except AlarmBase as alarm:
         assert alarm.alarm_type == "LimitError"
         aborted_scan = True
@@ -321,7 +339,7 @@ def test_limit_error(bec_ipython_client_fixture):
     aborted_scan = False
     dev.samx.limits = [-50, 50]
     try:
-        scans.umv(dev.samx, 500, relative=False)
+        getattr(scans, scan_name[1])(dev.samx, 500, relative=False)
     except AlarmBase as alarm:
         assert alarm.alarm_type == "LimitError"
         aborted_scan = True
@@ -332,16 +350,17 @@ def test_limit_error(bec_ipython_client_fixture):
 
 
 @pytest.mark.timeout(100)
-def test_queued_scan(bec_ipython_client_fixture):
+@pytest.mark.parametrize("scan_name", ["line_scan", "_v4_line_scan"])
+def test_queued_scan(bec_ipython_client_fixture, scan_name):
     bec = bec_ipython_client_fixture
     bec.metadata.update({"unit_test": "test_queued_scan"})
     scan_number_start = bec.queue.next_scan_number
     scans = bec.scans
     dev = bec.device_manager.devices
-    scan1 = scans.line_scan(
+    scan1 = getattr(scans, scan_name)(
         dev.samx, -5, 5, steps=100, exp_time=0.1, hide_report=True, relative=True
     )
-    scan2 = scans.line_scan(
+    scan2 = getattr(scans, scan_name)(
         dev.samx, -5, 5, steps=50, exp_time=0.1, hide_report=True, relative=True
     )
 
@@ -375,7 +394,8 @@ def test_fly_scan(bec_ipython_client_fixture):
 
 
 @pytest.mark.timeout(100)
-def test_scan_restart(bec_ipython_client_fixture):
+@pytest.mark.parametrize("scan_name", ["line_scan", "_v4_line_scan"])
+def test_scan_restart(bec_ipython_client_fixture, scan_name):
     bec = bec_ipython_client_fixture
     bec.metadata.update({"unit_test": "test_scan_restart"})
     scans = bec.scans
@@ -397,10 +417,12 @@ def test_scan_restart(bec_ipython_client_fixture):
 
     # We start two scans to ensure that the scan restart logic works correctly in a queued scenario
     # The first scan is started without printout to allow us to submit the second scan immediately after
-    scans.line_scan(dev.samx, -5, 5, steps=50, exp_time=0.1, hide_report=True, relative=True)
+    getattr(scans, scan_name)(
+        dev.samx, -5, 5, steps=50, exp_time=0.1, hide_report=True, relative=True
+    )
 
     # The second scan is using the live table printout. It should properly continue after the restart
-    scan2 = scans.line_scan(dev.samx, -5, 5, steps=50, exp_time=0.1, relative=True)
+    scan2 = getattr(scans, scan_name)(dev.samx, -5, 5, steps=50, exp_time=0.1, relative=True)
 
     scan2.wait()
 
@@ -413,7 +435,8 @@ def test_scan_restart(bec_ipython_client_fixture):
 
 
 @pytest.mark.timeout(100)
-def test_scan_observer_repeat_queued(bec_ipython_client_fixture: BECIPythonClient):
+@pytest.mark.parametrize("scan_name", ["line_scan", "_v4_line_scan"])
+def test_scan_observer_repeat_queued(bec_ipython_client_fixture: BECIPythonClient, scan_name):
     bec = bec_ipython_client_fixture
     bec.metadata.update({"unit_test": "test_scan_observer_repeat_queued"})
     scans = bec.scans
@@ -435,10 +458,10 @@ def test_scan_observer_repeat_queued(bec_ipython_client_fixture: BECIPythonClien
     # start repeat thread
     threading.Thread(target=send_repeat, args=(bec,), daemon=True).start()
     # start scan
-    scan1 = scans.line_scan(
+    scan1 = getattr(scans, scan_name)(
         dev.samx, -5, 5, steps=100, exp_time=0.1, hide_report=True, relative=True
     )
-    scan2 = scans.line_scan(
+    scan2 = getattr(scans, scan_name)(
         dev.samx, -5, 5, steps=100, exp_time=0.1, hide_report=True, relative=True
     )
 
@@ -453,7 +476,8 @@ def test_scan_observer_repeat_queued(bec_ipython_client_fixture: BECIPythonClien
 
 
 @pytest.mark.timeout(100)
-def test_scan_observer_repeat(bec_ipython_client_fixture):
+@pytest.mark.parametrize("scan_name", ["line_scan", "_v4_line_scan"])
+def test_scan_observer_repeat(bec_ipython_client_fixture, scan_name):
     bec = bec_ipython_client_fixture
     bec.metadata.update({"unit_test": "test_scan_observer_repeat"})
     scans = bec.scans
@@ -473,7 +497,7 @@ def test_scan_observer_repeat(bec_ipython_client_fixture):
     threading.Thread(target=send_repeat, args=(bec,), daemon=True).start()
     # start scan
     with pytest.raises(ScanAbortion):
-        scan1 = scans.line_scan(
+        scan1 = getattr(scans, scan_name)(
             dev.samx, -5, 5, steps=50, exp_time=0.1, hide_report=True, relative=True
         )
         scan1.wait()
@@ -488,7 +512,8 @@ def test_scan_observer_repeat(bec_ipython_client_fixture):
 
 
 @pytest.mark.timeout(100)
-def test_file_writer(bec_ipython_client_fixture):
+@pytest.mark.parametrize("scan_name", ["grid_scan", "_v4_grid_scan"])
+def test_file_writer(bec_ipython_client_fixture, scan_name):
     bec = bec_ipython_client_fixture
     bec.metadata.update({"unit_test": "test_file_writer"})
     scans = bec.scans
@@ -498,7 +523,7 @@ def test_file_writer(bec_ipython_client_fixture):
     dev.samx.velocity.set(98).wait()
     dev.samy.velocity.set(101).wait()
 
-    scan = scans.grid_scan(
+    scan = getattr(scans, scan_name)(
         dev.samx,
         -5,
         5,
@@ -566,21 +591,22 @@ def test_group_def(bec_ipython_client_fixture):
 
 
 @pytest.mark.timeout(100)
-def test_list_scan(bec_ipython_client_fixture):
+@pytest.mark.parametrize("scan_name", ["list_scan", "_v4_list_scan"])
+def test_list_scan(bec_ipython_client_fixture, scan_name):
     bec = bec_ipython_client_fixture
     bec.metadata.update({"unit_test": "test_list_scan"})
     scans = bec.scans
     dev = bec.device_manager.devices
 
-    status = scans.list_scan(
+    status = getattr(scans, scan_name)(
         dev.samx, [0, 1, 2, 3, 4], dev.samy, [0, 1, 2, 3, 4], exp_time=0.1, relative=False
     )
     assert len(status.scan.live_data) == 5
 
-    status = scans.list_scan(dev.samx, [0, 1, 2, 3, 4, 5], exp_time=0.1, relative=False)
+    status = getattr(scans, scan_name)(dev.samx, [0, 1, 2, 3, 4, 5], exp_time=0.1, relative=False)
     assert len(status.scan.live_data) == 6
 
-    status = scans.list_scan(
+    status = getattr(scans, scan_name)(
         dev.samx,
         [0, 1, 2, 3],
         dev.samy,
@@ -855,7 +881,8 @@ def test_grid_scan_secondary_queue(capsys, bec_ipython_client_fixture):
 
 
 @pytest.mark.timeout(100)
-def test_scan_after_scan_lock(capsys, bec_ipython_client_fixture):
+@pytest.mark.parametrize("scan_name", ["line_scan", "_v4_line_scan"])
+def test_scan_after_scan_lock(capsys, bec_ipython_client_fixture, scan_name):
     """
     Test that pending scans are properly executed after a scan lock is released.
     """
@@ -864,8 +891,10 @@ def test_scan_after_scan_lock(capsys, bec_ipython_client_fixture):
     bec.metadata.update({"unit_test": "test_scan_after_scan_lock"})
     dev = bec.device_manager.devices
     bec.queue.add_queue_lock(queue="primary", reason="unit_test_scan_lock", lock_id="test_lock")
-    scans.line_scan(dev.samx, -5, 5, steps=10, exp_time=0.01, relative=True, hide_report=True)
-    scan2 = scans.line_scan(
+    getattr(scans, scan_name)(
+        dev.samx, -5, 5, steps=10, exp_time=0.01, relative=True, hide_report=True
+    )
+    scan2 = getattr(scans, scan_name)(
         dev.samx, -5, 5, steps=10, exp_time=0.01, relative=True, hide_report=True
     )
 
@@ -879,7 +908,8 @@ def test_scan_after_scan_lock(capsys, bec_ipython_client_fixture):
 
 
 @pytest.mark.timeout(100)
-def test_scan_repeat_decorator(bec_ipython_client_fixture):
+@pytest.mark.parametrize("scan_name", ["line_scan", "_v4_line_scan"])
+def test_scan_repeat_decorator(bec_ipython_client_fixture, scan_name):
     """
     Test the scan_repeat decorator by simulating a communication failure during a scan.
     The scan should be retried according to the specified max_repeats and exc_handler.
@@ -923,7 +953,9 @@ def test_scan_repeat_decorator(bec_ipython_client_fixture):
 
     @scan_repeat(max_repeats=2, exc_handler=exc_handler)
     def my_scan():
-        scans.line_scan(dev.positioner_with_failure, -5, 5, steps=10, exp_time=0.01, relative=True)
+        getattr(scans, scan_name)(
+            dev.positioner_with_failure, -5, 5, steps=10, exp_time=0.01, relative=True
+        )
 
     my_scan()
 
@@ -933,7 +965,10 @@ def test_scan_repeat_decorator(bec_ipython_client_fixture):
 
 
 @pytest.mark.timeout(100)
-def test_scan_set_completed(bec_ipython_client_fixture):
+@pytest.mark.parametrize(
+    "scan_name", [("grid_scan", "line_scan"), ("_v4_grid_scan", "_v4_line_scan")]
+)
+def test_scan_set_completed(bec_ipython_client_fixture, scan_name):
     """
     Test that a scan can be manually set to completed.
     """
@@ -953,7 +988,9 @@ def test_scan_set_completed(bec_ipython_client_fixture):
 
     threading.Thread(target=_set_scan_completed, args=(bec,), daemon=True).start()
 
-    scans.grid_scan(dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=0.01, relative=True)
+    getattr(scans, scan_name[0])(
+        dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=0.01, relative=True
+    )
 
     # Now add a second scan to ensure scans can continue after setting completed
-    scans.line_scan(dev.samx, -5, 5, steps=10, exp_time=0.01, relative=True)
+    getattr(scans, scan_name[1])(dev.samx, -5, 5, steps=10, exp_time=0.01, relative=True)

--- a/bec_ipython_client/tests/end-2-end/test_scans_lib_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_scans_lib_e2e.py
@@ -411,32 +411,40 @@ def test_config_reload_with_describe_failure(bec_test_config_file_path, bec_clie
         },
     }
 
-    # set hexapod to fail
-    bec.connector.set(
-        f"e2e_test_hexapod_fail", messages.DeviceStatusMessage(device="hexapod", status=1)
-    )
+    try:
+        # set hexapod to fail
+        bec.connector.set(
+            "e2e_test_hexapod_fail", messages.DeviceStatusMessage(device="hexapod", status=1)
+        )
 
-    # write new config to disk
-    with open(runtime_config_file_path, "w") as f:
-        f.write(yaml.dump(config))
+        # write new config to disk
+        with open(runtime_config_file_path, "w") as f:
+            f.write(yaml.dump(config))
 
-    with pytest.raises(DeviceConfigError):
-        bec.config.update_session_with_file(runtime_config_file_path, force=True, validate=False)
+        with pytest.raises(DeviceConfigError):
+            bec.config.update_session_with_file(
+                runtime_config_file_path, force=True, validate=False
+            )
 
-    assert len(bec.device_manager.devices) == 2
-    assert bec.device_manager.devices["eyefoc"].enabled is True
-    assert bec.device_manager.devices["hexapod"].enabled is False
+        assert len(bec.device_manager.devices) == 2
+        assert bec.device_manager.devices["eyefoc"].enabled is True
+        assert bec.device_manager.devices["hexapod"].enabled is False
 
-    # set hexapod to pass
-    bec.connector.set(
-        f"e2e_test_hexapod_fail", messages.DeviceStatusMessage(device="hexapod", status=0)
-    )
+        # set hexapod to pass
+        bec.connector.set(
+            "e2e_test_hexapod_fail", messages.DeviceStatusMessage(device="hexapod", status=0)
+        )
 
-    bec.config.update_session_with_file(runtime_config_file_path, force=True)
-    assert len(bec.device_manager.devices) == 2
-    assert bec.device_manager.devices["eyefoc"].enabled is True
-    assert bec.device_manager.devices["hexapod"].enabled is True
-    assert bec.device_manager.devices["hexapod"].precision == 3
+        bec.config.update_session_with_file(runtime_config_file_path, force=True)
+        assert len(bec.device_manager.devices) == 2
+        assert bec.device_manager.devices["eyefoc"].enabled is True
+        assert bec.device_manager.devices["hexapod"].enabled is True
+        assert bec.device_manager.devices["hexapod"].precision == 3
+    finally:
+        bec.connector.set(
+            "e2e_test_hexapod_fail", messages.DeviceStatusMessage(device="hexapod", status=0)
+        )
+        bec.config.update_session_with_file(bec_test_config_file_path, force=True)
 
 
 @pytest.mark.timeout(100)
@@ -543,6 +551,7 @@ def test_cached_device_readout(bec_client_lib):
 
 
 @pytest.mark.timeout(100)
+@pytest.mark.skip(reason="Interactive scans are currently not supported in v4 scans.")
 def test_interactive_scan(bec_client_lib):
     bec = bec_client_lib
     bec.metadata.update({"unit_test": "test_interactive_scan"})

--- a/bec_ipython_client/tests/end-2-end/test_scans_lib_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_scans_lib_e2e.py
@@ -16,25 +16,31 @@ logger = bec_logger.logger
 
 
 @pytest.mark.timeout(100)
-def test_grid_scan_lib(bec_client_lib):
+@pytest.mark.parametrize("scan_name", [("umv", "grid_scan"), ("_v4_umv", "_v4_grid_scan")])
+def test_grid_scan_lib(bec_client_lib, scan_name):
     bec = bec_client_lib
     scans = bec.scans
     bec.metadata.update({"unit_test": "test_grid_scan_bec_client_lib"})
     dev = bec.device_manager.devices
-    scans.umv(dev.samx, 0, dev.samy, 0, relative=False)
-    status = scans.grid_scan(dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=0.01, relative=True)
+    getattr(scans, scan_name[0])(dev.samx, 0, dev.samy, 0, relative=False)
+    status = getattr(scans, scan_name[1])(
+        dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=0.01, relative=True
+    )
     status.wait(num_points=True, file_written=True)
     assert len(status.scan.live_data) == 100
     assert status.scan.num_points == 100
 
 
 @pytest.mark.timeout(100)
-def test_grid_scan_lib_cancel(bec_client_lib):
+@pytest.mark.parametrize("scan_name", ["grid_scan", "_v4_grid_scan"])
+def test_grid_scan_lib_cancel(bec_client_lib, scan_name):
     bec = bec_client_lib
     scans = bec.scans
     bec.metadata.update({"unit_test": "test_grid_scan_bec_client_lib"})
     dev = bec.device_manager.devices
-    status = scans.grid_scan(dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=1, relative=False)
+    status = getattr(scans, scan_name)(
+        dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=1, relative=False
+    )
     time.sleep(0.5)
     status.cancel()
 

--- a/bec_ipython_client/tests/end-2-end/test_scans_lib_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_scans_lib_e2e.py
@@ -381,6 +381,7 @@ def test_config_reload(
         assert bec.device_manager.devices[dev].enabled is False
 
 
+@pytest.mark.timeout(100)
 def test_config_reload_with_describe_failure(bec_test_config_file_path, bec_client_lib):
     bec = bec_client_lib
     bec.metadata.update({"unit_test": "test_config_reload"})
@@ -438,6 +439,7 @@ def test_config_reload_with_describe_failure(bec_test_config_file_path, bec_clie
     assert bec.device_manager.devices["hexapod"].precision == 3
 
 
+@pytest.mark.timeout(100)
 def test_config_add_remove_device(bec_client_lib):
     bec = bec_client_lib
     bec.metadata.update({"unit_test": "test_config_add_device"})
@@ -480,6 +482,7 @@ def test_config_add_remove_device(bec_client_lib):
     assert "samx" in dev
 
 
+@pytest.mark.timeout(100)
 def test_computed_signal(bec_client_lib):
     bec = bec_client_lib
     bec.metadata.update({"unit_test": "test_computed_signal"})
@@ -500,6 +503,7 @@ def test_computed_signal(bec_client_lib):
     assert dev.pseudo_signal1.read()["pseudo_signal1"]["value"] == 5
 
 
+@pytest.mark.timeout(100)
 def test_cached_device_readout(bec_client_lib):
     bec = bec_client_lib
     bec.metadata.update({"unit_test": "test_cached_device_readout"})
@@ -538,6 +542,7 @@ def test_cached_device_readout(bec_client_lib):
     assert timestamp_3 == timestamp_2
 
 
+@pytest.mark.timeout(100)
 def test_interactive_scan(bec_client_lib):
     bec = bec_client_lib
     bec.metadata.update({"unit_test": "test_interactive_scan"})

--- a/bec_lib/bec_lib/device.py
+++ b/bec_lib/bec_lib/device.py
@@ -428,7 +428,7 @@ class DeviceBase:
 
     def _handle_client_info_msg(self):
         """Handle client messages during RPC calls"""
-        msgs = self.root.parent.connector.xread(MessageEndpoints.client_info())
+        msgs = self.root.parent.connector.xread(MessageEndpoints.client_info(), block=5)
         # The client is the parent.parent of the device
         client: BECClient = self.root.parent.parent
         if client.live_updates_config.print_client_messages is False:

--- a/bec_lib/bec_lib/device.py
+++ b/bec_lib/bec_lib/device.py
@@ -357,7 +357,7 @@ class DeviceBase:
             messages.ScanQueueMessage: The RPC message.
         """
         client: BECClient = self.root.parent.parent
-        scan_type = "device_rpc"
+        scan_type = "_v4_device_rpc"
         if scan_type == "_v4_device_rpc":
             parameter = {
                 "args": [],

--- a/bec_lib/bec_lib/device.py
+++ b/bec_lib/bec_lib/device.py
@@ -356,18 +356,33 @@ class DeviceBase:
         Returns:
             messages.ScanQueueMessage: The RPC message.
         """
-
-        params = {
-            "device": device,
-            "rpc_id": rpc_id,
-            "func": func_call,
-            "args": args,
-            "kwargs": kwargs,
-        }
         client: BECClient = self.root.parent.parent
+        scan_type = "device_rpc"
+        if scan_type == "_v4_device_rpc":
+            parameter = {
+                "args": [],
+                "kwargs": {
+                    "device": device,
+                    "func": func_call,
+                    "func_args": args,
+                    "func_kwargs": kwargs,
+                    "rpc_id": rpc_id,
+                    "system_config": client.system_config,
+                },
+            }
+        else:
+            # TODO: Remove once we've fully migrated to v4
+            parameter = {
+                "device": device,
+                "rpc_id": rpc_id,
+                "func": func_call,
+                "args": args,
+                "kwargs": kwargs,
+            }
+
         msg = messages.ScanQueueMessage(
-            scan_type="device_rpc",
-            parameter=params,
+            scan_type=scan_type,
+            parameter=parameter,
             queue=client.queue.get_default_scan_queue(),  # type: ignore
             metadata={"RID": request_id, "response": True},
         )
@@ -413,7 +428,7 @@ class DeviceBase:
 
     def _handle_client_info_msg(self):
         """Handle client messages during RPC calls"""
-        msgs = self.root.parent.connector.xread(MessageEndpoints.client_info(), block=200)
+        msgs = self.root.parent.connector.xread(MessageEndpoints.client_info())
         # The client is the parent.parent of the device
         client: BECClient = self.root.parent.parent
         if client.live_updates_config.print_client_messages is False:

--- a/bec_lib/bec_lib/messages.py
+++ b/bec_lib/bec_lib/messages.py
@@ -267,7 +267,8 @@ class ScanStatusMessage(BECMessage):
         session_id (str, optional): Session ID
         num_points (int, optional): Number of points in the scan. Only relevant if the number of points is determined by BEC.
         scan_name (str, optional): Name of the scan, e.g. 'line_scan'
-        scan_type (Literal["step", "fly"], optional): Type of scan
+        scan_type (Literal["step", "fly", "software_triggered", "hardware_triggered"], optional):
+            Type of scan
         dataset_number (int, optional): Dataset number
         scan_report_devices (list[str], optional): List of devices that are part of the scan report
         user_metadata (dict, optional): User metadata
@@ -295,7 +296,9 @@ class ScanStatusMessage(BECMessage):
         default=0, description="Number of monitored readouts in the scan."
     )
     scan_name: str | None = Field(default=None, description="Name of the scan, e.g. 'line_scan'")
-    scan_type: Literal["step", "fly"] | None = Field(default=None, description="Type of scan")
+    scan_type: Literal["step", "fly", "software_triggered", "hardware_triggered"] | None = Field(
+        default=None, description="Type of scan"
+    )
     dataset_number: int | None = None
     scan_report_devices: list[str] | None = None
     user_metadata: dict | None = None

--- a/bec_lib/bec_lib/scan_report.py
+++ b/bec_lib/bec_lib/scan_report.py
@@ -68,7 +68,7 @@ class ScanReport:
         """returns the current status of the request"""
         scan_type = self.request.request.content["scan_type"]
         status = self.queue_item.status
-        if scan_type == "mv" and status == "COMPLETED":
+        if scan_type in ["mv", "_v4_mv"] and status == "COMPLETED":
             return "COMPLETED" if self._get_mv_status() else "RUNNING"
         return self.queue_item.status
 
@@ -147,7 +147,7 @@ class ScanReport:
             return self
         scan_type = self.request.request.content["scan_type"]
         try:
-            if scan_type == "mv":
+            if scan_type in ["mv", "_v4_mv"]:
                 self._wait_move(timeout, sleep_time)
             else:
                 self._wait_scan(
@@ -168,7 +168,7 @@ class ScanReport:
         if self._client is None:
             raise ValueError("Client is not set. Cannot cancel the scan.")
         scan_type = self.request.request.content["scan_type"]
-        if scan_type == "mv":
+        if scan_type in ["mv", "_v4_mv"]:
             motors = list(self.request.request.parameter["args"].keys())
             for motor in motors:
                 try:

--- a/bec_lib/tests/test_devices.py
+++ b/bec_lib/tests/test_devices.py
@@ -1,4 +1,3 @@
-from types import SimpleNamespace
 from typing import Any, Callable, Literal
 from unittest import mock
 
@@ -312,6 +311,20 @@ def test_handle_rpc_response_raises(dev: Any):
 def test_handle_rpc_response_returns_dict(dev: Any):
     msg = messages.DeviceRPCMessage(device="samx", return_val={"a": "b"}, out="done", success=True)
     assert dev.samx._handle_rpc_response(msg) == {"a": "b"}
+
+
+def test_prepare_rpc_msg_uses_v4_device_rpc_signature(dev: Any):
+    dev.samx.root.parent.parent.queue.get_default_scan_queue.return_value = "primary"
+
+    msg = dev.samx._prepare_rpc_msg("rpc-id", "request-id", "samx", "set", 1, "fast", armed=True)
+
+    assert msg.scan_type == "_v4_device_rpc"
+    assert msg.parameter["args"] == []
+    assert msg.parameter["kwargs"]["device"] == "samx"
+    assert msg.parameter["kwargs"]["func"] == "set"
+    assert msg.parameter["kwargs"]["func_args"] == (1, "fast")
+    assert msg.parameter["kwargs"]["func_kwargs"] == {"armed": True}
+    assert msg.parameter["kwargs"]["rpc_id"] == "rpc-id"
 
 
 def test_run_rpc_call_calls_stop_on_keyboardinterrupt(dev: Any):

--- a/bec_server/bec_server/file_writer/file_writer_manager.py
+++ b/bec_server/bec_server/file_writer/file_writer_manager.py
@@ -21,6 +21,8 @@ from bec_server.file_writer.file_writer import HDF5FileWriter
 
 logger = bec_logger.logger
 
+SYNC_SCAN_TYPES = {"step", "software_triggered", "hardware_triggered"}
+
 
 class ScanStorage:
     def __init__(self, scan_number: int, scan_id: str) -> None:
@@ -273,7 +275,7 @@ class FileWriterManager(BECService):
             scan_storage.num_monitored_readouts = msg.num_monitored_readouts
             info = msg.content.get("info")
             if info:
-                if msg.scan_type == "step":
+                if msg.scan_type in SYNC_SCAN_TYPES:
                     scan_storage.enforce_sync = True
                 else:
                     scan_storage.enforce_sync = info["monitor_sync"] == "bec"

--- a/bec_server/bec_server/scan_server/scan_assembler.py
+++ b/bec_server/bec_server/scan_server/scan_assembler.py
@@ -130,13 +130,16 @@ class ScanAssembler:
             scan_cls, scan_info["signature"], resolved_args, resolved_kwargs
         )
 
+        metadata = msg.metadata.copy() if msg.metadata is not None else None
+        user_metadata = metadata.pop("user_metadata", {}) if metadata is not None else {}
         with self.device_manager._rpc_method(partial(self._raise_on_rpc_call, scan_cls)):
             scan_instance = scan_cls(
                 *resolved_args,
                 device_manager=self.device_manager,
                 redis_connector=self.connector,
                 scan_modifier=get_scan_modifier(),
-                metadata=msg.metadata,
+                metadata=metadata,
+                user_metadata=user_metadata,
                 instruction_handler=self.parent.queue_manager.instruction_handler,
                 scan_id=scan_id,
                 request_inputs=request_inputs,

--- a/bec_server/bec_server/scan_server/scan_guard.py
+++ b/bec_server/bec_server/scan_server/scan_guard.py
@@ -115,10 +115,10 @@ class ScanGuard:
         if scan_type not in avail_scans.resource:
             raise ScanRejection(f"Unknown scan type {scan_type}.")
 
-        if scan_type == "device_rpc":
+        if scan_type in ["device_rpc", "_v4_device_rpc"]:
             # ensure that the requested rpc is allowed for this particular device
-            params = request.content.get("parameter")
-            if not self._device_rpc_is_valid(device=params.get("device"), func=params.get("func")):
+            device, func = self._extract_device_rpc_target(request)
+            if not self._device_rpc_is_valid(device=device, func=func):
                 raise ScanRejection(f"Rejected rpc: {request.content}")
 
     def _device_rpc_is_valid(self, device: str, func: str) -> bool:
@@ -141,11 +141,13 @@ class ScanGuard:
             ScanRejection: If any motor is not enabled or movable
         """
         parameter = request.parameter
-        if request.scan_type == "device_rpc":
-            device = parameter.get("device")
+        if request.scan_type in ["device_rpc", "_v4_device_rpc"]:
+            device, _ = self._extract_device_rpc_target(request)
             if not isinstance(device, list):
                 device = [device]
             for dev in device:
+                if dev not in self.device_manager.devices:
+                    raise ScanRejection(f"Device {dev} is not known.")
                 if not self.device_manager.devices[dev].enabled:
                     raise ScanRejection(f"Device {dev} is not enabled.")
             return
@@ -212,13 +214,23 @@ class ScanGuard:
             logger.info(f"Request was rejected: {scan_status.message}")
             return
 
-        if msg.scan_type == "device_rpc":
-            func = msg.content.get("parameter", {}).get("func", "")
+        if msg.scan_type in ["device_rpc", "_v4_device_rpc"]:
+            _, func = self._extract_device_rpc_target(msg)
             if func in ["get", "read"] or func.endswith(".get") or func.endswith(".read"):
                 logger.info("Scan request is a read operation, not enqueuing.")
                 self._direct_device_rpc(msg)
                 return
         self._append_to_scan_queue(msg)
+
+    @staticmethod
+    def _extract_device_rpc_target(
+        msg: messages.ScanQueueMessage,
+    ) -> tuple[str | list[str] | None, str]:
+        params = msg.content.get("parameter", {})
+        if msg.scan_type == "_v4_device_rpc":
+            rpc_kwargs = params.get("kwargs", {})
+            return rpc_kwargs.get("device"), rpc_kwargs.get("func", "")
+        return params.get("device"), params.get("func", "")
 
     def _direct_device_rpc(self, msg: messages.ScanQueueMessage):
         """
@@ -226,7 +238,7 @@ class ScanGuard:
         Args:
             msg: ScanQueueMessage containing the RPC request
         """
-        device = msg.content.get("parameter", {}).get("device")
+        device, _ = self._extract_device_rpc_target(msg)
         if not device:
             logger.error("No device specified for RPC request.")
             return
@@ -235,6 +247,15 @@ class ScanGuard:
         if not params:
             logger.error("No parameters provided for device RPC request.")
             return
+        if msg.scan_type == "_v4_device_rpc":
+            rpc_kwargs = params.get("kwargs", {})
+            params = {
+                "device": device,
+                "rpc_id": rpc_kwargs.get("rpc_id"),
+                "func": rpc_kwargs.get("func"),
+                "args": rpc_kwargs.get("func_args", []),
+                "kwargs": rpc_kwargs.get("func_kwargs", {}),
+            }
         instr = messages.DeviceInstructionMessage(
             device=device,
             action="rpc",

--- a/bec_server/bec_server/scan_server/scans/acquire.py
+++ b/bec_server/bec_server/scan_server/scans/acquire.py
@@ -106,7 +106,7 @@ class Acquire(ScanBase):
         )
 
         self.actions.add_scan_report_instruction_scan_progress(
-            points=self.scan_info.num_monitored_readouts, show_table=False
+            points=self.scan_info.num_monitored_readouts, show_table=True
         )
 
         self._baseline_readout_status = self.actions.read_baseline_devices(wait=False)

--- a/bec_server/bec_server/scan_server/scans/cont_line_scan.py
+++ b/bec_server/bec_server/scan_server/scans/cont_line_scan.py
@@ -147,7 +147,7 @@ class ContLineScan(ScanBase):
         )
 
         self.actions.add_scan_report_instruction_scan_progress(
-            points=self.scan_info.num_monitored_readouts, show_table=False
+            points=self.scan_info.num_monitored_readouts, show_table=True
         )
 
         self._baseline_readout_status = self.actions.read_baseline_devices(wait=False)

--- a/bec_server/bec_server/scan_server/scans/device_rpc.py
+++ b/bec_server/bec_server/scan_server/scans/device_rpc.py
@@ -114,7 +114,7 @@ class DeviceRpc(ScanBase):
         """
         Pre-scan steps to be executed before the main scan logic.
         This is typically the last chance to prepare the devices before the core scan
-        logic is executed. For example, this is a good place to initialize time-criticial
+        logic is executed. For example, this is a good place to initialize time-critical
         devices, e.g. devices that have a short timeout.
         The pre-scan logic is typically implemented on the device itself.
         """
@@ -126,10 +126,10 @@ class DeviceRpc(ScanBase):
         This is where the main scan logic should be implemented.
         """
         status = self.actions.rpc_call_no_wait(
-            self.device, self.func, self.rpc_id, *self.func_args, **self.func_kwargs
+            self.device, self.func, self.rpc_id, *self.func_args, response=True, **self.func_kwargs
         )
         # We don't wait for the RPC to resolve
-        self.actions._status_registry.pop(status._device_instr_id)
+        self.actions._status_registry.pop(status._device_instr_id, None)
 
     @scan_hook
     def at_each_point(self):

--- a/bec_server/bec_server/scan_server/scans/device_rpc.py
+++ b/bec_server/bec_server/scan_server/scans/device_rpc.py
@@ -1,0 +1,166 @@
+"""
+Device RPC implementation.
+
+Scan procedure:
+    - prepare_scan
+    - open_scan
+    - stage
+    - pre_scan
+    - scan_core
+        - at_each_point (optionally called by scan_core)
+    - post_scan
+    - unstage
+    - close_scan
+    - on_exception (called if any exception is raised during the scan)
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from bec_lib.device import DeviceBase
+from bec_lib.logger import bec_logger
+from bec_lib.scan_args import ScanArgument
+from bec_server.scan_server.scans.scan_base import ScanBase
+from bec_server.scan_server.scans.scan_modifier import scan_hook
+
+logger = bec_logger.logger
+
+
+class DeviceRpc(ScanBase):
+    # Scan Type: Hardware triggered or software triggered?
+    # If the main trigger and readout logic is done within the at_each_point method in scan_core, choose SOFTWARE_TRIGGERED.
+    # If the main trigger and readout logic is implemented on a device that is simply kicked off in this scan, choose HARDWARE_TRIGGERED.
+    # This primarily serves as information for devices: The device may need to react differently if a software trigger is expected
+    # for every point.
+    scan_type = None
+    is_scan = False
+
+    # Scan name: This is the name of the scan, e.g. "line_scan". This is used for display purposes and to identify the scan type in user interfaces.
+    # Choose a descriptive name that does not conflict with existing scan names.
+    # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
+    scan_name = "_v4_device_rpc"
+
+    def __init__(
+        self,
+        device: Annotated[DeviceBase, ScanArgument(display_name="Device", description="Device.")],
+        func: Annotated[
+            str, ScanArgument(display_name="RPC function", description="RPC function.")
+        ],
+        func_args: Annotated[
+            list,
+            ScanArgument(
+                display_name="RPC function arguments", description="RPC function arguments."
+            ),
+        ],
+        func_kwargs: Annotated[
+            dict,
+            ScanArgument(
+                display_name="RPC function keyword arguments",
+                description="RPC function keyword arguments.",
+            ),
+        ],
+        rpc_id: Annotated[str, ScanArgument(display_name="RPC ID", description="RPC ID.")],
+        **kwargs,
+    ):
+        """
+        Scan implementation.
+
+        Args:
+            device (DeviceBase): Device.
+            func (str): RPC function.
+            func_args (list): RPC function arguments.
+            func_kwargs (dict): RPC function keyword arguments.
+
+        Returns:
+            ScanReport
+        """
+        super().__init__(**kwargs)
+        self.device = device
+        self.rpc_id = rpc_id
+        self.func = func
+        self.func_args = func_args
+        self.func_kwargs = func_kwargs
+
+    @scan_hook
+    def prepare_scan(self):
+        """
+        Prepare the scan. This can include any steps that need to be executed
+        before the scan is opened, such as preparing the positions (if not done already)
+        or setting up the devices.
+        """
+
+    @scan_hook
+    def open_scan(self):
+        """
+        Open the scan.
+        This step must call self.actions.open_scan() to ensure that a new scan is
+        opened. Make sure to prepare the scan metadata before, either in
+        prepare_scan() or in open_scan() itself and call self.update_scan_info(...)
+        to update the scan metadata if needed.
+        """
+
+    @scan_hook
+    def stage(self):
+        """
+        Stage the devices for the upcoming scan. The stage logic is typically
+        implemented on the device itself (i.e. by the device's stage method).
+        However, if there are any additional steps that need to be executed before
+        staging the devices, they can be implemented here.
+        """
+
+    @scan_hook
+    def pre_scan(self):
+        """
+        Pre-scan steps to be executed before the main scan logic.
+        This is typically the last chance to prepare the devices before the core scan
+        logic is executed. For example, this is a good place to initialize time-criticial
+        devices, e.g. devices that have a short timeout.
+        The pre-scan logic is typically implemented on the device itself.
+        """
+
+    @scan_hook
+    def scan_core(self):
+        """
+        Core scan logic to be executed during the scan.
+        This is where the main scan logic should be implemented.
+        """
+        status = self.actions.rpc_call_no_wait(
+            self.device, self.func, self.rpc_id, *self.func_args, **self.func_kwargs
+        )
+        # We don't wait for the RPC to resolve
+        self.actions._status_registry.pop(status._device_instr_id)
+
+    @scan_hook
+    def at_each_point(self):
+        """
+        Logic to be executed at each acquisition point during the scan.
+        """
+
+    @scan_hook
+    def post_scan(self):
+        """
+        Post-scan steps to be executed after the main scan logic.
+        """
+
+    @scan_hook
+    def unstage(self):
+        """Unstage the scan by executing post-scan steps."""
+
+    @scan_hook
+    def close_scan(self):
+        """Close the scan."""
+
+    @scan_hook
+    def on_exception(self, exception: Exception):
+        """
+        Handle exceptions that occur during the scan.
+        This is a good place to implement any cleanup logic that needs to be executed in case of an exception,
+        such as returning the devices to a safe state or moving the motors back to their starting position.
+        """
+
+    #######################################################
+    ######### Helper methods for the scan logic ###########
+    #######################################################
+
+    # Implement scan-specific helper methods below.

--- a/bec_server/bec_server/scan_server/scans/fermat_scan.py
+++ b/bec_server/bec_server/scan_server/scans/fermat_scan.py
@@ -195,7 +195,7 @@ class FermatSpiralScan(ScanBase):
         )
 
         self.actions.add_scan_report_instruction_scan_progress(
-            points=self.scan_info.num_monitored_readouts, show_table=False
+            points=self.scan_info.num_monitored_readouts, show_table=True
         )
 
         self._baseline_readout_status = self.actions.read_baseline_devices(wait=False)

--- a/bec_server/bec_server/scan_server/scans/grid_scan.py
+++ b/bec_server/bec_server/scan_server/scans/grid_scan.py
@@ -155,7 +155,7 @@ class GridScan(ScanBase):
         )
 
         self.actions.add_scan_report_instruction_scan_progress(
-            points=self.scan_info.num_monitored_readouts, show_table=False
+            points=self.scan_info.num_monitored_readouts, show_table=True
         )
 
         self._baseline_readout_status = self.actions.read_baseline_devices(wait=False)

--- a/bec_server/bec_server/scan_server/scans/hexagonal_scan.py
+++ b/bec_server/bec_server/scan_server/scans/hexagonal_scan.py
@@ -177,7 +177,7 @@ class HexagonalScan(ScanBase):
         )
 
         self.actions.add_scan_report_instruction_scan_progress(
-            points=self.scan_info.num_monitored_readouts, show_table=False
+            points=self.scan_info.num_monitored_readouts, show_table=True
         )
 
         self._baseline_readout_status = self.actions.read_baseline_devices(wait=False)

--- a/bec_server/bec_server/scan_server/scans/line_scan.py
+++ b/bec_server/bec_server/scan_server/scans/line_scan.py
@@ -149,7 +149,7 @@ class LineScan(ScanBase):
         )
 
         self.actions.add_scan_report_instruction_scan_progress(
-            points=self.scan_info.num_monitored_readouts, show_table=False
+            points=self.scan_info.num_monitored_readouts, show_table=True
         )
         self._premove_motor_status = self.actions.set(self.motors, self.positions[0], wait=False)
         self._baseline_readout_status = self.actions.read_baseline_devices(wait=False)

--- a/bec_server/bec_server/scan_server/scans/line_sweep_scan.py
+++ b/bec_server/bec_server/scan_server/scans/line_sweep_scan.py
@@ -123,7 +123,7 @@ class LineSweepScan(ScanBase):
             self.start_positions = self.components.get_start_positions(self.motors)
             self.positions += self.start_positions
         self.components.check_limits(self.motors, self.positions)
-        self.actions.add_scan_report_instruction_scan_progress(points=0, show_table=False)
+        self.actions.add_scan_report_instruction_scan_progress(points=0, show_table=True)
 
         self.update_scan_info(positions=self.positions, num_points=0, num_monitored_readouts=0)
         self._baseline_readout_status = self.actions.read_baseline_devices(wait=False)

--- a/bec_server/bec_server/scan_server/scans/list_scan.py
+++ b/bec_server/bec_server/scan_server/scans/list_scan.py
@@ -140,7 +140,7 @@ class ListScan(ScanBase):
         )
 
         self.actions.add_scan_report_instruction_scan_progress(
-            points=self.scan_info.num_monitored_readouts, show_table=False
+            points=self.scan_info.num_monitored_readouts, show_table=True
         )
 
         self._premove_motor_status = self.actions.set(self.motors, self.positions[0], wait=False)

--- a/bec_server/bec_server/scan_server/scans/log_scan.py
+++ b/bec_server/bec_server/scan_server/scans/log_scan.py
@@ -144,7 +144,7 @@ class LogScan(ScanBase):
         )
 
         self.actions.add_scan_report_instruction_scan_progress(
-            points=self.scan_info.num_monitored_readouts, show_table=False
+            points=self.scan_info.num_monitored_readouts, show_table=True
         )
 
         self._premove_motor_status = self.actions.set(self.motors, self.positions[0], wait=False)

--- a/bec_server/bec_server/scan_server/scans/multi_region_grid_scan.py
+++ b/bec_server/bec_server/scan_server/scans/multi_region_grid_scan.py
@@ -138,7 +138,7 @@ class MultiRegionGridScan(ScanBase):
         )
 
         self.actions.add_scan_report_instruction_scan_progress(
-            points=self.scan_info.num_monitored_readouts, show_table=False
+            points=self.scan_info.num_monitored_readouts, show_table=True
         )
         self._premove_motor_status = self.actions.set(self.motors, self.positions[0], wait=False)
         self._baseline_readout_status = self.actions.read_baseline_devices(wait=False)

--- a/bec_server/bec_server/scan_server/scans/multi_region_line_scan.py
+++ b/bec_server/bec_server/scan_server/scans/multi_region_line_scan.py
@@ -135,7 +135,7 @@ class MultiRegionLineScan(ScanBase):
         )
 
         self.actions.add_scan_report_instruction_scan_progress(
-            points=self.scan_info.num_monitored_readouts, show_table=False
+            points=self.scan_info.num_monitored_readouts, show_table=True
         )
 
         self._premove_motor_status = self.actions.set(self.motors, self.positions[0], wait=False)

--- a/bec_server/bec_server/scan_server/scans/position_generators.py
+++ b/bec_server/bec_server/scan_server/scans/position_generators.py
@@ -367,18 +367,16 @@ def fermat_spiral_pos(
     if step <= 0:
         raise ValueError("step must be positive")
 
-    phi = np.pi * (3 - np.sqrt(5)) + spiral_type * np.pi
+    phi = 2 * np.pi * ((1 + np.sqrt(5)) / 2.0) + spiral_type * np.pi
     start_index = 0 if center else 1
 
     x_center = (m1_start + m1_stop) / 2
     y_center = (m2_start + m2_stop) / 2
     x_range = abs(m1_stop - m1_start)
     y_range = abs(m2_stop - m2_start)
-    half_x = x_range / 2
-    half_y = y_range / 2
 
     radial_scale = step / np.sqrt(np.pi)
-    max_index = max(1, int(np.ceil((max(half_x, half_y) / radial_scale) ** 2)) * 2)
+    max_index = int(np.ceil(x_range * y_range * 3.2 / step**2))
 
     points = []
     for ii in range(start_index, max_index + 1):

--- a/bec_server/bec_server/scan_server/scans/round_roi_scan.py
+++ b/bec_server/bec_server/scan_server/scans/round_roi_scan.py
@@ -184,7 +184,7 @@ class RoundROIScan(ScanBase):
         )
 
         self.actions.add_scan_report_instruction_scan_progress(
-            points=self.scan_info.num_monitored_readouts, show_table=False
+            points=self.scan_info.num_monitored_readouts, show_table=True
         )
 
         self._premove_motor_status = self.actions.set(self.motors, self.positions[0], wait=False)

--- a/bec_server/bec_server/scan_server/scans/round_scan.py
+++ b/bec_server/bec_server/scan_server/scans/round_scan.py
@@ -176,7 +176,7 @@ class RoundScan(ScanBase):
         )
 
         self.actions.add_scan_report_instruction_scan_progress(
-            points=self.scan_info.num_monitored_readouts, show_table=False
+            points=self.scan_info.num_monitored_readouts, show_table=True
         )
 
         self._premove_motor_status = self.actions.set(self.motors, self.positions[0], wait=False)

--- a/bec_server/bec_server/scan_server/scans/scan_actions.py
+++ b/bec_server/bec_server/scan_server/scans/scan_actions.py
@@ -935,7 +935,7 @@ class ScanActions:
 
     @requires_scan_is_running
     def rpc_call_no_wait(
-        self, device: str | DeviceBase, func_name: str, rpc_id: str, *args, **kwargs
+        self, device: str | DeviceBase, func_name: str, rpc_id: str, *args, response=False, **kwargs
     ) -> ScanStubStatus:
         """
         Make an RPC call to a device without waiting for the result. This will call the given function on the device with the given arguments.
@@ -947,6 +947,7 @@ class ScanActions:
             func_name (str): name of the function to call on the device
             rpc_id (str): unique identifier for the RPC call, used to match the response with the request
             *args: positional arguments to pass to the function
+            response (bool): if True, request a device response for status-returning RPC calls.
             **kwargs: keyword arguments to pass to the function
 
         Returns:
@@ -966,7 +967,7 @@ class ScanActions:
             device=device_name,
             action="rpc",
             parameter=parameter,
-            metadata={"device_instr_id": status._device_instr_id},
+            metadata={"device_instr_id": status._device_instr_id, "response": response},
         )
         self._send(msg)
         return status
@@ -1392,7 +1393,7 @@ class ScanActions:
             file_components=file_components,
         )
         scan_info = self._scan.scan_info
-        scan_type = scan_info.scan_type
+        scan_type = getattr(scan_info.scan_type, "value", scan_info.scan_type)
         return messages.ScanStatusMessage(
             scan_id=scan_info.scan_id,
             status=status,
@@ -1402,7 +1403,7 @@ class ScanActions:
             session_id=scan_info.metadata.get("session_id"),
             dataset_number=scan_info.dataset_number,
             num_points=scan_info.num_points,
-            scan_type=scan_type if scan_type in {"step", "fly"} else None,
+            scan_type=scan_type,
             scan_report_devices=scan_info.scan_report_devices,
             user_metadata=scan_info.user_metadata,
             readout_priority=resolved_readout_priority,

--- a/bec_server/bec_server/scan_server/scans/scan_actions.py
+++ b/bec_server/bec_server/scan_server/scans/scan_actions.py
@@ -762,7 +762,9 @@ class ScanActions:
         Args:
             device (str | DeviceBase): name of the device or DeviceBase instance to report
         """
-        device_name = self._normalize_device_name(device)
+        # NOTE: the device name does not use the dotted name as in many other scan actions but the root
+        # name. This is because the progress signal is scoped to an entire device.
+        device_name = device if isinstance(device, str) else device.root.name
         self.acquire_device_lock(device_name)
         scan_report_instruction = {"device_progress": [device_name]}
         self._scan.scan_info.scan_report_instructions.append(scan_report_instruction)

--- a/bec_server/bec_server/scan_server/scans/time_scan.py
+++ b/bec_server/bec_server/scan_server/scans/time_scan.py
@@ -90,7 +90,7 @@ class TimeScan(ScanBase):
             positions=np.array([]), num_points=self.points, num_monitored_readouts=self.points
         )
 
-        self.actions.add_scan_report_instruction_scan_progress(points=self.points, show_table=False)
+        self.actions.add_scan_report_instruction_scan_progress(points=self.points, show_table=True)
 
         self._baseline_readout_status = self.actions.read_baseline_devices(wait=False)
 

--- a/bec_server/tests/tests_file_writer/test_file_writer_manager.py
+++ b/bec_server/tests/tests_file_writer/test_file_writer_manager.py
@@ -258,6 +258,34 @@ def test_update_scan_storage_with_status_ignores_none(file_writer_manager_mock):
     assert file_manager.scan_storage == {}
 
 
+def test_update_scan_storage_with_status_waits_for_v4_sync_segments(file_writer_manager_mock):
+    file_manager = file_writer_manager_mock
+    storage = ScanStorage(1, "scan_id")
+    storage.scan_segments = {point_id: {"data": point_id} for point_id in range(99)}
+    file_manager.scan_storage["scan_id"] = storage
+    msg = messages.ScanStatusMessage(
+        scan_id="scan_id",
+        status="closed",
+        scan_number=1,
+        scan_type="software_triggered",
+        num_points=100,
+        num_monitored_readouts=100,
+        readout_priority={"monitored": ["samx"]},
+        info={"scan_number": 1, "monitor_sync": None},
+    )
+
+    with (
+        mock.patch.object(file_manager, "update_baseline_reading"),
+        mock.patch.object(file_manager, "update_file_references"),
+        mock.patch.object(file_manager, "write_file") as write_file,
+    ):
+        file_manager.update_scan_storage_with_status(msg)
+
+    assert storage.enforce_sync is True
+    assert storage.ready_to_write() is False
+    write_file.assert_not_called()
+
+
 def test_ready_to_write(file_writer_manager_mock, scan_storage_mock):
     file_manager = file_writer_manager_mock
     scan_storage_mock.status_msg = messages.ScanStatusMessage(

--- a/bec_server/tests/tests_scan_server/scans_v4/test_acquire.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_acquire.py
@@ -38,7 +38,7 @@ def test_acquire_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler):
     assert scan.scan_info.num_monitored_readouts == 3
     assert scan.scan_info.positions.size == 0
     assert scan.scan_info.scan_report_instructions == [
-        {"scan_progress": {"points": 3, "show_table": False}}
+        {"scan_progress": {"points": 3, "show_table": True}}
     ]
 
 

--- a/bec_server/tests/tests_scan_server/scans_v4/test_device_rpc_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_device_rpc_scan.py
@@ -1,0 +1,50 @@
+from unittest import mock
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("hook_name",),
+    [
+        ("prepare_scan",),
+        ("open_scan",),
+        ("stage",),
+        ("pre_scan",),
+        ("post_scan",),
+        ("unstage",),
+        ("close_scan",),
+    ],
+)
+def test_device_rpc_scan_default_noop_hooks_do_not_raise(v4_scan_assembler, hook_name):
+    scan = v4_scan_assembler("_v4_device_rpc", "samx", "read", [], {}, rpc_id="rpc-id-123")
+
+    getattr(scan, hook_name)()
+
+
+def test_device_rpc_scan_core_sends_fire_and_forget_rpc(v4_scan_assembler):
+    scan = v4_scan_assembler(
+        "_v4_device_rpc",
+        "samx",
+        "controller.set_mode",
+        [1, "fast"],
+        {"armed": True},
+        rpc_id="rpc-id-123",
+    )
+    status = mock.MagicMock(_device_instr_id="device-instr-id")
+    scan.actions.rpc_call_no_wait = mock.MagicMock(return_value=status)
+    scan.actions._status_registry = {"device-instr-id": status}
+
+    scan.scan_core()
+
+    scan.actions.rpc_call_no_wait.assert_called_once_with(
+        scan.device, "controller.set_mode", "rpc-id-123", 1, "fast", armed=True
+    )
+    assert scan.actions._status_registry == {}
+
+
+def test_device_rpc_scan_is_registered_as_non_scan(v4_scan_assembler):
+    scan = v4_scan_assembler("_v4_device_rpc", "samx", "read", [], {}, rpc_id="rpc-id-123")
+
+    assert scan.scan_name == "_v4_device_rpc"
+    assert scan.is_scan is False
+    assert scan.scan_info.scan_type is None

--- a/bec_server/tests/tests_scan_server/scans_v4/test_device_rpc_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_device_rpc_scan.py
@@ -37,7 +37,7 @@ def test_device_rpc_scan_core_sends_fire_and_forget_rpc(v4_scan_assembler):
     scan.scan_core()
 
     scan.actions.rpc_call_no_wait.assert_called_once_with(
-        scan.device, "controller.set_mode", "rpc-id-123", 1, "fast", armed=True
+        scan.device, "controller.set_mode", "rpc-id-123", 1, "fast", response=True, armed=True
     )
     assert scan.actions._status_registry == {}
 

--- a/bec_server/tests/tests_scan_server/scans_v4/test_fermat_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_fermat_scan.py
@@ -35,7 +35,7 @@ def test_fermat_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler)
     assert scan.scan_info.num_points == len(scan.positions)
     assert np.array_equal(scan.scan_info.positions, scan.positions)
     assert scan.scan_info.scan_report_instructions == [
-        {"scan_progress": {"points": len(scan.positions), "show_table": False}}
+        {"scan_progress": {"points": len(scan.positions), "show_table": True}}
     ]
 
     read_messages = [

--- a/bec_server/tests/tests_scan_server/scans_v4/test_grid_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_grid_scan.py
@@ -33,7 +33,7 @@ def test_grid_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler):
     assert scan.scan_info.num_points == 15
     assert np.array_equal(scan.scan_info.positions, scan.positions)
     assert scan.scan_info.scan_report_instructions == [
-        {"scan_progress": {"points": 15, "show_table": False}}
+        {"scan_progress": {"points": 15, "show_table": True}}
     ]
 
 

--- a/bec_server/tests/tests_scan_server/scans_v4/test_line_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_line_scan.py
@@ -33,7 +33,7 @@ def test_line_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler):
     assert scan.scan_info.num_points == 5
     assert np.array_equal(scan.scan_info.positions, expected_positions)
     assert scan.scan_info.scan_report_instructions == [
-        {"scan_progress": {"points": 5, "show_table": False}}
+        {"scan_progress": {"points": 5, "show_table": True}}
     ]
 
 

--- a/bec_server/tests/tests_scan_server/scans_v4/test_line_sweep_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_line_sweep_scan.py
@@ -65,7 +65,7 @@ def test_line_sweep_scan_prepare_scan_updates_scan_info(v4_scan_assembler):
     assert scan.scan_info.frames_per_trigger == 3
     assert scan.max_update == 0.4
     assert scan.scan_info.scan_report_instructions == [
-        {"scan_progress": {"points": 0, "show_table": False}}
+        {"scan_progress": {"points": 0, "show_table": True}}
     ]
 
 

--- a/bec_server/tests/tests_scan_server/scans_v4/test_log_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_log_scan.py
@@ -36,7 +36,7 @@ def test_log_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler):
     assert scan.scan_info.num_points == 3
     assert np.allclose(scan.scan_info.positions, expected_positions)
     assert scan.scan_info.scan_report_instructions == [
-        {"scan_progress": {"points": 3, "show_table": False}}
+        {"scan_progress": {"points": 3, "show_table": True}}
     ]
 
 

--- a/bec_server/tests/tests_scan_server/scans_v4/test_multi_region_grid_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_multi_region_grid_scan.py
@@ -60,7 +60,7 @@ def test_multi_region_grid_scan_prepare_scan_updates_scan_info_and_queue(v4_scan
     assert scan.scan_info.num_points == len(expected_positions)
     assert np.allclose(scan.scan_info.positions, expected_positions)
     assert scan.scan_info.scan_report_instructions == [
-        {"scan_progress": {"points": len(expected_positions), "show_table": False}}
+        {"scan_progress": {"points": len(expected_positions), "show_table": True}}
     ]
 
 

--- a/bec_server/tests/tests_scan_server/scans_v4/test_multi_region_line_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_multi_region_line_scan.py
@@ -43,7 +43,7 @@ def test_multi_region_line_scan_prepare_scan_updates_scan_info_and_queue(v4_scan
     assert scan.scan_info.num_points == len(expected_positions)
     assert np.allclose(scan.scan_info.positions, expected_positions)
     assert scan.scan_info.scan_report_instructions == [
-        {"scan_progress": {"points": len(expected_positions), "show_table": False}}
+        {"scan_progress": {"points": len(expected_positions), "show_table": True}}
     ]
 
 

--- a/bec_server/tests/tests_scan_server/scans_v4/test_scan_actions.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_scan_actions.py
@@ -15,13 +15,13 @@ from bec_lib.tests.utils import ConnectorMock
 from bec_lib.utils.scan_utils import compose_cli_input_from_scan_info
 from bec_server.scan_server.instruction_handler import InstructionHandler
 from bec_server.scan_server.scan_stubs import ScanStubStatus
-from bec_server.scan_server.scans.scan_base import ScanBase, ScanInfo
+from bec_server.scan_server.scans.scan_base import ScanBase, ScanInfo, ScanType
 from bec_server.scan_server.tests.utils import NoopScan
 
 
 class _TestScan(NoopScan):
     scan_name = "_v4_test_scan"
-    scan_type = None
+    scan_type = ScanType.SOFTWARE_TRIGGERED
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -388,7 +388,7 @@ def test_build_scan_status_message(action_context):
     assert msg.dataset_number == 2
     assert msg.num_points == 3
     assert msg.num_monitored_readouts == 0
-    assert msg.scan_type is None
+    assert msg.scan_type == "software_triggered"
     assert msg.scan_parameters == {
         "exp_time": 0.1,
         "frames_per_trigger": 1,
@@ -971,6 +971,24 @@ def test_rpc_call_no_wait_uses_dotted_name_for_nested_devices(action_context):
     sent_msg = ctx.actions._send.call_args.args[0]
     assert sent_msg.device == "samx.setpoint"
     assert sent_msg.parameter["device"] == "samx.setpoint"
+
+
+def test_rpc_call_no_wait_can_request_response(action_context):
+    ctx = action_context()
+    status = ScanStubStatus(
+        ctx.scan._instruction_handler,
+        device_instr_id="device-instr-id",
+        shutdown_event=threading.Event(),
+        registry={},
+        name="rpc_samx_set",
+    )
+    ctx.actions._create_status = mock.MagicMock(return_value=status)
+    ctx.actions._send = mock.MagicMock()
+
+    ctx.actions.rpc_call_no_wait("samx", "set", "rpc-id-123", 1, response=True)
+
+    sent_msg = ctx.actions._send.call_args.args[0]
+    assert sent_msg.metadata["response"] is True
 
 
 def test_send_scan_status_publishes_message(action_context):

--- a/bec_server/tests/tests_scan_server/scans_v4/test_scan_actions.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_scan_actions.py
@@ -867,7 +867,7 @@ def test_report_instructions_update_scan_info_and_queue(action_context):
     assert ctx.actions._update_queue_info_callback.call_count == 3
 
 
-def test_report_instructions_use_dotted_name_for_nested_devices(action_context):
+def test_report_instructions_use_root_name_for_nested_device_progress(action_context):
     ctx = action_context()
     setpoint = ctx.device_manager.devices.samx.setpoint
     readback = ctx.device_manager.devices.samx.readback
@@ -877,7 +877,7 @@ def test_report_instructions_use_dotted_name_for_nested_devices(action_context):
 
     assert ctx.scan.scan_info.scan_report_instructions == [
         {"readback": {"RID": "rid", "devices": ["samx.setpoint"], "start": [0], "end": [1]}},
-        {"device_progress": ["samx.readback"]},
+        {"device_progress": ["samx"]},
     ]
     assert "samx.setpoint" in ctx.actions._devices_with_required_response
 

--- a/bec_server/tests/tests_scan_server/scans_v4/test_time_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_time_scan.py
@@ -37,7 +37,7 @@ def test_time_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler):
     assert scan.scan_info.num_points == 3
     assert scan.scan_info.positions.size == 0
     assert scan.scan_info.scan_report_instructions == [
-        {"scan_progress": {"points": 3, "show_table": False}}
+        {"scan_progress": {"points": 3, "show_table": True}}
     ]
 
 

--- a/bec_server/tests/tests_scan_server/test_scan_assembler.py
+++ b/bec_server/tests/tests_scan_server/test_scan_assembler.py
@@ -761,3 +761,28 @@ def test_scan_assembler_maps_mixed_direct_scan_args_and_kwargs_for_acquire(dm_wi
         "burst_at_each_point": 3,
         "system_config": {"file_directory": "/tmp/data"},
     }
+
+
+def test_scan_assembler_extracts_user_metadata_for_direct_scans(dm_with_devices):
+    parent = mock.MagicMock()
+    parent.device_manager = dm_with_devices
+    parent.connector = mock.MagicMock()
+    parent.queue_manager.instruction_handler = mock.MagicMock()
+    assembler = ScanAssembler(parent=parent)
+
+    class MockScanManager:
+        scan_dict = {"_v4_acquire": Acquire}
+
+    msg = messages.ScanQueueMessage(
+        scan_type="_v4_acquire",
+        parameter={"args": [], "kwargs": {"exp_time": 0.2, "system_config": {}}},
+        queue="primary",
+        metadata={"RID": "rid-123", "user_metadata": {"sample": "my_sample"}},
+    )
+
+    with mock.patch.object(assembler, "scan_manager", MockScanManager()):
+        request = assembler.assemble_direct_scan(msg, "scan_id")
+
+    assert request.scan_info.metadata == {"RID": "rid-123"}
+    assert request.scan_info.user_metadata == {"sample": "my_sample"}
+    assert msg.metadata == {"RID": "rid-123", "user_metadata": {"sample": "my_sample"}}

--- a/bec_server/tests/tests_scan_server/test_scan_guard.py
+++ b/bec_server/tests/tests_scan_server/test_scan_guard.py
@@ -42,6 +42,22 @@ def scan_guard_mock(scan_server_mock):
                 queue="primary",
             )
         ),
+        (
+            messages.ScanQueueMessage(
+                scan_type="_v4_device_rpc",
+                parameter={
+                    "args": [],
+                    "kwargs": {
+                        "device": "samy",
+                        "func": "set",
+                        "func_args": [1],
+                        "func_kwargs": {},
+                        "rpc_id": "rpc-id",
+                    },
+                },
+                queue="primary",
+            )
+        ),
     ],
 )
 def test_check_motors_movable_enabled(scan_server_mock, scan_queue_msg):
@@ -92,6 +108,24 @@ def test_device_rpc_is_valid(scan_guard_mock, device, func, is_valid):
             messages.ScanQueueMessage(
                 scan_type="device_rpc",
                 parameter={"device": ["samy"], "args": {}, "kwargs": {}},
+                queue="primary",
+                metadata={"client_info": {"acl_user": "default"}},
+            ),
+            True,
+        ),
+        (
+            messages.ScanQueueMessage(
+                scan_type="_v4_device_rpc",
+                parameter={
+                    "args": [],
+                    "kwargs": {
+                        "device": "samy",
+                        "func": "set",
+                        "func_args": [1],
+                        "func_kwargs": {},
+                        "rpc_id": "rpc-id",
+                    },
+                },
                 queue="primary",
                 metadata={"client_info": {"acl_user": "default"}},
             ),
@@ -316,6 +350,36 @@ def test_handle_scan_request(scan_guard_mock):
             },
             queue="primary",
         ),
+        messages.ScanQueueMessage(
+            metadata={"RID": "9db0c540-c1e0-4f44-872d-f41209512316", "response": True},
+            scan_type="_v4_device_rpc",
+            parameter={
+                "args": [],
+                "kwargs": {
+                    "device": "hexapod",
+                    "rpc_id": "rpc-id-v4",
+                    "func": "x.read",
+                    "func_args": [],
+                    "func_kwargs": {},
+                },
+            },
+            queue="primary",
+        ),
+        messages.ScanQueueMessage(
+            metadata={"RID": "7d28d801-8e33-484d-af34-9cc061eefe0e", "response": True},
+            scan_type="_v4_device_rpc",
+            parameter={
+                "args": [],
+                "kwargs": {
+                    "device": "samx",
+                    "rpc_id": "rpc-id-v4-2",
+                    "func": "get",
+                    "func_args": [],
+                    "func_kwargs": {},
+                },
+            },
+            queue="primary",
+        ),
     ],
 )
 def test_handle_scan_request_bypassed_for_read(scan_guard_mock, msg):
@@ -330,6 +394,23 @@ def test_handle_scan_request_bypassed_for_read(scan_guard_mock, msg):
                 sg._handle_scan_request(msg, username="default")
                 append.assert_not_called()
                 send.assert_called_once_with(MessageEndpoints.device_instructions(), mock.ANY)
+                sent_msg = send.call_args.args[1]
+                expected_device = (
+                    msg.parameter["kwargs"]["device"]
+                    if msg.scan_type == "_v4_device_rpc"
+                    else msg.parameter["device"]
+                )
+                assert sent_msg.device == expected_device
+                if msg.scan_type == "_v4_device_rpc":
+                    assert sent_msg.parameter == {
+                        "device": expected_device,
+                        "rpc_id": msg.parameter["kwargs"]["rpc_id"],
+                        "func": msg.parameter["kwargs"]["func"],
+                        "args": msg.parameter["kwargs"]["func_args"],
+                        "kwargs": msg.parameter["kwargs"]["func_kwargs"],
+                    }
+                else:
+                    assert sent_msg.parameter == msg.parameter
 
 
 def test_handle_scan_request_rejected(scan_guard_mock):


### PR DESCRIPTION
## Description

Step towards the v4 release. 

## Type of Change

- Fixes a bug in the metadata forwarding of v4-type scans
- Adds e2e parametrization for v3 and v4 scans such that most tests are now executed with both systems
- Adds the missing DeviceRPC scan class and makes it the new default for device rpcs

## How to test

- Run unit tests
- Run rpc calls

## Additional Comments

This could be the last step before the v4 release unless we notice some problems. 

Should be merged after #995
