### PR TITLE
feat(acl): enhance ACL support

### DIFF
--- a/.github/actions/bec_e2e_install/action.yml
+++ b/.github/actions/bec_e2e_install/action.yml
@@ -77,5 +77,6 @@ runs:
         pip install -e ../bec_testing_plugin
         podman pod create --network=host local_bec
         python ./bec_ipython_client/tests/end-2-end/_ensure_requirements_container.py
-        coverage run --branch --source=./bec_server/bec_server,./bec_lib/bec_lib,./bec_ipython_client/bec_ipython_client, --omit=*/bec_server/scan_server/scan_plugins/*,*/bec_ipython_client/bec_ipython_client/plugins/*,*/bec_ipython_client/scripts/*,*/bec_lib/bec_lib/tests/* -m pytest -v --files-path ./ --start-servers --random-order  ./bec_ipython_client/tests/end-2-end/
+        coverage run --branch --source=./bec_server/bec_server,./bec_lib/bec_lib,./bec_ipython_client/bec_ipython_client, --omit=*/bec_server/scan_server/scan_plugins/*,*/bec_ipython_client/bec_ipython_client/plugins/*,*/bec_lib/bec_lib/tests/* -m pytest -v --files-path ./ --start-servers --flush-redis --random-order ./bec_ipython_client/tests/end-2-end/test_acl_e2e.py
+        coverage run --append --branch --source=./bec_server/bec_server,./bec_lib/bec_lib,./bec_ipython_client/bec_ipython_client, --omit=*/bec_server/scan_server/scan_plugins/*,*/bec_ipython_client/bec_ipython_client/plugins/*,*/bec_lib/bec_lib/tests/* -m pytest -v --files-path ./ --start-servers --random-order --ignore=./bec_ipython_client/tests/end-2-end/test_acl_e2e.py ./bec_ipython_client/tests/end-2-end/
         coverage xml -o coverage-e2e.xml

--- a/bec_ipython_client/tests/end-2-end/test_acl_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_acl_e2e.py
@@ -1,0 +1,140 @@
+import shutil
+
+import pytest
+import redis.exceptions
+
+from bec_lib import messages
+from bec_lib.client import BECClient
+from bec_lib.endpoints import MessageEndpoints
+from bec_lib.redis_connector import RedisConnector
+from bec_lib.service_config import ServiceConfig, ServiceConfigModel
+from bec_lib.tests.utils import wait_for_empty_queue
+from bec_lib.utils.user_acls_test import BECAccessDemo
+from bec_server.bec_server_utils.service_handler import ServiceHandler
+
+
+@pytest.fixture
+def acl_enabled_bec_services(
+    request,
+    bec_files_path,
+    bec_services_config_file_path,
+    bec_test_config_file_path,
+    bec_redis_host_port,
+    test_config_yaml_file_path,
+):
+    if not request.config.getoption("--start-servers") or not request.config.getoption(
+        "--flush-redis"
+    ):
+        pytest.skip("ACL e2e test mutates Redis ACLs and requires isolated pytest BEC services.")
+
+    redis_host, redis_port = bec_redis_host_port
+    redis_url = f"{redis_host}:{redis_port}"
+    acl_env_file = bec_services_config_file_path.parent / ".bec_acl.env"
+    acl_env_file.write_text("REDIS_USER=admin\nREDIS_PASSWORD=admin\n", encoding="utf-8")
+    shutil.copyfile(test_config_yaml_file_path, bec_test_config_file_path)
+
+    service_config = ServiceConfigModel(
+        redis={"host": redis_host, "port": redis_port},
+        file_writer={"base_path": str(bec_services_config_file_path.parent)},
+        acl={"env_file": str(acl_env_file)},
+    )
+    bec_services_config_file_path.write_text(
+        service_config.model_dump_json(indent=4), encoding="utf-8"
+    )
+
+    service_handler = ServiceHandler(
+        bec_path=bec_files_path, config_path=bec_services_config_file_path, interface="subprocess"
+    )
+    processes = None
+    try:
+        acl_connector = RedisConnector(redis_url)
+        try:
+            access_control = BECAccessDemo(acl_connector)
+            access_control.reset()
+            access_control.add_user()
+            access_control.add_admin()
+            access_control.set_default_non_admin()
+        finally:
+            acl_connector.shutdown()
+
+        processes = service_handler.start()
+        yield bec_services_config_file_path
+    finally:
+        if processes is not None:
+            service_handler.stop(processes)
+        restore_connector = RedisConnector(redis_url)
+        try:
+            BECAccessDemo(restore_connector).reset()
+        finally:
+            restore_connector.shutdown()
+
+
+@pytest.mark.timeout(120)
+def test_acl_admin_server_allows_default_user_scan(acl_enabled_bec_services):
+    admin_config = ServiceConfig(acl_enabled_bec_services)
+    admin_client = BECClient(admin_config, RedisConnector, forced=True, wait_for_server=True)
+    admin_client.start()
+    try:
+        admin_client.config.load_demo_config(force=True)
+    finally:
+        admin_client.shutdown()
+        admin_client._client._reset_singleton()
+
+    user_config = ServiceConfig(acl_enabled_bec_services, acl={"env_file": "", "user": "user"})
+    user_client = BECClient(user_config, RedisConnector, forced=True, wait_for_server=True)
+    user_client.start()
+    try:
+        user_client.queue.request_queue_reset()
+        user_client.queue.request_scan_continuation()
+        wait_for_empty_queue(user_client)
+        assert user_client.username == "user"
+
+        dev = user_client.device_manager.devices
+        status = user_client.scans.line_scan(
+            dev.samx, -0.1, 0.1, steps=3, exp_time=0.01, relative=False
+        )
+        status.wait(num_points=True, file_written=True)
+
+        assert status.scan.num_points == 3
+    finally:
+        user_client.shutdown()
+        user_client._client._reset_singleton()
+
+
+@pytest.mark.timeout(120)
+def test_acl_account_endpoint_allows_user_read_but_admin_only_write(acl_enabled_bec_services):
+    account_endpoint = MessageEndpoints.account()
+    initial_account_msg = messages.VariableMessage(value="initial-admin-account")
+    updated_account_msg = messages.VariableMessage(value="updated-admin-account")
+
+    user_config = ServiceConfig(acl_enabled_bec_services, acl={"env_file": "", "user": "user"})
+    user_client = BECClient(user_config, RedisConnector, forced=True, wait_for_server=True)
+    user_client.start()
+    try:
+        assert user_client.username == "user"
+        with user_client.acl.temporary_user(username="admin", token="admin"):
+            user_client._update_username()
+            assert user_client.username == "admin"
+            user_client.connector.xadd(account_endpoint, {"data": initial_account_msg})
+            assert user_client.connector.get_last(account_endpoint, "data") == initial_account_msg
+
+        user_client._update_username()
+        assert user_client.username == "user"
+        assert user_client.connector.get_last(account_endpoint, "data") == initial_account_msg
+        with pytest.raises(redis.exceptions.NoPermissionError):
+            user_client.connector.xadd(
+                account_endpoint, {"data": messages.VariableMessage(value="user-account")}
+            )
+
+        with user_client.acl.temporary_user(username="admin", token="admin"):
+            user_client._update_username()
+            assert user_client.username == "admin"
+            user_client.connector.xadd(account_endpoint, {"data": updated_account_msg})
+            assert user_client.connector.get_last(account_endpoint, "data") == updated_account_msg
+
+        user_client._update_username()
+        assert user_client.username == "user"
+        assert user_client.connector.get_last(account_endpoint, "data") == updated_account_msg
+    finally:
+        user_client.shutdown()
+        user_client._client._reset_singleton()

--- a/bec_lib/bec_lib/acl_login.py
+++ b/bec_lib/bec_lib/acl_login.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Iterator
+from contextlib import contextmanager
 from functools import wraps
 from getpass import getpass
 from typing import TYPE_CHECKING, cast
@@ -13,6 +15,7 @@ from rich.table import Table
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.logger import bec_logger
 from bec_lib.redis_connector import RedisConnector
+from bec_lib.service_config import ACLConfig
 from bec_lib.utils.import_utils import lazy_import_from
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -87,8 +90,35 @@ class BECAccess:
         """
         self.connector.authenticate(username=username, password=token)
 
+    @contextmanager
+    def temporary_user(self, *, username: str, token: str | None) -> Iterator[None]:
+        """
+        Temporarily authenticate as another ACL user and restore the current user on exit.
+        """
+        credentials = self.current_credentials()
+        self.login_with_token(username=username, token=token)
+        try:
+            yield
+        finally:
+            self.login_with_token(
+                username=credentials["username"] or "default", token=credentials.get("token")
+            )
+
+    def current_credentials(self) -> dict[str, str | None]:
+        """
+        Return the current Redis ACL credentials for forwarding to linked clients.
+        """
+        # pylint: disable=protected-access
+        conn_kwargs = (
+            self.connector._managed_connection._redis_conn.connection_pool.connection_kwargs
+        )
+        token = conn_kwargs.get("password")
+        if token == "null":
+            token = None
+        return {"username": self.connector.username, "token": token}
+
     def _bec_service_login(
-        self, prompt_for_acl: bool = False, acl_config: dict | str | None = None
+        self, prompt_for_acl: bool = False, acl_config: ACLConfig | dict | str | None = None
     ) -> None:
         """
         Login to Redis using the ACL system. This is the main entry point for the login process, started
@@ -97,9 +127,8 @@ class BECAccess:
         Args:
             prompt_for_acl (bool): If True, prompt the user to login using ACL. This is typically only used
                 for user-facing services. Default is False.
-            acl_config (dict or str): The ACL configuration. If a string is provided, it will be treated as a
-                path to the configuration file. If a dictionary is provided, it should contain the username and
-                password for the account.
+            acl_config (ACLConfig, dict, str, optional): The ACL configuration. If a string is provided,
+                it will be treated as a path to the configuration file.
         """
 
         if not self.connector.redis_server_is_running():
@@ -241,40 +270,58 @@ class BECAccess:
         password = getpass(f"Enter the token for {selected_account} (hidden): ")
         return password
 
-    def _config_login_successful(self, prompt_for_acl: bool, acl_config: dict | str) -> bool:
+    def _config_login_successful(
+        self, prompt_for_acl: bool, acl_config: ACLConfig | dict | str | None
+    ) -> bool:
         """
         Login to Redis using the configuration file.
 
         Args:
             prompt_for_acl (bool): If True, prompt the user to login using ACL. Default is False.
-            acl_config (dict or str): The ACL configuration. If a string is provided, it will be treated as a path to the configuration file.
+            acl_config (ACLConfig, dict, str, optional): The ACL configuration. If a string is provided,
+                it will be treated as a path to the configuration file.
 
         Returns:
             bool: True if the login was successful, False otherwise.
         """
 
+        if acl_config is None:
+            return False
+
         if isinstance(acl_config, str):
-            if os.path.exists(acl_config) and not prompt_for_acl:
-                # Load the account information from the .env file
-                # This is relevant for the BEC services that are not launched by the user
-                # but are auto-deployed.
-                account = dotenv_values(acl_config)
-                user = account.get("REDIS_USER")
-                password = account.get("REDIS_PASSWORD")
-                if self._check_redis_auth(user, password):
-                    return True
+            env_file = acl_config
+            username = None
+            password = None
         elif isinstance(acl_config, dict):
-            username = acl_config.get("username")
+            env_file = acl_config.get("env_file")
+            username = acl_config.get("username") or acl_config.get("user")
             password = acl_config.get("password")
-            if self._check_redis_auth(username, password):
-                return True
-            if not password and prompt_for_acl:
-                self._user_service_login(username=username)
-                return True
+        elif isinstance(acl_config, ACLConfig):
+            env_file = acl_config.env_file
+            username = acl_config.user
+            password = acl_config.password
         else:
             raise ValueError(
-                "Invalid value for 'acl' in the service config. Must be a dict or a path to a .env file."
+                "Invalid value for 'acl' in the service config. Must be an ACLConfig, dict, "
+                "or a path to a .env file."
             )
+
+        if env_file and not prompt_for_acl and os.path.exists(env_file):
+            # Load the account information from the .env file. This is relevant for BEC services
+            # that are not launched by the user but are auto-deployed.
+            account = dotenv_values(env_file)
+            user = account.get("REDIS_USER")
+            env_password = account.get("REDIS_PASSWORD")
+            if self._check_redis_auth(user, env_password):
+                return True
+
+        if (username or password) and self._check_redis_auth(username, password):
+            return True
+
+        if prompt_for_acl and username:
+            self._user_service_login(username=username)
+            return True
+
         return False
 
     def _default_user_login_successful(self, full_access: bool) -> bool:

--- a/bec_lib/bec_lib/acl_login.py
+++ b/bec_lib/bec_lib/acl_login.py
@@ -329,7 +329,8 @@ class BECAccess:
         Login using the default user account.
 
         Args:
-            full_access (bool): If True, the user has to have full access to the Redis
+            full_access (bool): If True, the user has sufficient access to perform all user
+                operations. If False, the user has limited access or no access to perform user operations.
 
         Returns:
             bool: True if the login was successful, False otherwise.
@@ -339,8 +340,8 @@ class BECAccess:
                 return True
 
             try:
-                self.connector.get(MessageEndpoints.acl_accounts())
-                # ACLs are enabled but we have full access. No need to login.
+                # We check an endpoint on level INFO to verify that the user has sufficient access to perform all user operations.
+                self.connector.get(MessageEndpoints.device_config())
                 return True
             # pylint: disable=broad-except
             except Exception:
@@ -366,7 +367,7 @@ class BECAccess:
             raise BECAuthenticationError("Login information not available. Unable to login.")
         self._atlas_login = self._info.atlas_login
         if not username and not self._info.atlas_login:
-            return self.login_with_token(username="user", token=None)
+            return self.login_with_token(username="default", token=None)
         return self.login(username)
 
     def _check_redis_auth(self, user: str | None, password: str | None) -> bool:

--- a/bec_lib/bec_lib/bec_service.py
+++ b/bec_lib/bec_lib/bec_service.py
@@ -6,19 +6,15 @@ from __future__ import annotations
 
 import argparse
 import getpass
-import os
 import socket
 import sys
 import threading
 import time
 import uuid
 from dataclasses import asdict, dataclass
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as importlib_version
 from typing import TYPE_CHECKING, Any, Literal
 
 import psutil
-import tomli
 from rich.console import Console
 from rich.table import Table
 
@@ -111,7 +107,7 @@ def parse_cmdline_args(parser=None, config_name: Literal["client", "server"] | s
     config_file = args.config
     cli_args = vars(args)
     user = cli_args.pop("user")
-    acl_config = {"username": user} if user else {}
+    acl_config = {"user": user} if user else None
     redis_url = args.bec_server
 
     if redis_url and config_file:
@@ -134,18 +130,21 @@ def parse_cmdline_args(parser=None, config_name: Literal["client", "server"] | s
             except ValueError:
                 raise ValueError(f"Invalid port number in Redis URL: {comps[1]}")
 
-        service_config = ServiceConfig(
-            redis=redis_data, cmdline_args=cli_args, acl=acl_config, config_name=config_name
-        )
+        kwargs = {"redis": redis_data, "cmdline_args": cli_args, "config_name": config_name}
+        if acl_config:
+            kwargs["acl"] = acl_config
+        service_config = ServiceConfig(**kwargs)
     elif config_file:
-        service_config = ServiceConfig(
-            config_file, cmdline_args=cli_args, acl=acl_config, config_name=config_name
-        )
+        kwargs = {"cmdline_args": cli_args, "config_name": config_name}
+        if acl_config:
+            kwargs["acl"] = acl_config
+        service_config = ServiceConfig(config_file, **kwargs)
     else:
         # If no config file or Redis URL is provided, use the default ServiceConfig
-        service_config = ServiceConfig(
-            cmdline_args=cli_args, acl=acl_config, config_name=config_name
-        )
+        kwargs = {"cmdline_args": cli_args, "config_name": config_name}
+        if acl_config:
+            kwargs["acl"] = acl_config
+        service_config = ServiceConfig(**kwargs)
 
     return args, extra_args, service_config
 
@@ -173,7 +172,7 @@ class BECService:
             else connector
         )
         self.acl = BECAccess(self.connector)
-        self.acl._bec_service_login(prompt_for_acl, self._service_config.config.get("acl"))
+        self.acl._bec_service_login(prompt_for_acl, self._service_config.model.acl)
 
         self._unique_service = unique_service
         self.wait_for_server = wait_for_server

--- a/bec_lib/bec_lib/endpoints.py
+++ b/bec_lib/bec_lib/endpoints.py
@@ -234,7 +234,7 @@ class MessageEndpoints:
         Returns:
             EndpointInfo: Endpoint for device config request.
         """
-        endpoint = f"{EndpointType.ADMIN.value}/devices/config_request"
+        endpoint = f"{EndpointType.USER.value}/devices/config_request"
         return EndpointInfo(
             endpoint=endpoint, message_type=messages.DeviceConfigMessage, message_op=MessageOp.SEND
         )
@@ -703,7 +703,7 @@ class MessageEndpoints:
         Returns:
             EndpointInfo: Endpoint for stopping devices.
         """
-        endpoint = f"{EndpointType.INFO.value}/queue/stop_devices"
+        endpoint = f"{EndpointType.USER.value}/queue/stop_devices"
         return EndpointInfo(
             endpoint=endpoint, message_type=messages.VariableMessage, message_op=MessageOp.SEND
         )
@@ -848,17 +848,6 @@ class MessageEndpoints:
             message_type=messages.AvailableResourceMessage,
             message_op=MessageOp.SET_PUBLISH,
         )
-
-    @staticmethod
-    def bluesky_events() -> str:
-        """
-        Endpoint for bluesky events. This endpoint is used by the scan bundler to
-        publish the bluesky events using a direct msgpack dump of the bluesky event.
-
-        Returns:
-            str: Endpoint for bluesky events.
-        """
-        return f"{EndpointType.INFO.value}/scans/bluesky-events"
 
     @staticmethod
     def scan_segment():
@@ -1084,7 +1073,7 @@ class MessageEndpoints:
         Returns:
             EndpointInfo: Endpoint for log.
         """
-        endpoint = f"{EndpointType.INFO.value}/log"
+        endpoint = f"{EndpointType.USER.value}/log"
         return EndpointInfo(
             endpoint=endpoint, message_type=messages.LogMessage, message_op=MessageOp.STREAM
         )
@@ -1626,7 +1615,7 @@ class MessageEndpoints:
         Returns:
             EndpointInfo: Endpoint for procedure queue updates for given queue.
         """
-        endpoint = f"{EndpointType.INFO.value}/procedures/logs/{queue}"
+        endpoint = f"{EndpointType.USER.value}/procedures/logs/{queue}"
         return EndpointInfo(
             endpoint=endpoint, message_type=messages.RawMessage, message_op=MessageOp.STREAM
         )
@@ -1682,7 +1671,7 @@ class MessageEndpoints:
 
     @staticmethod
     def modify_interlock_table():
-        endpoint = f"{EndpointType.INTERNAL.value}/actor/builtin/scan_interlock/table_mod"
+        endpoint = f"{EndpointType.USER.value}/actor/builtin/scan_interlock/table_mod"
         return EndpointInfo(
             endpoint=endpoint,
             message_type=messages.ScanInterlockModifyStateTableMessage,
@@ -1700,7 +1689,7 @@ class MessageEndpoints:
 
     @staticmethod
     def scan_interlock_enabled():
-        endpoint = f"{EndpointType.INFO.value}/actor/builtin/scan_interlock/config/enabled"
+        endpoint = f"{EndpointType.USER.value}/actor/builtin/scan_interlock/config/enabled"
         return EndpointInfo(
             endpoint=endpoint,
             message_type=messages.BoolConfigDefaultFalse,
@@ -1710,7 +1699,7 @@ class MessageEndpoints:
     @staticmethod
     def scan_interlock_trigger_setting():
         """Whether to restart the scan when the interlock is triggered."""
-        endpoint = f"{EndpointType.INFO.value}/actor/builtin/scan_interlock/config/trigger_setting"
+        endpoint = f"{EndpointType.USER.value}/actor/builtin/scan_interlock/config/trigger_setting"
         return EndpointInfo(
             endpoint=endpoint,
             message_type=messages.ScanInterlockTriggerSettingMessage,
@@ -1812,7 +1801,7 @@ class MessageEndpoints:
         Returns:
             EndpointInfo: Endpoint for script execution info.
         """
-        endpoint = f"{EndpointType.INFO.value}/scripts/execution_info/{script_id}"
+        endpoint = f"{EndpointType.USER.value}/scripts/execution_info/{script_id}"
         return EndpointInfo(
             endpoint=endpoint,
             message_type=messages.ScriptExecutionInfoMessage,
@@ -1828,7 +1817,7 @@ class MessageEndpoints:
         Returns:
             EndpointInfo: Endpoint for script content.
         """
-        endpoint = f"{EndpointType.INFO.value}/scripts/content/{script_id}"
+        endpoint = f"{EndpointType.USER.value}/scripts/content/{script_id}"
         return EndpointInfo(
             endpoint=endpoint, message_type=messages.VariableMessage, message_op=MessageOp.KEY_VALUE
         )
@@ -1859,7 +1848,7 @@ class MessageEndpoints:
         Returns:
             EndpointInfo: Endpoint for beamline state.
         """
-        endpoint = f"{EndpointType.INFO.value}/beamline_state/{state_name}"
+        endpoint = f"{EndpointType.USER.value}/beamline_state/{state_name}"
         return EndpointInfo(
             endpoint=endpoint,
             message_type=messages.BeamlineStateMessage,
@@ -1875,7 +1864,7 @@ class MessageEndpoints:
         Returns:
             EndpointInfo: Endpoint for beamline state updates.
         """
-        endpoint = f"{EndpointType.INFO.value}/available_beamline_states"
+        endpoint = f"{EndpointType.USER.value}/available_beamline_states"
         return EndpointInfo(
             endpoint=endpoint,
             message_type=messages.AvailableBeamlineStatesMessage,
@@ -2073,7 +2062,7 @@ class MessageEndpoints:
         Returns:
             EndpointInfo: Endpoint for dynamic metric publishing.
         """
-        endpoint = f"{EndpointType.INFO.value}/dynamic_metrics/{group_name}"
+        endpoint = f"{EndpointType.USER.value}/dynamic_metrics/{group_name}"
         return EndpointInfo(
             endpoint=endpoint,
             message_type=messages.DynamicMetricMessage,

--- a/bec_lib/bec_lib/endpoints.py
+++ b/bec_lib/bec_lib/endpoints.py
@@ -1738,18 +1738,18 @@ class MessageEndpoints:
         )
 
     @staticmethod
-    def gui_acl(gui_id: str):
+    def acl_session(session_id: str):
         """
-        Endpoint for exchanging GUI ACL information. This endpoint is used by the CLI or GUI to exchange
+        Endpoint for exchanging ACL session information. This endpoint is used by the CLI or GUI to exchange
         updates on the required ACL user. It uses a messages.CredentialsMessage message.
 
         Args:
-            gui_id (str): GUI ID.
+            session_id (str): Session ID.
         Returns:
-            EndpointInfo: Endpoint for GUI ACL.
+            EndpointInfo: Endpoint for ACL session.
         """
 
-        endpoint = f"{EndpointType.USER.value}/gui/acl/{gui_id}"
+        endpoint = f"{EndpointType.USER.value}/acl/{session_id}"
         return EndpointInfo(
             endpoint=endpoint, message_type=messages.CredentialsMessage, message_op=MessageOp.SEND
         )

--- a/bec_lib/bec_lib/service_config.py
+++ b/bec_lib/bec_lib/service_config.py
@@ -83,6 +83,7 @@ class ACLConfig(BaseModel):
 
     env_file: str = Field(default_factory=lambda: os.path.join(DEFAULT_BASE_PATH, ".bec_acl.env"))
     user: str | None = None
+    password: str | None = None
 
 
 class ProcedureConfig(BaseModel):

--- a/bec_lib/bec_lib/utils/user_acls_test.py
+++ b/bec_lib/bec_lib/utils/user_acls_test.py
@@ -1,7 +1,7 @@
 import sys
 from typing import Literal
 
-from bec_lib.endpoints import MessageEndpoints
+from bec_lib.endpoints import EndpointType, MessageEndpoints
 from bec_lib.redis_connector import RedisConnector
 
 
@@ -12,12 +12,20 @@ class BECAccessDemo:  # pragma: no cover
             self.connector = connector
         else:
             self.connector = RedisConnector("localhost:6379")
-        self.connector.authenticate(**self._find_admin_account())
+        admin_account = self._find_admin_account()
+        if admin_account:
+            self.connector.authenticate(**admin_account)
         self.username = "user"
         self.admin_username = "admin"
         self.deployment_id = "test_deployment"
 
-    def _find_admin_account(self) -> dict[str, str]:
+    def _find_admin_account(self) -> dict[str, str] | None:
+        try:
+            self.connector.acl_list()
+            return None
+        except Exception:
+            pass
+
         for user, token in [("default", "null"), ("admin", "admin")]:
             try:
                 self.connector.authenticate(username=user, password=token)
@@ -149,6 +157,27 @@ class BECAccessDemo:  # pragma: no cover
                 reset_keys=True,
             )
 
+    def set_default_non_admin(self):
+        """Grant the default user access to all non-admin endpoint namespaces."""
+        allowed_namespaces = [
+            EndpointType.PUBLIC.value,
+            EndpointType.PERSONAL.value,
+            EndpointType.USER.value,
+            EndpointType.INFO.value,
+            EndpointType.INTERNAL.value,
+        ]
+        self.connector._managed_connection._redis_conn.acl_setuser(
+            "default",
+            enabled=True,
+            nopass=True,
+            categories=["+@all", "-@dangerous"],
+            keys=[f"%RW~{namespace}/*" for namespace in allowed_namespaces],
+            channels=[f"{namespace}/*" for namespace in allowed_namespaces],
+            commands=["+keys"],
+            reset_channels=True,
+            reset_keys=True,
+        )
+
 
 def _main(
     mode: str, connector: RedisConnector | None = None, shutdown: bool = True
@@ -166,6 +195,14 @@ def _main(
             demo.set_default_limited(True)
             print(
                 "Enabled mode admin. Please make sure to place the .bec_acl.env file in the root directory and restart the bec server."
+            )
+        case "non_admin":
+            demo.reset()
+            demo.add_user()
+            demo.add_admin()
+            demo.set_default_non_admin()
+            print(
+                "Enabled mode non_admin. The default user can access all non-admin namespaces. Please restart the bec server."
             )
         case _:
             raise ValueError(f"Invalid mode: {mode}")
@@ -185,6 +222,6 @@ if __name__ == "__main__":  # pragma: no cover
     args = parser.parse_args()
 
     if args.mode is None:
-        args.mode = "default"
+        args.mode = "non_admin"
 
     _main("default" if args.reset else args.mode)

--- a/bec_lib/bec_lib/utils/user_acls_test.py
+++ b/bec_lib/bec_lib/utils/user_acls_test.py
@@ -163,8 +163,6 @@ class BECAccessDemo:  # pragma: no cover
             EndpointType.PUBLIC.value,
             EndpointType.PERSONAL.value,
             EndpointType.USER.value,
-            EndpointType.INFO.value,
-            EndpointType.INTERNAL.value,
         ]
         self.connector._managed_connection._redis_conn.acl_setuser(
             "default",

--- a/bec_lib/bec_lib/utils/user_acls_test.py
+++ b/bec_lib/bec_lib/utils/user_acls_test.py
@@ -159,18 +159,23 @@ class BECAccessDemo:  # pragma: no cover
 
     def set_default_non_admin(self):
         """Grant the default user access to all non-admin endpoint namespaces."""
-        allowed_namespaces = [
+        read_write_namespaces = [
             EndpointType.PUBLIC.value,
             EndpointType.PERSONAL.value,
             EndpointType.USER.value,
         ]
+        read_only_namespaces = [EndpointType.INFO.value]
         self.connector._managed_connection._redis_conn.acl_setuser(
             "default",
             enabled=True,
             nopass=True,
             categories=["+@all", "-@dangerous"],
-            keys=[f"%RW~{namespace}/*" for namespace in allowed_namespaces],
-            channels=[f"{namespace}/*" for namespace in allowed_namespaces],
+            keys=[f"%RW~{namespace}/*" for namespace in read_write_namespaces]
+            + [f"%R~{namespace}/*" for namespace in read_only_namespaces],
+            channels=[
+                f"{namespace}/*" for namespace in read_write_namespaces + read_only_namespaces
+            ]
+            + [MessageEndpoints.public_file("*", "*").endpoint],
             commands=["+keys"],
             reset_channels=True,
             reset_keys=True,

--- a/bec_lib/tests/test_acl_login.py
+++ b/bec_lib/tests/test_acl_login.py
@@ -166,8 +166,6 @@ def test_access_demo_set_default_non_admin_allows_non_admin_namespaces(access_co
             f"&{EndpointType.PUBLIC.value}/*",
             f"&{EndpointType.PERSONAL.value}/*",
             f"&{EndpointType.USER.value}/*",
-            f"&{EndpointType.INFO.value}/*",
-            f"&{EndpointType.INTERNAL.value}/*",
         ]
     )
     assert f"&{EndpointType.ADMIN.value}/*" not in acl_info["channels"]

--- a/bec_lib/tests/test_acl_login.py
+++ b/bec_lib/tests/test_acl_login.py
@@ -166,6 +166,8 @@ def test_access_demo_set_default_non_admin_allows_non_admin_namespaces(access_co
             f"&{EndpointType.PUBLIC.value}/*",
             f"&{EndpointType.PERSONAL.value}/*",
             f"&{EndpointType.USER.value}/*",
+            f"&{EndpointType.INFO.value}/*",
+            f"&{MessageEndpoints.public_file('*', '*').endpoint}",
         ]
     )
     assert f"&{EndpointType.ADMIN.value}/*" not in acl_info["channels"]

--- a/bec_lib/tests/test_acl_login.py
+++ b/bec_lib/tests/test_acl_login.py
@@ -4,6 +4,7 @@ import pytest
 
 from bec_lib import messages
 from bec_lib.acl_login import BECAccess, BECAuthenticationError
+from bec_lib.endpoints import EndpointType, MessageEndpoints
 from bec_lib.utils.user_acls_test import BECAccessDemo
 
 # pylint: disable=protected-access
@@ -97,6 +98,30 @@ def test_login_psi_login(bec_access, access_control):
             local_login.assert_not_called()
 
 
+def test_temporary_user_restores_previous_user(bec_access, access_control):
+    access_control.add_account("operator", "operator", "admin")
+    access_control.add_account("admin", "admin", "admin")
+    bec_access.login_with_token(username="operator", token="operator")
+
+    with bec_access.temporary_user(username="admin", token="admin"):
+        assert bec_access.connector.username == "admin"
+
+    assert bec_access.connector.username == "operator"
+
+
+def test_temporary_user_restores_previous_user_after_exception(bec_access, access_control):
+    access_control.add_account("operator", "operator", "admin")
+    access_control.add_account("admin", "admin", "admin")
+    bec_access.login_with_token(username="operator", token="operator")
+
+    with pytest.raises(RuntimeError):
+        with bec_access.temporary_user(username="admin", token="admin"):
+            assert bec_access.connector.username == "admin"
+            raise RuntimeError("boom")
+
+    assert bec_access.connector.username == "operator"
+
+
 def test_bec_service_login_default(bec_access):
     bec_access._info = _login_info()
 
@@ -104,6 +129,62 @@ def test_bec_service_login_default(bec_access):
     conn = bec_access.connector._managed_connection._redis_conn.connection_pool.connection_kwargs
     assert conn["username"] is None
     assert conn["password"] is None
+
+
+def test_access_demo_uses_current_admin_connection_without_auth():
+    connector = mock.MagicMock()
+    connector.acl_list.return_value = ["user default on nopass ~* &* +@all"]
+
+    handler = BECAccessDemo(connector)
+
+    assert handler.connector is connector
+    connector.authenticate.assert_not_called()
+
+
+def test_access_demo_falls_back_to_configured_admin_account():
+    connector = mock.MagicMock()
+    connector.acl_list.side_effect = Exception("Access denied")
+    connector.authenticate.side_effect = [Exception("auth failed"), None, None]
+
+    BECAccessDemo(connector)
+
+    assert connector.authenticate.call_args_list == [
+        mock.call(username="default", password="null"),
+        mock.call(username="admin", password="admin"),
+        mock.call(username="admin", password="admin"),
+    ]
+
+
+def test_access_demo_set_default_non_admin_allows_non_admin_namespaces(access_control, bec_access):
+    access_control.add_admin()
+    access_control.set_default_non_admin()
+
+    acl_info = bec_access.connector._managed_connection._redis_conn.acl_getuser("default")
+    assert "nopass" in acl_info["flags"]
+    assert sorted(acl_info["channels"]) == sorted(
+        [
+            f"&{EndpointType.PUBLIC.value}/*",
+            f"&{EndpointType.PERSONAL.value}/*",
+            f"&{EndpointType.USER.value}/*",
+            f"&{EndpointType.INFO.value}/*",
+            f"&{EndpointType.INTERNAL.value}/*",
+        ]
+    )
+    assert f"&{EndpointType.ADMIN.value}/*" not in acl_info["channels"]
+
+
+def test_access_demo_main_non_admin_mode():
+    demo = mock.MagicMock()
+
+    with mock.patch("bec_lib.utils.user_acls_test.BECAccessDemo", return_value=demo):
+        from bec_lib.utils.user_acls_test import _main
+
+        _main("non_admin", shutdown=False)
+
+    demo.reset.assert_called_once()
+    demo.add_user.assert_called_once()
+    demo.add_admin.assert_called_once()
+    demo.set_default_non_admin.assert_called_once()
 
 
 @mock.patch("bec_lib.acl_login.input")
@@ -273,6 +354,35 @@ def test_config_login_successful_with_env_file_failure(mock_exists, bec_access):
 
             assert result is False
             mock_check.assert_called_once_with("env_user", "env_pass")
+
+
+@mock.patch("os.path.exists")
+@mock.patch("bec_lib.acl_login.dotenv_values")
+def test_config_login_successful_with_dict_env_file(mock_dotenv, mock_exists, bec_access):
+    """Test _config_login_successful with an env_file from the service config."""
+    mock_exists.return_value = True
+    mock_dotenv.return_value = {"REDIS_USER": "env_user", "REDIS_PASSWORD": "env_pass"}
+
+    with mock.patch.object(bec_access, "_check_redis_auth", return_value=True) as mock_check:
+        result = bec_access._config_login_successful(
+            False, {"env_file": "/path/to/.bec_acl.env", "user": None}
+        )
+
+        assert result is True
+        mock_check.assert_called_once_with("env_user", "env_pass")
+
+
+def test_config_login_successful_with_prompt_and_env_file_uses_user_login(bec_access):
+    """Prompted clients should defer env_file-only configs to the default/full-access check."""
+    with mock.patch.object(bec_access, "_check_redis_auth", return_value=True) as mock_check:
+        with mock.patch.object(bec_access, "_user_service_login") as mock_user_login:
+            result = bec_access._config_login_successful(
+                True, {"env_file": "/path/to/.bec_acl.env"}
+            )
+
+            assert result is False
+            mock_check.assert_not_called()
+            mock_user_login.assert_not_called()
 
 
 def test_config_login_successful_with_dict(bec_access):

--- a/bec_lib/tests/test_bec_logger.py
+++ b/bec_lib/tests/test_bec_logger.py
@@ -112,7 +112,7 @@ def test_console_redis_callback_publishes_to_log_endpoint_with_console_service_n
 
     logger.connector.xadd.assert_called_once()
     kwargs = logger.connector.xadd.call_args.kwargs
-    assert kwargs["topic"].endpoint == "info/log"
+    assert kwargs["topic"].endpoint == "user/log"
     assert kwargs["msg_dict"]["data"].log_type == "console_log"
     assert kwargs["msg_dict"]["data"].log_msg["service_name"] == "test_CONSOLE"
 

--- a/bec_lib/tests/test_bec_service.py
+++ b/bec_lib/tests/test_bec_service.py
@@ -410,7 +410,28 @@ def test_parse_cmdline_args_with_config():
                     "bec_server": None,
                     "use_subprocess_proc_worker": False,
                 },
-                acl={},
+                config_name="server",
+            )
+
+
+def test_parse_cmdline_args_with_user():
+    """Test parse_cmdline_args with a service ACL user."""
+    with mock.patch.object(sys, "argv", ["script.py", "--user", "admin"]):
+        with mock.patch("bec_lib.bec_service.ServiceConfig", autospec=True) as mock_service_config:
+            parse_cmdline_args()
+
+            mock_service_config.assert_called_once_with(
+                cmdline_args={
+                    "version": False,
+                    "json": False,
+                    "config": "",
+                    "log_level": None,
+                    "file_log_level": None,
+                    "redis_log_level": None,
+                    "bec_server": None,
+                    "use_subprocess_proc_worker": False,
+                },
+                acl={"user": "admin"},
                 config_name="server",
             )
 

--- a/bec_server/bec_server/procedures/manager.py
+++ b/bec_server/bec_server/procedures/manager.py
@@ -39,6 +39,11 @@ class ProcedureWorkerEntry(TypedDict):
     future: Future
 
 
+class RedisCredentials(TypedDict):
+    username: str | None
+    token: str | None
+
+
 def _log_on_end(future: Future):
     """Use as a callback so that future is always done."""
     if e := future.exception():
@@ -63,7 +68,11 @@ class ProcedureManagerBase(ABC, Generic[_ReqMsgT, _ExecMsgT]):
     exec_msg_type: _ExecMsgT
 
     def __init__(
-        self, redis: str, worker_type: type[ProcedureWorker], thread_prefix: str = "user_procedure_"
+        self,
+        redis: str,
+        worker_type: type[ProcedureWorker],
+        thread_prefix: str = "user_procedure_",
+        redis_credentials: RedisCredentials | None = None,
     ):
         """Watches the request queue and pushes to worker execution queues. Manages
         instantiating and cleaning up after workers.
@@ -81,7 +90,16 @@ class ProcedureManagerBase(ABC, Generic[_ReqMsgT, _ExecMsgT]):
         )
 
         self._logs = deque([], maxlen=1000)
+
+        # NOTE: I'm not convinced that we should really instantiate a new RedisConnector here
+        # but I will keep it for now. We should probably simply pass in the existing RedisConnector
+        # from the ScanServer, but that would require some refactoring of the ScanServer and ProcedureManager.
         self._conn = RedisConnector([redis], name="ProcedureManager RedisConnector")
+        if redis_credentials is not None:
+            self._conn.authenticate(
+                username=redis_credentials["username"] or "default",
+                password=redis_credentials.get("token"),
+            )
 
         self._active_workers: dict[str, ProcedureWorkerEntry] = {}
         self.executor = ThreadPoolExecutor(
@@ -224,9 +242,13 @@ class ProcedureManagerBase(ABC, Generic[_ReqMsgT, _ExecMsgT]):
 
 class ProcedureManager(ProcedureManagerBase[ProcedureRequestMessage, ProcedureExecutionMessage]):
     def __init__(
-        self, redis: str, worker_type: type[ProcedureWorker], thread_prefix: str = "user_procedure_"
+        self,
+        redis: str,
+        worker_type: type[ProcedureWorker],
+        thread_prefix: str = "user_procedure_",
+        redis_credentials: RedisCredentials | None = None,
     ):
-        super().__init__(redis, worker_type, thread_prefix)
+        super().__init__(redis, worker_type, thread_prefix, redis_credentials)
         self._messages_by_ids: dict[str, ProcedureExecutionMessage] = {}
         self._helper = BackendProcedureHelper(self._conn, monitor_responses=False)
         self._startup()

--- a/bec_server/bec_server/scan_server/scan_server.py
+++ b/bec_server/bec_server/scan_server/scan_server.py
@@ -84,7 +84,11 @@ class ScanServer(BECService):
             if (use_subprocess_proc_worker or not podman_available())
             else ContainerProcedureWorker
         )
-        self.proc_manager = ProcedureManager(self.bootstrap_server, procedure_worker)
+        self.proc_manager = ProcedureManager(
+            self.bootstrap_server,
+            procedure_worker,
+            redis_credentials=self.acl.current_credentials(),
+        )
 
     def _start_actor_managers(self):
         self.actor_manager = ActorManager(self.bootstrap_server)

--- a/bec_server/tests/tests_scan_server/test_procedures.py
+++ b/bec_server/tests/tests_scan_server/test_procedures.py
@@ -164,6 +164,22 @@ def test_helper_log_streams(procedure_manager):
     assert helper.get.log_queue_names() == ["queue1", "queue2"]
 
 
+def test_procedure_manager_authenticates_with_forwarded_credentials():
+    conn = MagicMock()
+    with (
+        patch("bec_server.procedures.manager.RedisConnector", return_value=conn),
+        patch("bec_server.procedures.manager.BackendProcedureHelper", return_value=MagicMock()),
+    ):
+        manager = ProcedureManager(
+            f"{FAKEREDIS_HOST}:{FAKEREDIS_PORT}",
+            InlineWorker,
+            redis_credentials={"username": "admin", "token": "admin"},
+        )
+
+    conn.authenticate.assert_called_once_with(username="admin", password="admin")
+    manager.shutdown()
+
+
 @pytest.mark.parametrize(["accepted", "msg"], zip([True, False], ["test true", "test false"]))
 def test_ack(procedure_manager: ProcedureManager, accepted: bool, msg: str):
     ps = procedure_manager._conn._managed_connection._redis_conn.pubsub()


### PR DESCRIPTION
## Description

This PR improves the support for ACLs in BEC. In particular, it adds an e2e test for ensuring that they remain functional. 

## Type of Change

- Forward service auth details from scan server to the procedure manager
- Re-assign endpoints (ADMIN, INFO, USER) depending on what makes sense
- Add e2e test for ACLs
- Add context manager for temporarily using a different account

## How to test

- Run unit tests
- Use the `bec_lib/bec_lib/utils/user_acls_test.py` module to set up your ACL environment and restart your server and client
- run the client normally, use BW...
- restart redis to reset the ACLs

## Potential side effects

The renaming of the endpoints also means that certain data will be lost on redeployment

## Additional Comments

The forwarding in the procedure manager is likely not needed. Instead, we should simply forward the entire connector.

## Definition of Done
- [ ] Documentation is up-to-date.

