### PR TITLE
fix(bec_lib): log alarms in raise_alarm and drop redundant caller logs

### DIFF
--- a/bec_lib/bec_lib/redis_connector/hli.py
+++ b/bec_lib/bec_lib/redis_connector/hli.py
@@ -168,8 +168,9 @@ class RedisConnector:
         self._managed_connection.set_and_publish(MessageEndpoints.alarm().endpoint, alarm_msg)
         compact_message = info.compact_error_message or info.error_message or info.exception_type
         # Log the alarm so it also surfaces in the log of the service that raised it.
+        device_part = f" for device '{info.device}'" if getattr(info, "device", None) else ""
         log_message = (
-            f"Alarm ({Alarms(severity).name}) raised for device '{info.device}': "
+            f"Alarm ({Alarms(severity).name}) raised{device_part}: "
             f"{info.error_message or compact_message}"
         )
         if int(severity) >= Alarms.MINOR:

--- a/bec_lib/bec_lib/redis_connector/hli.py
+++ b/bec_lib/bec_lib/redis_connector/hli.py
@@ -167,6 +167,15 @@ class RedisConnector:
         alarm_msg = AlarmMessage(severity=severity, info=info, metadata=metadata or {})
         self._managed_connection.set_and_publish(MessageEndpoints.alarm().endpoint, alarm_msg)
         compact_message = info.compact_error_message or info.error_message or info.exception_type
+        # Log the alarm so it also surfaces in the log of the service that raised it.
+        log_message = (
+            f"Alarm ({Alarms(severity).name}) raised for device '{info.device}': "
+            f"{info.error_message or compact_message}"
+        )
+        if int(severity) >= Alarms.MINOR:
+            logger.error(log_message)
+        else:
+            logger.warning(log_message)
         event_by_severity = {
             0: MessagingEvent.ALARM_WARNING,
             1: MessagingEvent.ALARM_MINOR,

--- a/bec_lib/tests/test_hli_redis_connector.py
+++ b/bec_lib/tests/test_hli_redis_connector.py
@@ -41,11 +41,12 @@ def hli_connector():
 
 
 @pytest.mark.parametrize(
-    "severity, expected_event, alarm_type, msg, compact_msg, metadata",
+    "severity, expected_event, expected_log_level, alarm_type, msg, compact_msg, metadata",
     [
         [
             Alarms.MAJOR,
             MessagingEvent.ALARM_MAJOR,
+            "error",
             "alarm",
             "content1",
             "compact_msg",
@@ -54,6 +55,7 @@ def hli_connector():
         [
             Alarms.MINOR,
             MessagingEvent.ALARM_MINOR,
+            "error",
             "alarm",
             "content1",
             "compact_msg",
@@ -62,6 +64,7 @@ def hli_connector():
         [
             Alarms.WARNING,
             MessagingEvent.ALARM_WARNING,
+            "warning",
             "alarm",
             "content1",
             "compact_msg",
@@ -70,11 +73,19 @@ def hli_connector():
     ],
 )
 def test_redis_connector_raise_alarm(
-    hli_connector, severity, expected_event, alarm_type, msg, compact_msg, metadata
+    hli_connector,
+    severity,
+    expected_event,
+    expected_log_level,
+    alarm_type,
+    msg,
+    compact_msg,
+    metadata,
 ):
     with (
         mock.patch.object(hli_connector._managed_connection, "set_and_publish", return_value=None),
         mock.patch.object(hli_connector, "notify", return_value=None),
+        mock.patch("bec_lib.redis_connector.hli.logger") as mock_logger,
     ):
         info = messages.ErrorInfo(
             error_message=msg, compact_error_message=compact_msg, exception_type=alarm_type
@@ -86,6 +97,15 @@ def test_redis_connector_raise_alarm(
             AlarmMessage(severity=severity, info=info, metadata=metadata),
         )
         hli_connector.notify.assert_called_once_with(expected_event, compact_msg)
+
+        # the alarm is also written to the log of the service that raised it, at a level
+        # matching the alarm severity (warnings -> warning, minor/major -> error)
+        log_call = getattr(mock_logger, expected_log_level)
+        log_call.assert_called_once()
+        logged_message = log_call.call_args.args[0]
+        assert msg in logged_message
+        other_level = "warning" if expected_log_level == "error" else "error"
+        getattr(mock_logger, other_level).assert_not_called()
 
 
 def test_redis_connector_send_converts_ep(hli_connector: RedisConnector):

--- a/bec_server/bec_server/device_server/device_server.py
+++ b/bec_server/bec_server/device_server/device_server.py
@@ -429,7 +429,6 @@ class DeviceServer(BECService):
                     dev.obj.stop()
                 except Exception as exc:  # pylint: disable=broad-except
                     content = traceback.format_exc()
-                    logger.error(content)
                     error_info = messages.ErrorInfo(
                         error_message=content,
                         compact_error_message=traceback.format_exc(limit=0),

--- a/bec_server/bec_server/file_writer/file_writer_manager.py
+++ b/bec_server/bec_server/file_writer/file_writer_manager.py
@@ -424,7 +424,7 @@ class FileWriterManager(BECService):
         # pylint: disable=unused-variable
         except Exception as exc:
             content = traceback.format_exc()
-            logger.error(f"Failed to write to file {file_path}. Error: {content}")
+            logger.error(f"Failed to write to file {file_path}.")
             error_info = messages.ErrorInfo(
                 error_message=content,
                 compact_error_message=traceback.format_exc(limit=0),

--- a/bec_server/bec_server/scan_server/beamline_state_manager.py
+++ b/bec_server/bec_server/scan_server/beamline_state_manager.py
@@ -6,7 +6,6 @@ from bec_lib import bl_states, messages
 from bec_lib.alarm_handler import Alarms
 from bec_lib.devicemanager import DeviceManagerBase
 from bec_lib.endpoints import MessageEndpoints
-from bec_lib.logger import bec_logger
 from bec_lib.messages import ErrorInfo
 from bec_lib.redis_connector import RedisConnector
 
@@ -32,7 +31,6 @@ class BeamlineStateManager:
             self.update_states(msg)
         except Exception as exc:
             content = traceback.format_exc()
-            bec_logger.logger.error(content)
             info = ErrorInfo(
                 exception_type=type(exc).__name__,
                 error_message=content,

--- a/bec_server/bec_server/scan_server/direct_scan_worker.py
+++ b/bec_server/bec_server/scan_server/direct_scan_worker.py
@@ -187,7 +187,6 @@ class DirectScanWorker:
             exc (Exception): The exception that was raised, which will be included in the alarm information.
         """
 
-        logger.error(content)
         error_info = messages.ErrorInfo(
             error_message=content,
             compact_error_message=traceback.format_exc(limit=0),

--- a/bec_server/bec_server/scan_server/scan_manager.py
+++ b/bec_server/bec_server/scan_server/scan_manager.py
@@ -115,9 +115,6 @@ class ScanManager:
         for name, scan_cls in members:
 
             if not scan_cls.scan_name.isidentifier():
-                logger.error(
-                    f"Invalid scan_name '{scan_cls.scan_name}' for scan class {name}. scan_name must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number. Skipping."
-                )
                 self.parent.connector.raise_alarm(
                     severity=Alarms.WARNING,
                     info=ErrorInfo(
@@ -130,7 +127,6 @@ class ScanManager:
                 continue
 
             if scan_cls.scan_name in self.available_scans:
-                logger.error(f"{scan_cls.scan_name} already exists. Skipping.")
                 self.parent.connector.raise_alarm(
                     severity=Alarms.WARNING,
                     info=ErrorInfo(

--- a/bec_server/bec_server/scan_server/scan_queue.py
+++ b/bec_server/bec_server/scan_server/scan_queue.py
@@ -90,7 +90,6 @@ class QueueManager:
         # pylint: disable=broad-except
         except Exception as exc:
             content = traceback.format_exc()
-            logger.error(content)
             error_info = messages.ErrorInfo(
                 error_message=content,
                 compact_error_message=traceback.format_exc(limit=0),

--- a/bec_server/bec_server/scan_server/scan_worker.py
+++ b/bec_server/bec_server/scan_server/scan_worker.py
@@ -80,7 +80,6 @@ class ScanWorker(threading.Thread):
         # pylint: disable=broad-except
         except Exception as exc:
             content = traceback.format_exc()
-            logger.error(content)
             error_info = messages.ErrorInfo(
                 error_message=content,
                 compact_error_message=traceback.format_exc(limit=0),


### PR DESCRIPTION
## Description

`raise_alarm` puts logs on the BECIPythonClient level, however it would be more efficient when browsing through logs that they would be logged on the source service. Removes also redundant logs which were manually logged along alarms.