### PR TITLE
Fix/v4 nested devices

### DIFF
--- a/bec_server/bec_server/scan_server/scan_assembler.py
+++ b/bec_server/bec_server/scan_server/scan_assembler.py
@@ -97,13 +97,15 @@ class ScanAssembler:
         )
         return scan_instance
 
-    def assemble_direct_scan(self, msg: messages.ScanQueueMessage, scan_id: str) -> ScanBaseV4:
+    def assemble_direct_scan(
+        self, msg: messages.ScanQueueMessage, scan_id: str | None
+    ) -> ScanBaseV4:
         """Assemble the device instructions for a given ScanQueueMessage.
         This will be achieved by calling the specified class (must be a derived class of ScanBaseV4)
 
         Args:
             msg (messages.ScanQueueMessage): scan queue message for which the instruction should be assembled
-            scan_id (str): scan id of the scan
+            scan_id (str | None): scan id of the scan
 
         Raises:
             ScanAbortion: Raised if the scan initialization fails.

--- a/bec_server/bec_server/scan_server/scan_queue.py
+++ b/bec_server/bec_server/scan_server/scan_queue.py
@@ -1594,7 +1594,9 @@ class DirectInstructionQueueItem:
         Args:
             msg (ScanQueueMessage): the scan queue message containing the scan information
         """
-        scan = self.assembler.assemble_direct_scan(msg, scan_id=self._scan_id)
+        scan_cls = self.assembler.scan_manager.scan_dict[msg.scan_type]
+        scan_id = self._scan_id if getattr(scan_cls, "is_scan", True) else None
+        scan = self.assembler.assemble_direct_scan(msg, scan_id=scan_id)
         self.scans.append(scan)
         self.scan_msgs.append(msg)
 
@@ -1718,7 +1720,7 @@ class DirectInstructionQueueItem:
     def _set_scan_as_active(self, scan: ScanBase_v4):
         """set a given scan as the active scan"""
         self.active_scan = scan
-        if scan.scan_info.scan_number is None:
+        if scan.scan_info.scan_number is None and scan.is_scan:
             with self.parent.queue_manager._lock:
                 self.parent.queue_manager.parent.scan_number += 1
                 if not self.scan_msgs[self.scans.index(scan)].metadata.get("dataset_id_on_hold"):

--- a/bec_server/bec_server/scan_server/scans/scan_actions.py
+++ b/bec_server/bec_server/scan_server/scans/scan_actions.py
@@ -153,15 +153,7 @@ class ScanActions:
 
         # We support str and DeviceBase inputs as well as lists of those.
         # We convert them to a list of device names for easier processing.
-        if isinstance(device, list):
-            device_names = []
-            for dev in device:
-                if isinstance(dev, DeviceBase):
-                    device_names.append(dev.name)
-                else:
-                    device_names.append(dev)
-        else:
-            device_names = [device.name if isinstance(device, DeviceBase) else device]
+        device_names = self._normalize_device_names(device)
         if len(device_names) == 1:
             device_names = device_names[0]
         status = self._create_status(name=status_name or f"stage_{device_names}")
@@ -290,7 +282,7 @@ class ScanActions:
 
         status = self._create_status(is_container=True, name="set")
         for dev, val in zip(devices, values, strict=False):
-            device_name = dev.name if isinstance(dev, DeviceBase) else dev
+            device_name = self._normalize_device_name(dev)
             sub_status = self._create_status(name=f"set_{device_name}")
             instr = messages.DeviceInstructionMessage(
                 device=device_name,
@@ -320,7 +312,7 @@ class ScanActions:
         Returns:
             ScanStubStatus: status object to track the kickoff process
         """
-        device_name = device.name if isinstance(device, DeviceBase) else device
+        device_name = self._normalize_device_name(device)
         status = self._create_status(name=f"kickoff_{device_name}")
 
         instr = messages.DeviceInstructionMessage(
@@ -347,7 +339,7 @@ class ScanActions:
         Returns:
             ScanStubStatus: status object to track the completion process
         """
-        device_name = device.name if isinstance(device, DeviceBase) else device
+        device_name = self._normalize_device_name(device)
         status = self._create_status(name=f"complete_{device_name}")
 
         instr = messages.DeviceInstructionMessage(
@@ -620,7 +612,7 @@ class ScanActions:
         Returns:
             ScanStubStatus: status object to track the unstaging process
         """
-        device_name = device.name if isinstance(device, DeviceBase) else device
+        device_name = self._normalize_device_name(device)
         status = self._create_status(name=f"unstage_{device_name}")
 
         instr = messages.DeviceInstructionMessage(
@@ -687,7 +679,7 @@ class ScanActions:
             request_id (str, optional): request ID to associate the readback instruction with. If None, the scan's RID will be used. Defaults to None.
         """
         request_id = request_id or self._scan.scan_info.metadata["RID"]
-        device_names = [dev.name if isinstance(dev, DeviceBase) else dev for dev in devices]
+        device_names = self._normalize_device_names(devices)
         scan_report_instruction = {
             "readback": {"RID": request_id, "devices": device_names, "start": start, "end": stop}
         }
@@ -705,10 +697,7 @@ class ScanActions:
         Args:
             device (str | DeviceBase): name of the device or DeviceBase instance to report
         """
-        if isinstance(device, DeviceBase):
-            device_name = device.name
-        else:
-            device_name = device
+        device_name = self._normalize_device_name(device)
         scan_report_instruction = {"device_progress": [device_name]}
         self._scan.scan_info.scan_report_instructions.append(scan_report_instruction)
         if self._update_queue_info_callback is not None:
@@ -762,10 +751,7 @@ class ScanActions:
             devices = [devices]
 
         for device in devices:
-            if isinstance(device, DeviceBase):
-                device_name = device.name
-            else:
-                device_name = device
+            device_name = self._normalize_device_name(device)
             self._scan.scan_info.readout_priority_modification[priority].append(device_name)
 
     def close_scan(self):
@@ -834,13 +820,15 @@ class ScanActions:
         """
         if isinstance(device, list):
             for dev in device:
-                device_name = dev.name if isinstance(dev, DeviceBase) else dev
+                device_name = self._normalize_device_name(dev)
                 self._devices_with_required_response.add(device_name)
         else:
-            device_name = device.name if isinstance(device, DeviceBase) else device
+            device_name = self._normalize_device_name(device)
             self._devices_with_required_response.add(device_name)
 
-    def rpc_call(self, device: str, func_name: str, *args, **kwargs) -> Any | ScanStubStatus:
+    def rpc_call(
+        self, device: str | DeviceBase, func_name: str, *args, **kwargs
+    ) -> Any | ScanStubStatus:
         """
         Make an RPC call to a device. This will call the given function on the device with the given arguments.
         The device server will execute the function and return the result in the instruction response.
@@ -864,26 +852,49 @@ class ScanActions:
             Any | ScanStubStatus: The result of the RPC call or a ScanStubStatus object if the result is a status object.
 
         """
-        status = self._create_status(name=f"rpc_{device}_{func_name}")
         rpc_id = str(uuid.uuid4())
+        status = self.rpc_call_no_wait(device, func_name, rpc_id, *args, **kwargs)
+        status.wait(resolve_on_known_type=True)
+        if status._result_is_status:
+            return status
+        return status.result
+
+    def rpc_call_no_wait(
+        self, device: str | DeviceBase, func_name: str, rpc_id: str, *args, **kwargs
+    ) -> ScanStubStatus:
+        """
+        Make an RPC call to a device without waiting for the result. This will call the given function on the device with the given arguments.
+        The device server will execute the function and return the result in the instruction response.
+        This method is a low-level interface to call arbitrary functions on the device server and should be used with caution.
+
+        Args:
+            device (str | DeviceBase): name of the device or device instance to call the function on
+            func_name (str): name of the function to call on the device
+            rpc_id (str): unique identifier for the RPC call, used to match the response with the request
+            *args: positional arguments to pass to the function
+            **kwargs: keyword arguments to pass to the function
+
+        Returns:
+            ScanStubStatus: A ScanStubStatus object that can be used to wait for the result of the RPC call.
+        """
+        device_name = self._normalize_device_name(device)
+        status = self._create_status(name=f"rpc_{device_name}_{func_name}")
+
         parameter = {
-            "device": device,
+            "device": device_name,
             "func": func_name,
             "rpc_id": rpc_id,
             "args": args,
             "kwargs": kwargs,
         }
         msg = messages.DeviceInstructionMessage(
-            device=device,
+            device=device_name,
             action="rpc",
             parameter=parameter,
             metadata={"device_instr_id": status._device_instr_id},
         )
         self._send(msg)
-        status.wait(resolve_on_known_type=True)
-        if status._result_is_status:
-            return status
-        return status.result
+        return status
 
     def send_client_info(self, message: str):
         """
@@ -959,12 +970,37 @@ class ScanActions:
                 metadata[key] = value + self._metadata_suffix
         return metadata
 
-    def _normalize_device_names(
-        self, devices: str | DeviceBase | list[str | DeviceBase]
-    ) -> list[str]:
+    @staticmethod
+    def _normalize_device_name(device: str | DeviceBase) -> str:
+        """
+        Normalize the device name to a string. If the device is a DeviceBase instance, return its dotted name.
+        We use the dotted name because it is uniquely identifying a device in the device tree, even for
+        sub-devices.
+
+        Args:
+            device (str | DeviceBase): device name or DeviceBase instance
+
+        Returns:
+            str: normalized device name
+        """
+        if isinstance(device, DeviceBase):
+            return getattr(device, "dotted_name", None) or device.name
+        return device
+
+    @staticmethod
+    def _normalize_device_names(devices: str | DeviceBase | list[str | DeviceBase]) -> list[str]:
+        """
+        Normalize a list of device names to a list of strings. If the devices are DeviceBase instances, return their dotted names.
+
+        Args:
+            devices (str | DeviceBase | list[str | DeviceBase]): device name(s) or DeviceBase instance(s)
+
+        Returns:
+            list[str]: list of normalized device names
+        """
         if not isinstance(devices, list):
             devices = [devices]
-        return [dev.name if isinstance(dev, DeviceBase) else dev for dev in devices]
+        return [ScanActions._normalize_device_name(dev) for dev in devices]
 
     def _get_monitored_device_names(self) -> list[str]:
         monitored_devices = [

--- a/bec_server/bec_server/scan_server/scans/scan_base.py
+++ b/bec_server/bec_server/scan_server/scans/scan_base.py
@@ -54,7 +54,7 @@ class ScanInfo(BaseModel):
 
     # General scan information
     scan_name: Annotated[str, Field(description="Name of the scan type, e.g. 'grid_scan'")]
-    scan_id: Annotated[str, Field(description="Unique identifier for the scan")]
+    scan_id: Annotated[str | None, Field(description="Unique identifier for the scan")] = None
     scan_type: Annotated[
         ScanType | None,
         Field(
@@ -167,7 +167,7 @@ class ScanBase(ABC):
 
     def __init__(
         self,
-        scan_id: str,
+        scan_id: str | None,
         redis_connector: RedisConnector,
         device_manager: DeviceManager,
         instruction_handler: InstructionHandler,

--- a/bec_server/bec_server/scan_server/tests/scan_fixtures.py
+++ b/bec_server/bec_server/scan_server/tests/scan_fixtures.py
@@ -120,6 +120,10 @@ class _MockDevice(DeviceBase):
         return self.name
 
     @property
+    def dotted_name(self):
+        return self.name
+
+    @property
     def limits(self):
         return self._limits
 
@@ -220,6 +224,10 @@ class MockCustomDevice(DeviceBase):
 
     @property
     def full_name(self):
+        return self.name
+
+    @property
+    def dotted_name(self):
         return self.name
 
     @property

--- a/bec_server/tests/tests_scan_server/scans_v4/test_scan_actions.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_scan_actions.py
@@ -251,6 +251,20 @@ def test_device_instruction_actions_emit_expected_messages(action_context):
     assert unstage_msg.metadata["device_instr_id"] == unstage_status._device_instr_id
 
 
+def test_device_instruction_actions_omit_scan_id_when_not_assigned(action_context):
+    ctx = action_context()
+    ctx.scan.scan_info.scan_id = None
+    ctx.scan.scan_info.metadata["RID"] = "rid-123"
+
+    stage_status = ctx.actions.stage("samx", wait=False)
+    stage_msg = _last_device_instruction(ctx, "stage")
+
+    assert stage_msg.device == "samx"
+    assert stage_msg.metadata["device_instr_id"] == stage_status._device_instr_id
+    assert "scan_id" not in stage_msg.metadata
+    assert stage_msg.metadata["RID"] == "rid-123"
+
+
 def test_set_emits_one_instruction_per_device(action_context):
     ctx = action_context()
 

--- a/bec_server/tests/tests_scan_server/scans_v4/test_scan_actions.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_scan_actions.py
@@ -251,6 +251,31 @@ def test_device_instruction_actions_emit_expected_messages(action_context):
     assert unstage_msg.metadata["device_instr_id"] == unstage_status._device_instr_id
 
 
+def test_device_instruction_actions_use_dotted_name_for_nested_devices(action_context):
+    ctx = action_context()
+    setpoint = ctx.device_manager.devices.samx.setpoint
+    readback = ctx.device_manager.devices.samx.readback
+
+    stage_status = ctx.actions.stage(setpoint, wait=False)
+    kickoff_status = ctx.actions.kickoff(setpoint, parameters={"frames": 3}, wait=False)
+    complete_status = ctx.actions.complete(readback, wait=False)
+    unstage_status = ctx.actions.unstage(readback, wait=False)
+
+    stage_msg = _last_device_instruction(ctx, "stage")
+    kickoff_msg = _last_device_instruction(ctx, "kickoff")
+    complete_msg = _last_device_instruction(ctx, "complete")
+    unstage_msg = _last_device_instruction(ctx, "unstage")
+
+    assert stage_msg.device == "samx.setpoint"
+    assert stage_msg.metadata["device_instr_id"] == stage_status._device_instr_id
+    assert kickoff_msg.device == "samx.setpoint"
+    assert kickoff_msg.metadata["device_instr_id"] == kickoff_status._device_instr_id
+    assert complete_msg.device == "samx.readback"
+    assert complete_msg.metadata["device_instr_id"] == complete_status._device_instr_id
+    assert unstage_msg.device == "samx.readback"
+    assert unstage_msg.metadata["device_instr_id"] == unstage_status._device_instr_id
+
+
 def test_device_instruction_actions_omit_scan_id_when_not_assigned(action_context):
     ctx = action_context()
     ctx.scan.scan_info.scan_id = None
@@ -282,6 +307,28 @@ def test_set_emits_one_instruction_per_device(action_context):
     assert [(msg.device, msg.parameter) for msg in set_messages] == [
         ("samx", {"value": 1.5}),
         ("samy", {"value": 2.5}),
+    ]
+
+
+def test_set_emits_dotted_name_for_nested_devices(action_context):
+    ctx = action_context()
+    setpoint = ctx.device_manager.devices.samx.setpoint
+    readback = ctx.device_manager.devices.samx.readback
+
+    status = ctx.actions.set([setpoint, readback], [1.5, 2.5], wait=False)
+
+    set_messages = _sent_device_instructions(ctx, "set")[-2:]
+    assert (
+        status._sub_status_objects[0]._device_instr_id
+        == set_messages[0].metadata["device_instr_id"]
+    )
+    assert (
+        status._sub_status_objects[1]._device_instr_id
+        == set_messages[1].metadata["device_instr_id"]
+    )
+    assert [(msg.device, msg.parameter) for msg in set_messages] == [
+        ("samx.setpoint", {"value": 1.5}),
+        ("samx.readback", {"value": 2.5}),
     ]
 
 
@@ -535,6 +582,21 @@ def test_report_instructions_update_scan_info_and_queue(action_context):
     assert ctx.actions._update_queue_info_callback.call_count == 3
 
 
+def test_report_instructions_use_dotted_name_for_nested_devices(action_context):
+    ctx = action_context()
+    setpoint = ctx.device_manager.devices.samx.setpoint
+    readback = ctx.device_manager.devices.samx.readback
+
+    ctx.actions.add_scan_report_instruction_readback([setpoint], [0], [1], "rid")
+    ctx.actions.add_scan_report_instruction_device_progress(readback)
+
+    assert ctx.scan.scan_info.scan_report_instructions == [
+        {"readback": {"RID": "rid", "devices": ["samx.setpoint"], "start": [0], "end": [1]}},
+        {"device_progress": ["samx.readback"]},
+    ]
+    assert "samx.setpoint" in ctx.actions._devices_with_required_response
+
+
 def test_rpc_call_returns_result_or_status(action_context):
     ctx = action_context()
     status = ScanStubStatus(
@@ -571,6 +633,56 @@ def test_rpc_call_returns_result_or_status(action_context):
 
     assert result is status
     status.wait.assert_called_once_with(resolve_on_known_type=True)
+
+
+def test_rpc_call_no_wait_returns_status_without_waiting(action_context):
+    ctx = action_context()
+    status = ScanStubStatus(
+        ctx.scan._instruction_handler,
+        device_instr_id="device-instr-id",
+        shutdown_event=threading.Event(),
+        registry={},
+        name="rpc_samx_kickoff",
+    )
+    status.wait = mock.MagicMock()
+    ctx.actions._create_status = mock.MagicMock(return_value=status)
+    ctx.actions._send = mock.MagicMock()
+
+    result = ctx.actions.rpc_call_no_wait("samx", "kickoff", "rpc-id-123", 1, test=True)
+
+    assert result is status
+    sent_msg = ctx.actions._send.call_args.args[0]
+    assert sent_msg.device == "samx"
+    assert sent_msg.action == "rpc"
+    assert sent_msg.parameter["device"] == "samx"
+    assert sent_msg.parameter["func"] == "kickoff"
+    assert sent_msg.parameter["rpc_id"] == "rpc-id-123"
+    assert sent_msg.parameter["args"] == (1,)
+    assert sent_msg.parameter["kwargs"] == {"test": True}
+    assert sent_msg.metadata["device_instr_id"] == "device-instr-id"
+    status.wait.assert_not_called()
+
+
+def test_rpc_call_no_wait_uses_dotted_name_for_nested_devices(action_context):
+    ctx = action_context()
+    status = ScanStubStatus(
+        ctx.scan._instruction_handler,
+        device_instr_id="device-instr-id",
+        shutdown_event=threading.Event(),
+        registry={},
+        name="rpc_hexapod.x_kickoff",
+    )
+    ctx.actions._create_status = mock.MagicMock(return_value=status)
+    ctx.actions._send = mock.MagicMock()
+
+    result = ctx.actions.rpc_call_no_wait(
+        ctx.device_manager.devices.samx.setpoint, "kickoff", "rpc-id-123", 1, test=True
+    )
+
+    assert result is status
+    sent_msg = ctx.actions._send.call_args.args[0]
+    assert sent_msg.device == "samx.setpoint"
+    assert sent_msg.parameter["device"] == "samx.setpoint"
 
 
 def test_send_scan_status_publishes_message(action_context):

--- a/bec_server/tests/tests_scan_server/test_scan_server_queue.py
+++ b/bec_server/tests/tests_scan_server/test_scan_server_queue.py
@@ -76,7 +76,9 @@ class _DummyV4Scan(NoopScan):
     scan_name = "_v4_dummy_scan"
 
 
-def _build_dummy_v4_scan(scan_id: str, scan_number: int | None = None) -> _DummyV4Scan:
+def _build_dummy_v4_scan(
+    scan_id: str, scan_number: int | None = None, is_scan: bool = True
+) -> _DummyV4Scan:
     scan = _DummyV4Scan(
         scan_id=scan_id,
         redis_connector=mock.MagicMock(),
@@ -85,7 +87,8 @@ def _build_dummy_v4_scan(scan_id: str, scan_number: int | None = None) -> _Dummy
         request_inputs={},
         system_config={},
     )
-    scan.scan_info.scan_type = ScanType.SOFTWARE_TRIGGERED
+    scan.is_scan = is_scan
+    scan.scan_info.scan_type = ScanType.SOFTWARE_TRIGGERED if is_scan else None
     scan.scan_info.scan_number = scan_number
     return scan
 
@@ -401,6 +404,60 @@ def test_direct_instruction_queue_move_to_next_scan_activates_and_assigns_number
     assert active_scan is second_scan
     assert second_scan.scan_info.scan_number is not None
     assert second_scan.scan_info.dataset_number == first_dataset_number
+
+
+def test_direct_instruction_queue_non_scan_does_not_allocate_scan_number(queuemanager_mock):
+    queue_manager = queuemanager_mock()
+    scan_queue = queue_manager.queues["primary"]
+    queue = DirectInstructionQueueItem(scan_queue, mock.MagicMock(), scan_queue.scan_worker)
+    scan_queue.queue.append(queue)
+    scan = _build_dummy_v4_scan("scan-1", is_scan=False)
+    msg = messages.ScanQueueMessage(
+        scan_type="_v4_umv",
+        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        queue="primary",
+        metadata={"RID": "rid-1"},
+    )
+    start_scan_number = queue_manager.parent.scan_number
+    start_dataset_number = queue_manager.parent.dataset_number
+    queue.scans = [scan]
+    queue.scan_msgs = [msg]
+
+    active_scan = queue.move_to_next_scan()
+
+    assert active_scan is scan
+    assert scan.scan_info.scan_number is None
+    assert scan.scan_info.dataset_number is None
+    assert queue_manager.parent.scan_number == start_scan_number
+    assert queue_manager.parent.dataset_number == start_dataset_number
+    assert queue.is_scan == [False]
+    assert queue.scan_number == [None]
+
+
+def test_direct_instruction_queue_non_scan_does_not_allocate_scan_id(queuemanager_mock):
+    queue_manager = queuemanager_mock()
+    scan_queue = queue_manager.queues["primary"]
+    assembler = mock.MagicMock()
+    assembler.scan_manager.scan_dict = {"_v4_umv": mock.MagicMock(is_scan=False)}
+    scan = _build_dummy_v4_scan("placeholder-scan-id", is_scan=False)
+    scan.scan_info.scan_id = None
+    assembler.assemble_direct_scan.return_value = scan
+    queue = DirectInstructionQueueItem(scan_queue, assembler, scan_queue.scan_worker)
+
+    msg = messages.ScanQueueMessage(
+        scan_type="_v4_umv",
+        parameter={"args": {"samx": (1,)}, "kwargs": {"relative": False}},
+        queue="primary",
+        metadata={"RID": "rid-1"},
+    )
+
+    queue.append_scan_request(msg)
+
+    assert len(queue.scans) == 1
+    assembler.assemble_direct_scan.assert_called_once_with(msg, scan_id=None)
+    assert queue.scans[0] is scan
+    assert queue.scans[0].scan_info.scan_id is None
+    assert queue.scan_id == [None]
 
 
 def test_direct_instruction_queue_move_to_next_scan_raises_when_empty_or_exhausted(


### PR DESCRIPTION
## Description

Some fixes for v4-type scans.

## Type of Change

- Allow scan id to be None for plain requests (e.g. umv, mv, device_rpc)
- Resolve nested devices using their dotted name

