### PR TITLE
fix(redis_connector): fix unregister for just cb as input

### DIFF
--- a/bec_lib/bec_lib/redis_connector/managed_redis_connection.py
+++ b/bec_lib/bec_lib/redis_connector/managed_redis_connection.py
@@ -595,7 +595,9 @@ class ManagedRedisConnection:
         unsubscribe_list = []
         with self._topics_cb_lock:
             for topic in topics:
-                topics_cb = self._topics_cb[topic]
+                topics_cb = self._topics_cb.get(topic)
+                if topics_cb is None:
+                    continue
                 # remove callback from list
                 self._topics_cb[topic] = list(
                     filter(lambda item: cb and item[0]() != cb, topics_cb)
@@ -631,9 +633,16 @@ class ManagedRedisConnection:
                     self._pubsub_conn.unsubscribe(unsubscribe_list)
         else:
             with self._topics_cb_lock:
-                topics = list(self._topics_cb.keys())
-            self.unregister(topics, cb)
-            self.unregister(self._stream_subs.all_topics, cb)
+                registered_topics = list(self._topics_cb.keys())
+            direct_topics = [
+                topic for topic in registered_topics if not set("*?[]").intersection(topic)
+            ]
+            pattern_topics = [topic for topic in registered_topics if topic not in direct_topics]
+            if direct_topics:
+                self.unregister(topics=direct_topics, cb=cb)
+            if pattern_topics:
+                self.unregister(patterns=pattern_topics, cb=cb)
+            self.unregister(topics=self._stream_subs.all_topics, cb=cb)
 
     def _unregister_stream(self, topics: list[str], cb: Callable | None = None) -> bool:
         """Unregister callbacks from a list of topics. Returns true if any were removed"""

--- a/bec_lib/tests/test_redis_connector_fakeredis.py
+++ b/bec_lib/tests/test_redis_connector_fakeredis.py
@@ -148,6 +148,35 @@ def test_redis_connector_unregister(connected_connector):
     assert len(connector._topics_cb) == 0
 
 
+def test_redis_connector_unregister_all_for_callback(connected_connector):
+    connector = connected_connector
+    cb_mock = mock.Mock(spec=[])
+
+    connector.register(topics=["topic1"], cb=cb_mock, start_thread=False)
+    connector.register(patterns=["topic2:*"], cb=cb_mock, start_thread=False)
+    connector.register(TestStreamEndpoint, cb=cb_mock, start_thread=False)
+
+    connector.send("topic1", TestMessage(msg="topic1"))
+    connector.poll_messages(timeout=1)
+    connector.send("topic2:a", TestMessage(msg="topic2"))
+    connector.poll_messages(timeout=1)
+    connector.xadd("test", {"data": 1})
+    connector.poll_messages(timeout=1)
+    assert cb_mock.call_count == 3
+
+    cb_mock.reset_mock()
+    connector.unregister(cb=cb_mock)
+
+    connector.send("topic1", TestMessage(msg="topic1"))
+    connector.send("topic2:a", TestMessage(msg="topic2"))
+    connector.xadd("test", {"data": 2})
+    with pytest.raises(TimeoutError):
+        connector.poll_messages(timeout=1)
+    assert cb_mock.call_count == 0
+    assert len(connector._topics_cb) == 0
+    assert connector._stream_subs.all_topics == []
+
+
 def test_redis_connector_register_identical(connected_connector):
     connector = connected_connector
 


### PR DESCRIPTION
## Description

Add support for unregistering a callback without endpoint. Everything for this callback will be removed. 

