### PR TITLE
feat(device): simplify device info structure by removing redundant keys

### DIFF
--- a/bec_lib/bec_lib/device.py
+++ b/bec_lib/bec_lib/device.py
@@ -245,7 +245,7 @@ class DeviceBase:
         set_device_config(self, config)
         if info is None:
             info = {}
-        self._info = info.get("device_info", {})
+        self._info = info
         self.parent = parent
 
         self._custom_rpc_methods = {}
@@ -563,8 +563,8 @@ class DeviceBase:
             self.precision = precision
         if self._info.get("sub_devices"):
             for dev in self._info.get("sub_devices"):
-                base_class = dev["device_info"].get("device_base_class")
-                attr_name = dev["device_info"].get("device_attr_name")
+                base_class = dev.get("device_base_class")
+                attr_name = dev.get("device_attr_name")
                 if base_class == "positioner":
                     setattr(self, attr_name, Positioner(name=attr_name, info=dev, parent=self))
                 elif base_class == "device":
@@ -596,7 +596,7 @@ class DeviceBase:
             else:
                 self._custom_rpc_methods[user_access_name] = DeviceBase(
                     name=user_access_name,
-                    info={"device_info": {"custom_user_access": descr["info"]}},
+                    info={"custom_user_access": descr["info"]},
                     parent=self,
                     class_name=descr["device_class"],
                 )

--- a/bec_lib/bec_lib/devicemanager.py
+++ b/bec_lib/bec_lib/devicemanager.py
@@ -593,7 +593,7 @@ class DeviceManagerBase:
                     self.devices[dev]._config["enabled"] = config[dev]["enabled"]
                     if self.devices[dev].enabled:
                         dev_info_msg = self._get_device_info(dev)
-                        self.devices[dev]._info = dev_info_msg.info.get("device_info", {})
+                        self.devices[dev]._info = dev_info_msg.info
                         if self._use_proxy_objects:
                             self.devices[dev]._parse_info()
                     status = "enabled" if self.devices[dev].enabled else "disabled"
@@ -737,8 +737,8 @@ class DeviceManagerBase:
         name = msg.content["device"]
         info = msg.content["info"]
 
-        base_class = info["device_info"]["device_base_class"]
-        class_name = info["device_info"]["device_class"]
+        base_class = info["device_base_class"]
+        class_name = info["device_class"]
 
         if base_class == (t := "device"):
             obj = Device(name=name, info=info, config=dev, parent=self, class_name=class_name)

--- a/bec_lib/bec_lib/tests/utils.py
+++ b/bec_lib/bec_lib/tests/utils.py
@@ -154,96 +154,94 @@ class ClientMock(BECClient):
 def positioner_info_mock(device_name):
     # fmt: off
     return {
-        "device_info": {
-            "device_base_class": "positioner",
-            "device_class": "SimPositioner",
-            "signals": {
-                "readback": {
-                    "component_name": "readback",
-                    "obj_name": device_name,
-                    "kind_int": 5,
-                    "kind_str": "hinted",
-                    "doc": "readback doc string",
-                    "describe": {"source": f"SIM:{device_name}", "dtype": "integer", "shape": [], "precision": 3},
-                    "metadata": {"connected": True, "read_access": True, "write_access": False, "timestamp": 0, "status": None, "severity": None, "precision": None},
-                },
-                "setpoint": {
-                    "component_name": "setpoint",
-                    "obj_name": f"{device_name}_setpoint",
-                    "kind_int": 1,
-                    "kind_str": "normal",
-                    "doc": "setpoint doc string",
-                    "describe": {"source": f"SIM:{device_name}_setpoint", "dtype": "integer", "shape": [], "precision": 3},
-                    "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
-                },
-                "motor_is_moving": {
-                    "component_name": "motor_is_moving",
-                    "obj_name": f"{device_name}_motor_is_moving",
-                    "kind_int": 1,
-                    "kind_str": "normal",
-                    "doc": "motor_is_moving doc string",
-                    "describe": {"source": f"SIM:{device_name}_motor_is_moving", "dtype": "integer", "shape": [], "precision": 3},
-                    "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
-                },
-                "velocity": {
-                    "component_name": "velocity",
-                    "obj_name": f"{device_name}_velocity",
-                    "kind_int": 2,
-                    "kind_str": "config",
-                    "doc": "velocity doc string",
-                    "describe": {"source": f"SIM:{device_name}_velocity", "dtype": "integer", "shape": [], "precision": 3},
-                    "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
-                },
-                "acceleration": {
-                    "component_name": "acceleration",
-                    "obj_name": f"{device_name}_acceleration",
-                    "kind_int": 2,
-                    "kind_str": "config",
-                    "doc": "acceleration doc string",
-                    "describe": {"source": f"SIM:{device_name}_acceleration", "dtype": "integer", "shape": [], "precision": 3},
-                    "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
-                },
-                "high_limit_travel": {
-                    "component_name": "high_limit_travel",
-                    "obj_name": f"{device_name}_high_limit_travel",
-                    "kind_int": 2,
-                    "kind_str": "config",
-                    "doc": "",
-                    "describe": {"source": f"SIM:{device_name}_high_limit_travel", "dtype": "integer", "shape": [], "precision": 3},
-                    "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
-                },
-                "low_limit_travel": {
-                    "component_name": "low_limit_travel",
-                    "obj_name": f"{device_name}_low_limit_travel",
-                    "kind_int": 2,
-                    "kind_str": "config",
-                    "doc": "",
-                    "describe": {"source": f"SIM:{device_name}_low_limit_travel", "dtype": "integer", "shape": [], "precision": 3},
-                    "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
-                },
-                "unused": {
-                    "component_name": "unused",
-                    "obj_name": f"{device_name}_unused",
-                    "kind_int": 0,
-                    "kind_str": "omitted",
-                    "doc": "",
-                    "describe": {"source": f"SIM:{device_name}_unused", "dtype": "integer", "shape": [], "precision": 3},
-                    "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
-                },
+        "device_base_class": "positioner",
+        "device_class": "SimPositioner",
+        "signals": {
+            "readback": {
+                "component_name": "readback",
+                "obj_name": device_name,
+                "kind_int": 5,
+                "kind_str": "hinted",
+                "doc": "readback doc string",
+                "describe": {"source": f"SIM:{device_name}", "dtype": "integer", "shape": [], "precision": 3},
+                "metadata": {"connected": True, "read_access": True, "write_access": False, "timestamp": 0, "status": None, "severity": None, "precision": None},
             },
-            "hints": {"fields": [device_name]},
-            "describe": {
-                device_name: {"source": f"SIM:{device_name}", "dtype": "integer", "shape": [], "precision": 3},
-                f"{device_name}_setpoint": {"source": f"SIM:{device_name}_setpoint", "dtype": "integer", "shape": [], "precision": 3},
-                f"{device_name}_motor_is_moving": {"source": f"SIM:{device_name}_motor_is_moving", "dtype": "integer", "shape": [], "precision": 3},
+            "setpoint": {
+                "component_name": "setpoint",
+                "obj_name": f"{device_name}_setpoint",
+                "kind_int": 1,
+                "kind_str": "normal",
+                "doc": "setpoint doc string",
+                "describe": {"source": f"SIM:{device_name}_setpoint", "dtype": "integer", "shape": [], "precision": 3},
+                "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
             },
-            "describe_configuration": {
-                f"{device_name}_velocity": {"source": f"SIM:{device_name}_velocity", "dtype": "integer", "shape": []},
-                f"{device_name}_acceleration": {"source": f"SIM:{device_name}_acceleration", "dtype": "integer", "shape": []},
+            "motor_is_moving": {
+                "component_name": "motor_is_moving",
+                "obj_name": f"{device_name}_motor_is_moving",
+                "kind_int": 1,
+                "kind_str": "normal",
+                "doc": "motor_is_moving doc string",
+                "describe": {"source": f"SIM:{device_name}_motor_is_moving", "dtype": "integer", "shape": [], "precision": 3},
+                "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
             },
-            "sub_devices": [],
-            "custom_user_access": {},
-        }
+            "velocity": {
+                "component_name": "velocity",
+                "obj_name": f"{device_name}_velocity",
+                "kind_int": 2,
+                "kind_str": "config",
+                "doc": "velocity doc string",
+                "describe": {"source": f"SIM:{device_name}_velocity", "dtype": "integer", "shape": [], "precision": 3},
+                "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
+            },
+            "acceleration": {
+                "component_name": "acceleration",
+                "obj_name": f"{device_name}_acceleration",
+                "kind_int": 2,
+                "kind_str": "config",
+                "doc": "acceleration doc string",
+                "describe": {"source": f"SIM:{device_name}_acceleration", "dtype": "integer", "shape": [], "precision": 3},
+                "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
+            },
+            "high_limit_travel": {
+                "component_name": "high_limit_travel",
+                "obj_name": f"{device_name}_high_limit_travel",
+                "kind_int": 2,
+                "kind_str": "config",
+                "doc": "",
+                "describe": {"source": f"SIM:{device_name}_high_limit_travel", "dtype": "integer", "shape": [], "precision": 3},
+                "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
+            },
+            "low_limit_travel": {
+                "component_name": "low_limit_travel",
+                "obj_name": f"{device_name}_low_limit_travel",
+                "kind_int": 2,
+                "kind_str": "config",
+                "doc": "",
+                "describe": {"source": f"SIM:{device_name}_low_limit_travel", "dtype": "integer", "shape": [], "precision": 3},
+                "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
+            },
+            "unused": {
+                "component_name": "unused",
+                "obj_name": f"{device_name}_unused",
+                "kind_int": 0,
+                "kind_str": "omitted",
+                "doc": "",
+                "describe": {"source": f"SIM:{device_name}_unused", "dtype": "integer", "shape": [], "precision": 3},
+                "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
+            },
+        },
+        "hints": {"fields": [device_name]},
+        "describe": {
+            device_name: {"source": f"SIM:{device_name}", "dtype": "integer", "shape": [], "precision": 3},
+            f"{device_name}_setpoint": {"source": f"SIM:{device_name}_setpoint", "dtype": "integer", "shape": [], "precision": 3},
+            f"{device_name}_motor_is_moving": {"source": f"SIM:{device_name}_motor_is_moving", "dtype": "integer", "shape": [], "precision": 3},
+        },
+        "describe_configuration": {
+            f"{device_name}_velocity": {"source": f"SIM:{device_name}_velocity", "dtype": "integer", "shape": []},
+            f"{device_name}_acceleration": {"source": f"SIM:{device_name}_acceleration", "dtype": "integer", "shape": []},
+        },
+        "sub_devices": [],
+        "custom_user_access": {},
     }
     # fmt: on
 
@@ -251,7 +249,7 @@ def positioner_info_mock(device_name):
 def positioner_info_mock_with_user_access(device_name):
     info = positioner_info_mock(device_name)
     # fmt: off
-    info["device_info"]["custom_user_access"].update(
+    info["custom_user_access"].update(
         {
             "dummy_controller": {
                 "device_class": "DummyController",
@@ -295,133 +293,126 @@ def positioner_info_mock_with_user_access(device_name):
 DYN_SIGNALS_MSG = messages.DeviceInfoMessage(
     device="dyn_signals",
     info={
-        "device_info": {
-            "device_dotted_name": "dyn_signals",
-            "device_attr_name": "dyn_signals",
-            "device_base_class": "device",
-            "device_class": "SimDevice",
-            "signals": {},
-            "hints": {"fields": []},
-            "describe": {
-                "dyn_signals_messages_message1": {"source": "SIM:dyn_signals_messages_message1", "dtype": "integer", "shape": [], "precision": 3},
-                "dyn_signals_messages_message2": {"source": "SIM:dyn_signals_messages_message2", "dtype": "integer", "shape": [], "precision": 3},
-                "dyn_signals_messages_message3": {"source": "SIM:dyn_signals_messages_message3", "dtype": "integer", "shape": [], "precision": 3},
-                "dyn_signals_messages_message4": {"source": "SIM:dyn_signals_messages_message4", "dtype": "integer", "shape": [], "precision": 3},
-                "dyn_signals_messages_message5": {"source": "SIM:dyn_signals_messages_message5", "dtype": "integer", "shape": [], "precision": 3},
-            },
-            "describe_configuration": {},
-            "sub_devices": [
-                {
-                    "device_name": "dyn_signals_messages",
-                    "device_info": {
-                        "device_attr_name": "messages",
-                        "device_dotted_name": "messages",
-                        "device_base_class": "device",
-                        "device_class": "SimDevice",
-                        "signals": {
-                            "message1": {
-                                "component_name": "message1",
-                                "obj_name": "dyn_signals_messages_message1",
-                                "kind_int": 1,
-                                "kind_str": "normal",
-                                "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
-                            },
-                            "message2": {
-                                "component_name": "message2",
-                                "obj_name": "dyn_signals_messages_message2",
-                                "kind_int": 1,
-                                "kind_str": "normal",
-                                "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
-                            },
-                            "message3": {
-                                "component_name": "message3",
-                                "obj_name": "dyn_signals_messages_message3",
-                                "kind_int": 1,
-                                "kind_str": "normal",
-                                "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
-                            },
-                            "message4": {
-                                "component_name": "message4",
-                                "obj_name": "dyn_signals_messages_message4",
-                                "kind_int": 1,
-                                "kind_str": "normal",
-                                "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
-                            },
-                            "message5": {
-                                "component_name": "message5",
-                                "obj_name": "dyn_signals_messages_message5",
-                                "kind_int": 1,
-                                "kind_str": "normal",
-                                "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
-                            },
-                        },
-                        "hints": {"fields": []},
-                        "describe": {
-                            "dyn_signals_messages_message1": {"source": "SIM:dyn_signals_messages_message1", "dtype": "integer", "shape": [], "precision": 3},
-                            "dyn_signals_messages_message2": {"source": "SIM:dyn_signals_messages_message2", "dtype": "integer", "shape": [], "precision": 3},
-                            "dyn_signals_messages_message3": {"source": "SIM:dyn_signals_messages_message3", "dtype": "integer", "shape": [], "precision": 3},
-                            "dyn_signals_messages_message4": {"source": "SIM:dyn_signals_messages_message4", "dtype": "integer", "shape": [], "precision": 3},
-                            "dyn_signals_messages_message5": {"source": "SIM:dyn_signals_messages_message5", "dtype": "integer", "shape": [], "precision": 3},
-                        },
-                        "describe_configuration": {},
-                        "sub_devices": [],
-                        "custom_user_access": {},
+        "device_dotted_name": "dyn_signals",
+        "device_attr_name": "dyn_signals",
+        "device_base_class": "device",
+        "device_class": "SimDevice",
+        "signals": {},
+        "hints": {"fields": []},
+        "describe": {
+            "dyn_signals_messages_message1": {"source": "SIM:dyn_signals_messages_message1", "dtype": "integer", "shape": [], "precision": 3},
+            "dyn_signals_messages_message2": {"source": "SIM:dyn_signals_messages_message2", "dtype": "integer", "shape": [], "precision": 3},
+            "dyn_signals_messages_message3": {"source": "SIM:dyn_signals_messages_message3", "dtype": "integer", "shape": [], "precision": 3},
+            "dyn_signals_messages_message4": {"source": "SIM:dyn_signals_messages_message4", "dtype": "integer", "shape": [], "precision": 3},
+            "dyn_signals_messages_message5": {"source": "SIM:dyn_signals_messages_message5", "dtype": "integer", "shape": [], "precision": 3},
+        },
+        "describe_configuration": {},
+        "sub_devices": [
+            {
+                "device_attr_name": "messages",
+                "device_dotted_name": "messages",
+                "device_base_class": "device",
+                "device_class": "SimDevice",
+                "signals": {
+                    "message1": {
+                        "component_name": "message1",
+                        "obj_name": "dyn_signals_messages_message1",
+                        "kind_int": 1,
+                        "kind_str": "normal",
+                        "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
                     },
-                }
-            ],
-            "custom_user_access": {},
-        }
+                    "message2": {
+                        "component_name": "message2",
+                        "obj_name": "dyn_signals_messages_message2",
+                        "kind_int": 1,
+                        "kind_str": "normal",
+                        "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
+                    },
+                    "message3": {
+                        "component_name": "message3",
+                        "obj_name": "dyn_signals_messages_message3",
+                        "kind_int": 1,
+                        "kind_str": "normal",
+                        "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
+                    },
+                    "message4": {
+                        "component_name": "message4",
+                        "obj_name": "dyn_signals_messages_message4",
+                        "kind_int": 1,
+                        "kind_str": "normal",
+                        "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
+                    },
+                    "message5": {
+                        "component_name": "message5",
+                        "obj_name": "dyn_signals_messages_message5",
+                        "kind_int": 1,
+                        "kind_str": "normal",
+                        "metadata": {"connected": True, "read_access": True, "write_access": True, "timestamp": 0, "status": None, "severity": None, "precision": None},
+                    },
+                },
+                "hints": {"fields": []},
+                "describe": {
+                    "dyn_signals_messages_message1": {"source": "SIM:dyn_signals_messages_message1", "dtype": "integer", "shape": [], "precision": 3},
+                    "dyn_signals_messages_message2": {"source": "SIM:dyn_signals_messages_message2", "dtype": "integer", "shape": [], "precision": 3},
+                    "dyn_signals_messages_message3": {"source": "SIM:dyn_signals_messages_message3", "dtype": "integer", "shape": [], "precision": 3},
+                    "dyn_signals_messages_message4": {"source": "SIM:dyn_signals_messages_message4", "dtype": "integer", "shape": [], "precision": 3},
+                    "dyn_signals_messages_message5": {"source": "SIM:dyn_signals_messages_message5", "dtype": "integer", "shape": [], "precision": 3},
+                },
+                "describe_configuration": {},
+                "sub_devices": [],
+                "custom_user_access": {},
+            }
+        ],
+        "custom_user_access": {},
     },
 )
 EIGER_MSG = messages.DeviceInfoMessage(
         device="eiger",
         info={
-            "device_info": {
-                "device_dotted_name": "eiger",
-                "device_attr_name": "eiger",
-                "device_base_class": "device",
-                "device_class": "SimCamera",
-                "signals": {
-                    "preview": {
-                        "component_name": "preview",
-                        "signal_class": "PreviewSignal",
-                        "obj_name": "eiger_preview",
-                        "kind_int": 5,
-                        "kind_str": "hinted",
-                        "doc": "",
-                        "describe": {
-                            "source": "BECMessageSignal:eiger_preview",
-                            "dtype": "DevicePreviewMessage",
-                            "shape": [],
-                            "signal_info": {
-                                "data_type": "raw",
-                                "saved": False,
-                                "ndim": 2,
-                                "scope": "scan",
-                                "role": "preview",
-                                "enabled": True,
-                                "rpc_access": False,
-                                "signals": [["preview", 5]],
-                                "signal_metadata": {"num_rotation_90": 0, "transpose": False},
-                            },
+            "device_dotted_name": "eiger",
+            "device_attr_name": "eiger",
+            "device_base_class": "device",
+            "device_class": "SimCamera",
+            "signals": {
+                "preview": {
+                    "component_name": "preview",
+                    "signal_class": "PreviewSignal",
+                    "obj_name": "eiger_preview",
+                    "kind_int": 5,
+                    "kind_str": "hinted",
+                    "doc": "",
+                    "describe": {
+                        "source": "BECMessageSignal:eiger_preview",
+                        "dtype": "DevicePreviewMessage",
+                        "shape": [],
+                        "signal_info": {
+                            "data_type": "raw",
+                            "saved": False,
+                            "ndim": 2,
+                            "scope": "scan",
+                            "role": "preview",
+                            "enabled": True,
+                            "rpc_access": False,
+                            "signals": [["preview", 5]],
+                            "signal_metadata": {"num_rotation_90": 0, "transpose": False},
                         },
-                        "metadata": {
-                            "connected": True,
-                            "read_access": True,
-                            "write_access": True,
-                            "timestamp": 1749046715.160324,
-                            "status": None,
-                            "severity": None,
-                            "precision": None,
-                        },
-                    }
-                },
-                "hints": {"fields": []},
-                "describe": {},
-                "describe_configuration": {},
-                "sub_devices": [],
-                "custom_user_access": {},
-            }
+                    },
+                    "metadata": {
+                        "connected": True,
+                        "read_access": True,
+                        "write_access": True,
+                        "timestamp": 1749046715.160324,
+                        "status": None,
+                        "severity": None,
+                        "precision": None,
+                    },
+                }
+            },
+            "hints": {"fields": []},
+            "describe": {},
+            "describe_configuration": {},
+            "sub_devices": [],
+            "custom_user_access": {},
         },
     )
 # fmt: on
@@ -438,7 +429,7 @@ def get_device_info_mock(device_name, device_class) -> messages.DeviceInfoMessag
         return EIGER_MSG
     device_base_class = "positioner" if device_class == "SimPositioner" else "signal"
     if device_base_class == "positioner":
-        signals = positioner_info_mock(device_name)["device_info"]["signals"]
+        signals = positioner_info_mock(device_name)["signals"]
     elif device_base_class == "signal":
         signals = {
             device_name: {
@@ -456,14 +447,11 @@ def get_device_info_mock(device_name, device_class) -> messages.DeviceInfoMessag
     else:
         signals = {}
     dev_info = {
-        "device_name": device_name,
-        "device_info": {
-            "device_dotted_name": device_name,
-            "device_attr_name": device_name,
-            "device_base_class": device_base_class,
-            "device_class": device_class.__class__.__name__,
-            "signals": signals,
-        },
+        "device_dotted_name": device_name,
+        "device_attr_name": device_name,
+        "device_base_class": device_base_class,
+        "device_class": device_class.__class__.__name__,
+        "signals": signals,
         "custom_user_access": {},
     }
     # fmt: on

--- a/bec_lib/bec_lib/tests/utils.py
+++ b/bec_lib/bec_lib/tests/utils.py
@@ -293,7 +293,6 @@ def positioner_info_mock_with_user_access(device_name):
 DYN_SIGNALS_MSG = messages.DeviceInfoMessage(
     device="dyn_signals",
     info={
-        "device_dotted_name": "dyn_signals",
         "device_attr_name": "dyn_signals",
         "device_base_class": "device",
         "device_class": "SimDevice",
@@ -310,7 +309,6 @@ DYN_SIGNALS_MSG = messages.DeviceInfoMessage(
         "sub_devices": [
             {
                 "device_attr_name": "messages",
-                "device_dotted_name": "messages",
                 "device_base_class": "device",
                 "device_class": "SimDevice",
                 "signals": {
@@ -369,7 +367,6 @@ DYN_SIGNALS_MSG = messages.DeviceInfoMessage(
 EIGER_MSG = messages.DeviceInfoMessage(
         device="eiger",
         info={
-            "device_dotted_name": "eiger",
             "device_attr_name": "eiger",
             "device_base_class": "device",
             "device_class": "SimCamera",
@@ -447,7 +444,6 @@ def get_device_info_mock(device_name, device_class) -> messages.DeviceInfoMessag
     else:
         signals = {}
     dev_info = {
-        "device_dotted_name": device_name,
         "device_attr_name": device_name,
         "device_base_class": device_base_class,
         "device_class": device_class.__class__.__name__,

--- a/bec_lib/tests/test_dap_plugins.py
+++ b/bec_lib/tests/test_dap_plugins.py
@@ -448,7 +448,7 @@ def test_dap_wait_for_dap_response_returns(dap):
 
 def test_dap_select(dap):
     with mock.patch.object(dap.GaussianModel, "_update_dap_config") as mock_update_dap_config:
-        obj = DeviceBase(name="samx", info={"device_info": {"hints": {"fields": ["samx"]}}})
+        obj = DeviceBase(name="samx", info={"hints": {"fields": ["samx"]}})
         dap._parent.device_manager.devices.get.return_value = obj
         dap.GaussianModel.select("samx")
         mock_update_dap_config.assert_called_once()
@@ -458,9 +458,7 @@ def test_dap_select(dap):
 def test_dap_select_raises_with_too_many_hints(dap):
     with pytest.raises(AttributeError):
         with mock.patch.object(dap.GaussianModel, "_update_dap_config") as mock_update_dap_config:
-            obj = DeviceBase(
-                name="samx", info={"device_info": {"hints": {"fields": ["samx", "samx2"]}}}
-            )
+            obj = DeviceBase(name="samx", info={"hints": {"fields": ["samx", "samx2"]}})
             dap._parent.device_manager.devices.get.return_value = obj
             dap.GaussianModel.select("samx")
             mock_update_dap_config.assert_called_once()

--- a/bec_server/bec_server/device_server/devices/device_serializer.py
+++ b/bec_server/bec_server/device_server/devices/device_serializer.py
@@ -309,7 +309,6 @@ def get_device_info(
         describe_configuration = {}
     return {
         "device_attr_name": getattr(obj, "attr_name", ""),
-        "device_dotted_name": getattr(obj, "dotted_name", ""),
         "device_base_class": get_device_base_class(obj),
         "device_class": obj.__class__.__name__,
         "ownership_mode": get_ownership_mode(obj).value,

--- a/bec_server/bec_server/device_server/devices/device_serializer.py
+++ b/bec_server/bec_server/device_server/devices/device_serializer.py
@@ -308,22 +308,19 @@ def get_device_info(
         describe = {}
         describe_configuration = {}
     return {
-        "device_name": obj.name,
-        "device_info": {
-            "device_attr_name": getattr(obj, "attr_name", ""),
-            "device_dotted_name": getattr(obj, "dotted_name", ""),
-            "device_base_class": get_device_base_class(obj),
-            "device_class": obj.__class__.__name__,
-            "ownership_mode": get_ownership_mode(obj).value,
-            "read_access": getattr(obj, "read_access", None),
-            "write_access": getattr(obj, "write_access", None),
-            "signals": signals,
-            "hints": hints,
-            "describe": describe,
-            "describe_configuration": describe_configuration,
-            "sub_devices": sub_devices,
-            "custom_user_access": user_access,
-        },
+        "device_attr_name": getattr(obj, "attr_name", ""),
+        "device_dotted_name": getattr(obj, "dotted_name", ""),
+        "device_base_class": get_device_base_class(obj),
+        "device_class": obj.__class__.__name__,
+        "ownership_mode": get_ownership_mode(obj).value,
+        "read_access": getattr(obj, "read_access", None),
+        "write_access": getattr(obj, "write_access", None),
+        "signals": signals,
+        "hints": hints,
+        "describe": describe,
+        "describe_configuration": describe_configuration,
+        "sub_devices": sub_devices,
+        "custom_user_access": user_access,
     }
 
 

--- a/bec_server/bec_server/scan_server/tests/scan_fixtures.py
+++ b/bec_server/bec_server/scan_server/tests/scan_fixtures.py
@@ -97,10 +97,8 @@ def device_manager(device_manager_class, session_from_test_config):
 class _MockDevice(DeviceBase):
     def __init__(self, name: str, limits=(-10.0, 10.0), value: float = 0.0):
         info = {
-            "device_info": {
-                "signals": {
-                    name: {"obj_name": name, "kind_str": "hinted", "describe": {"precision": 3}}
-                }
+            "signals": {
+                name: {"obj_name": name, "kind_str": "hinted", "describe": {"precision": 3}}
             }
         }
         super().__init__(name=name, info=info)
@@ -153,7 +151,7 @@ class MockCustomDevice(DeviceBase):
         Args:
             name (str): The name of the device.
             device_info (dict): A dictionary containing the device information, including signal definitions. Typically taken from
-                the "_info" field, e.g. dev.samx._info["signals"].
+                the "_info" field, e.g. dev.samx._info.
             signal_read_values (dict[str, float | Iterator], optional): A dictionary mapping signal names or their corresponding
                 obj_names to their read values. If a value is an iterator, the next value will be returned on each read. If not provided,
                 signals will return None. Note that the signal name should be the signal name, not the readout name (obj_name).
@@ -161,8 +159,7 @@ class MockCustomDevice(DeviceBase):
             precision (int, optional): The precision of the device. Defaults to 3.
             enabled (bool, optional): Whether the device is enabled. Defaults to True.
         """
-        info = {"device_info": device_info}
-        super().__init__(name=name, info=info)
+        super().__init__(name=name, info=device_info)
         self._limits = limits
         self._precision = precision
         self._enabled = enabled

--- a/bec_server/tests/tests_device_server/test_device_serializer.py
+++ b/bec_server/tests/tests_device_server/test_device_serializer.py
@@ -155,8 +155,8 @@ def test_get_device_info_allows_aliased_signal_names():
 
     info = get_device_info(device, connect=True)
 
-    assert info["device_info"]["signals"]["signal"]["obj_name"] == "test_signal"
-    assert info["device_info"]["signals"]["signal_alias"]["obj_name"] == "test_signal"
+    assert info["signals"]["signal"]["obj_name"] == "test_signal"
+    assert info["signals"]["signal_alias"]["obj_name"] == "test_signal"
 
 
 def test_get_device_info_marks_read_only_plain_signal_as_free():
@@ -164,7 +164,7 @@ def test_get_device_info_marks_read_only_plain_signal_as_free():
 
     info = get_device_info(signal, connect=False)
 
-    assert info["device_info"]["ownership_mode"] == "free"
+    assert info["ownership_mode"] == "free"
 
 
 def test_get_device_info_marks_writable_plain_signal_as_claimable():
@@ -172,7 +172,7 @@ def test_get_device_info_marks_writable_plain_signal_as_claimable():
 
     info = get_device_info(signal, connect=False)
 
-    assert info["device_info"]["ownership_mode"] == "claimable"
+    assert info["ownership_mode"] == "claimable"
 
 
 def test_get_device_info_marks_psi_devices_as_pinned():
@@ -180,7 +180,7 @@ def test_get_device_info_marks_psi_devices_as_pinned():
 
     info = get_device_info(device, connect=False)
 
-    assert info["device_info"]["ownership_mode"] == "pinned"
+    assert info["ownership_mode"] == "pinned"
 
 
 def test_get_device_info_prefers_explicit_class_ownership_mode():
@@ -188,7 +188,7 @@ def test_get_device_info_prefers_explicit_class_ownership_mode():
 
     info = get_device_info(device, connect=False)
 
-    assert info["device_info"]["ownership_mode"] == "free"
+    assert info["ownership_mode"] == "free"
 
 
 def test_get_device_info_raises_device_config_error_for_invalid_explicit_ownership_mode():


### PR DESCRIPTION
## Description

This PR simplifies the device info: https://github.com/bec-project/bec/pull/1007/changes#diff-48a79e17403712240993cc8b6d62287987743c8c3f9c064dbd858f64b491aea4L311

The device name is already part of the device info message so we don't need to add it to the info as well. With the device name gone, there is no need for a nesting. 

## Additional Comments

This should allow us to write a proper device info api more cleanly.

We need to update some tests in BW though.

## Definition of Done
- [ ] Documentation is up-to-date.

