### PR TITLE
fix: remove unused parent from macro update

### DIFF
--- a/bec_lib/bec_lib/macro_update_handler.py
+++ b/bec_lib/bec_lib/macro_update_handler.py
@@ -271,12 +271,11 @@ class MacroUpdateHandler:
         self.forget_user_macro(name)
         self.load_user_macro(file, ignore_existing=True)
 
-    def _macro_update_callback(self, msg, parent):
+    def _macro_update_callback(self, msg):
         """Callback to handle macro update messages.
 
         Args:
             msg: The message containing the macro update information.
-            parent: The UserMacros instance.
         """
         msg = msg.value
         if not isinstance(msg, messages.MacroUpdateMessage):

--- a/bec_lib/tests/test_user_macros.py
+++ b/bec_lib/tests/test_user_macros.py
@@ -457,7 +457,7 @@ def test_macro_update_callback_valid_message(user_macros):
     # Mock the on_macro_update method
     with mock.patch.object(macros._update_handler, "on_macro_update") as mock_on_update:
         # Call the callback
-        macros._update_handler._macro_update_callback(mock_msg, macros._update_handler)
+        macros._update_handler._macro_update_callback(mock_msg)
 
         # Verify on_macro_update was called with the correct message
         mock_on_update.assert_called_once_with(mock_msg.value)
@@ -475,7 +475,7 @@ def test_macro_update_callback_invalid_message_type(user_macros):
         # Mock on_macro_update to ensure it's not called
         with mock.patch.object(macros._update_handler, "on_macro_update") as mock_on_update:
             # Call the callback
-            macros._update_handler._macro_update_callback(mock_msg, macros._update_handler)
+            macros._update_handler._macro_update_callback(mock_msg)
 
             # Verify error was logged and on_macro_update was not called
             mock_logger.assert_called_once_with("Received invalid message type: <class 'str'>")
@@ -489,21 +489,21 @@ def test_macro_update_callback_with_different_message_types(user_macros):
         # Test with None
         mock_msg = mock.MagicMock()
         mock_msg.value = None
-        macros._update_handler._macro_update_callback(mock_msg, macros._update_handler)
+        macros._update_handler._macro_update_callback(mock_msg)
         mock_logger.assert_called_with("Received invalid message type: <class 'NoneType'>")
 
         mock_logger.reset_mock()
 
         # Test with integer
         mock_msg.value = 123
-        macros._update_handler._macro_update_callback(mock_msg, macros._update_handler)
+        macros._update_handler._macro_update_callback(mock_msg)
         mock_logger.assert_called_with("Received invalid message type: <class 'int'>")
 
         mock_logger.reset_mock()
 
         # Test with dict
         mock_msg.value = {"not": "a_message"}
-        macros._update_handler._macro_update_callback(mock_msg, macros._update_handler)
+        macros._update_handler._macro_update_callback(mock_msg)
         mock_logger.assert_called_with("Received invalid message type: <class 'dict'>")
 
 


### PR DESCRIPTION
## Description

fixing a bug in the macro update handler introduced by the transition away from static methods

