### PR TITLE
Adapt retention and rotation policy for bec_logger

### DIFF
--- a/bec_lib/bec_lib/logger.py
+++ b/bec_lib/bec_lib/logger.py
@@ -85,7 +85,7 @@ class BECLogger:
     """Logger for BEC."""
 
     DEFAULT_MAX_FILE_SIZE_MB = 50
-    DEFAULT_MAX_FILES = 3
+    DEFAULT_MAX_FILES = 14
 
     LOG_FORMAT_STDERR = (
         "<green>{service_name} | {{time:YYYY-MM-DD HH:mm:ss}}</green> | {{name}} | <level>[{{level}}]</level> |"
@@ -382,9 +382,10 @@ class BECLogger:
             level=level,
             format=self.formatting(),
             filter=self.filter(),
+            retention=self._file_max_files,
             rotation=self._rotator.should_rotate,
-            catch=True,
             opener=self._file_opener,
+            compression="gz",
         )
 
     def add_console_log(self):
@@ -415,10 +416,10 @@ class BECLogger:
             level=LogLevel.CONSOLE_LOG,
             format=self.get_format(LogLevel.CONSOLE_LOG).rstrip(),
             filter=self.filter(is_console=True),
-            retention=self._file_retention,
-            rotation=f"{self._file_max_size_mb} MB",
-            catch=True,
+            retention=self._file_max_files,
+            rotation=self._rotator.should_rotate,
             opener=self._file_opener,
+            compression="gz",
         )
         self._console_log = True
         self.add_console_redis_log()

--- a/bec_lib/bec_lib/logger.py
+++ b/bec_lib/bec_lib/logger.py
@@ -50,7 +50,8 @@ class LogLevel(int, enum.Enum):
 class BECLoguruRotator:
     """
     Custom rotator for loguru that rotates logs based on size and time. We assume
-    that logs are rotated once per day.
+    that logs are rotated once per day. There is a timer that limits rotation checks
+    to once per 10 minutes, to avoid excessive checks.
 
     Args:
         size (int): Maximum size of the log file in bytes before rotation.
@@ -59,6 +60,8 @@ class BECLoguruRotator:
 
     def __init__(self, *, size: int, at: datetime.time):
         now = datetime.datetime.now()
+        self._last_check = time.monotonic()
+        self._limiter = 600  # 10 minutes
 
         self._size_limit = size
         self._time_limit = now.replace(hour=at.hour, minute=at.minute, second=at.second)
@@ -70,6 +73,8 @@ class BECLoguruRotator:
 
     def should_rotate(self, message, file):
         """Custom rotator function for loguru that rotates logs based on size and time."""
+        if time.monotonic() - self._last_check < self._limiter:
+            return False
         file.seek(0, 2)
         if file.tell() + len(message) > self._size_limit:
             return True

--- a/bec_lib/bec_lib/logger.py
+++ b/bec_lib/bec_lib/logger.py
@@ -124,7 +124,6 @@ class BECLogger:
         self._file_log_level = self._log_level
         self._console_log = False
         self._configured = False
-        self._rotator = None
         self._disabled_modules = set()
         self._file_max_size_mb = self.DEFAULT_MAX_FILE_SIZE_MB
         self._file_max_files = self.DEFAULT_MAX_FILES
@@ -175,10 +174,6 @@ class BECLogger:
         self.bootstrap_server = bootstrap_server
         self.service_name = service_name
         self._configured = True
-        # default rotation time is 8:00AM
-        self._rotator = BECLoguruRotator(
-            size=self._file_max_size_mb * 1024 * 1024, at=datetime.time(8, 0, 0)
-        )
         self._update_sinks()
 
     def _get_connector(
@@ -377,13 +372,16 @@ class BECLogger:
         if not self.service_name:
             return
         filename = os.path.join(self._base_path, f"{self.service_name}.log")
+        rotator = BECLoguruRotator(
+            size=self._file_max_size_mb * 1024 * 1024, at=datetime.time(8, 0, 0)
+        )
         self.logger.add(
             filename,
             level=level,
             format=self.formatting(),
             filter=self.filter(),
             retention=self._file_max_files,
-            rotation=self._rotator.should_rotate,
+            rotation=rotator.should_rotate,
             opener=self._file_opener,
             compression="gz",
         )
@@ -410,6 +408,9 @@ class BECLogger:
         # define a level corresponding to console log - this is to be able to filter messages
         # (only those with this particular level will be recorded by the console logger,
         # while other loggers will ignore them)
+        rotator = BECLoguruRotator(
+            size=self._file_max_size_mb * 1024 * 1024, at=datetime.time(8, 0, 0)
+        )
 
         self.logger.add(
             filename,
@@ -417,7 +418,7 @@ class BECLogger:
             format=self.get_format(LogLevel.CONSOLE_LOG).rstrip(),
             filter=self.filter(is_console=True),
             retention=self._file_max_files,
-            rotation=self._rotator.should_rotate,
+            rotation=rotator.should_rotate,
             opener=self._file_opener,
             compression="gz",
         )

--- a/bec_lib/bec_lib/logger.py
+++ b/bec_lib/bec_lib/logger.py
@@ -5,10 +5,12 @@ configure and manage the logging of the BEC.
 
 from __future__ import annotations
 
+import datetime
 import enum
 import json
 import os
 import sys
+import time
 import traceback
 from itertools import takewhile
 from typing import TYPE_CHECKING, Literal
@@ -45,8 +47,45 @@ class LogLevel(int, enum.Enum):
     CONSOLE_LOG_ERROR = 22
 
 
+class BECLoguruRotator:
+    """
+    Custom rotator for loguru that rotates logs based on size and time. We assume
+    that logs are rotated once per day.
+
+    Args:
+        size (int): Maximum size of the log file in bytes before rotation.
+        at (datetime.time): Time of day when the log file should be rotated.
+    """
+
+    def __init__(self, *, size: int, at: datetime.time):
+        now = datetime.datetime.now()
+
+        self._size_limit = size
+        self._time_limit = now.replace(hour=at.hour, minute=at.minute, second=at.second)
+
+        if now >= self._time_limit:
+            # If current time is passed now, add one day to the time limit to ensure rotations
+            # happens at the next occurrence of the specified time.
+            self._time_limit += datetime.timedelta(days=1)
+
+    def should_rotate(self, message, file):
+        """Custom rotator function for loguru that rotates logs based on size and time."""
+        file.seek(0, 2)
+        if file.tell() + len(message) > self._size_limit:
+            return True
+        excess = message.record["time"].timestamp() - self._time_limit.timestamp()
+        if excess >= 0:
+            elapsed_days = datetime.timedelta(seconds=excess).days
+            self._time_limit += datetime.timedelta(days=elapsed_days + 1)
+            return True
+        return False
+
+
 class BECLogger:
     """Logger for BEC."""
+
+    DEFAULT_MAX_FILE_SIZE_MB = 50
+    DEFAULT_MAX_FILES = 3
 
     LOG_FORMAT_STDERR = (
         "<green>{service_name} | {{time:YYYY-MM-DD HH:mm:ss}}</green> | {{name}} | <level>[{{level}}]</level> |"
@@ -85,7 +124,10 @@ class BECLogger:
         self._file_log_level = self._log_level
         self._console_log = False
         self._configured = False
+        self._rotator = None
         self._disabled_modules = set()
+        self._file_max_size_mb = self.DEFAULT_MAX_FILE_SIZE_MB
+        self._file_max_files = self.DEFAULT_MAX_FILES
 
     def __new__(cls):
         if not hasattr(cls, "_logger") or cls._logger is None:
@@ -133,6 +175,10 @@ class BECLogger:
         self.bootstrap_server = bootstrap_server
         self.service_name = service_name
         self._configured = True
+        # default rotation time is 8:00AM
+        self._rotator = BECLoguruRotator(
+            size=self._file_max_size_mb * 1024 * 1024, at=datetime.time(8, 0, 0)
+        )
         self._update_sinks()
 
     def _get_connector(
@@ -336,8 +382,8 @@ class BECLogger:
             level=level,
             format=self.formatting(),
             filter=self.filter(),
-            retention="3 days",
-            rotation="3 days",
+            rotation=self._rotator.should_rotate,
+            catch=True,
             opener=self._file_opener,
         )
 
@@ -369,8 +415,9 @@ class BECLogger:
             level=LogLevel.CONSOLE_LOG,
             format=self.get_format(LogLevel.CONSOLE_LOG).rstrip(),
             filter=self.filter(is_console=True),
-            retention="3 days",
-            rotation="3 days",
+            retention=self._file_retention,
+            rotation=f"{self._file_max_size_mb} MB",
+            catch=True,
             opener=self._file_opener,
         )
         self._console_log = True

--- a/bec_lib/tests/test_bec_logger.py
+++ b/bec_lib/tests/test_bec_logger.py
@@ -56,14 +56,14 @@ def test_file_sink_uses_resolved_rotation_policy(logger, tmp_path):
     logger._base_path = tmp_path
     logger._file_max_size_mb = 75
     logger._file_max_files = 3
-    logger._rotator = BECLoguruRotator(
+    rotator = BECLoguruRotator(
         size=logger._file_max_size_mb * 1024 * 1024, at=datetime.time(8, 0, 0)
     )
 
     with mock.patch.object(logger.logger, "add") as add:
         logger.add_file_log(LogLevel.INFO)
 
-    assert add.call_args.kwargs["rotation"] == logger._rotator.should_rotate
+    assert add.call_args.kwargs["rotation"].__func__ == rotator.should_rotate.__func__
 
 
 @pytest.mark.parametrize(

--- a/bec_lib/tests/test_bec_logger.py
+++ b/bec_lib/tests/test_bec_logger.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import os
 from pathlib import Path
@@ -6,7 +7,7 @@ from unittest import mock
 import pytest
 
 from bec_lib.bec_errors import ServiceConfigError
-from bec_lib.logger import BECLogger, LogLevel
+from bec_lib.logger import BECLogger, BECLoguruRotator, LogLevel
 from bec_lib.redis_connector import RedisConnector
 
 
@@ -48,6 +49,22 @@ def test_update_base_path_wrong_config(logger):
     assert logger._base_path is None
     with pytest.raises(ServiceConfigError):
         logger._update_base_path(config)
+
+
+def test_file_sink_uses_resolved_rotation_policy(logger, tmp_path):
+    logger.service_name = "DeviceServer"
+    logger._base_path = tmp_path
+    logger._file_max_size_mb = 75
+    logger._file_max_files = 3
+    logger._rotator = BECLoguruRotator(
+        size=logger._file_max_size_mb * 1024 * 1024, at=datetime.time(8, 0, 0)
+    )
+
+    with mock.patch.object(logger.logger, "add") as add:
+        logger.add_file_log(LogLevel.INFO)
+
+    assert add.call_args.kwargs["rotation"] == logger._rotator.should_rotate
+    assert add.call_args.kwargs["catch"] is True
 
 
 @pytest.mark.parametrize(

--- a/bec_lib/tests/test_bec_logger.py
+++ b/bec_lib/tests/test_bec_logger.py
@@ -64,7 +64,6 @@ def test_file_sink_uses_resolved_rotation_policy(logger, tmp_path):
         logger.add_file_log(LogLevel.INFO)
 
     assert add.call_args.kwargs["rotation"] == logger._rotator.should_rotate
-    assert add.call_args.kwargs["catch"] is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Our logs are regularly becoming relatively large if we are not careful with what is being logged. Recently, this happened at x10sa-bec-001, where the /var/log/bec folder was getting swamped with logs from BECClients actively polling via "read(cached=False)" commands. This obviously should not be implemented like this, I would nevertheless suggest an updated policy for rotation and retention.

The following PR adds an option to configure the retention policy optionally through the service config. This can be adapted on a per service basis, or global for all services. Per default, reasonable entries are chosen. 50MB size policy for logs, which a maximum of 3 files. So in total 150MB logs per service. In addition, a retention policy kicks in on a rotation that drops any file logs older than 14days. This second option can be discussed. 

For now, I keep this PR as a draft and suggestion.