### PR TITLE
fix(device_server): add conversion for enum strings from float values

### DIFF
--- a/bec_server/bec_server/device_server/device_server.py
+++ b/bec_server/bec_server/device_server/device_server.py
@@ -727,6 +727,7 @@ class DeviceServer(BECService):
         else:
             obj = device_obj.obj
         try:
+            val = self.convert_value_if_needed(obj, val)
             status = obj.set(val)
         except Exception as exc:  # pylint: disable=broad-except
             exc = reformat_known_device_exceptions(
@@ -737,6 +738,28 @@ class DeviceServer(BECService):
         self._add_status_object_info(status, instr, obj)
         status.__dict__["sub_id"] = sub_id
         self.requests_handler.add_status_object(instr.metadata["device_instr_id"], status)
+
+    @staticmethod
+    def convert_value_if_needed(obj: ophyd.OphydObject, val: Any) -> Any:
+        """
+        Convert the value to the appropriate type if needed. This is particularly
+        needed for ophyd signals that implement enum strings but are given as floats.
+
+        Args:
+            obj (ophyd.OphydObject): The ophyd object to set.
+            val (Any): The value to set.
+
+        Returns:
+            Any: The converted value.
+        """
+        if hasattr(obj, "enum_strs") and len(obj.enum_strs) > 0 and isinstance(val, float):
+            if not val.is_integer():
+                raise ValueError(
+                    f"Cannot convert float {val} to enum index for {obj.name}. "
+                    f"Value must be an integer to select one of the enum strings: {obj.enum_strs}."
+                )
+            val = int(val)
+        return val
 
     def _pre_scan(self, instr: messages.DeviceInstructionMessage) -> None:
         devices = instr.content["device"]

--- a/bec_server/bec_server/device_server/rpc_handler.py
+++ b/bec_server/bec_server/device_server/rpc_handler.py
@@ -199,6 +199,11 @@ class RPCHandler:
             instr(messages.DeviceInstructionMessage): RPC instruction
         """
         _, obj, rpc_var = self._get_rpc_components(instr)
+
+        if isinstance(obj, ophyd.Signal) and getattr(rpc_var, "__name__", None) in ["set", "put"]:
+            val = instr.parameter.get("args")[0]
+            val = self.device_server.convert_value_if_needed(obj, val)
+            instr.parameter["args"][0] = val
         res = self._execute_rpc_call(rpc_var, instr)
 
         if not isinstance(res, ophyd.StatusBase) or res.done:

--- a/bec_server/tests/tests_device_server/test_device_server.py
+++ b/bec_server/tests/tests_device_server/test_device_server.py
@@ -1,8 +1,10 @@
 import threading
 from io import StringIO
+from types import SimpleNamespace
 from unittest import mock
 from unittest.mock import ANY, patch
 
+import numpy as np
 import pytest
 from loguru import logger
 from ophyd import Device, DeviceStatus, Kind, Staged
@@ -63,6 +65,41 @@ def device_instruction_message_mock(ophyd_device_mock):
         metadata={"stream": "primary", "device_instr_id": "diid", "RID": "test"},
     )
     yield instr
+
+
+@pytest.mark.parametrize("value, expected", [(0.0, 0), (1.0, 1), (np.float64(2.0), 2)])
+def test_convert_value_if_needed_converts_integral_float_for_enum(value, expected):
+    obj = SimpleNamespace(name="enum_signal", enum_strs=("zero", "one", "two"))
+
+    converted = DeviceServer.convert_value_if_needed(obj, value)
+
+    assert converted == expected
+    assert isinstance(converted, int)
+
+
+def test_convert_value_if_needed_rejects_non_integral_float_for_enum():
+    obj = SimpleNamespace(name="enum_signal", enum_strs=("zero", "one", "two"))
+
+    with pytest.raises(ValueError, match="Cannot convert float 1.5 to enum index"):
+        DeviceServer.convert_value_if_needed(obj, 1.5)
+
+
+@pytest.mark.parametrize("value", [1, 1.0, np.float64(1.0)])
+def test_convert_value_if_needed_leaves_non_enum_values_unchanged(value):
+    obj = SimpleNamespace(name="plain_signal")
+
+    converted = DeviceServer.convert_value_if_needed(obj, value)
+
+    assert converted is value
+
+
+def test_convert_value_if_needed_leaves_enum_int_unchanged():
+    obj = SimpleNamespace(name="enum_signal", enum_strs=("zero", "one"))
+
+    converted = DeviceServer.convert_value_if_needed(obj, 1)
+
+    assert converted == 1
+    assert isinstance(converted, int)
 
 
 def test_start(device_server_mock):


### PR DESCRIPTION
## Description

Converting floats to ints if the underlying signal is based on string enums. 

## Additional Comments

This currently only happens for legacy scans as they convert the inputs to a numpy array of floats. For v4-type scans the input types are kept. However, using the GUI will likely also emit floats as the inputs are given through a doublespincombobox. So it is probably a good idea to convert them to ints on the device server if possible. 

## Definition of Done
- [ ] Documentation is up-to-date.

