### PR TITLE
Feature/v4 default scans

### DIFF
--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -26,6 +26,7 @@ on:
 jobs:
   pytest:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v6

--- a/bec_ipython_client/bec_ipython_client/callbacks/ipython_live_updates.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/ipython_live_updates.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import collections
 import time
 from contextvars import Token
 from typing import TYPE_CHECKING, Any
@@ -41,12 +40,9 @@ class IPythonLiveUpdates:
         """
         self.client = client
         self._interrupted_request = None
-        self._active_callback = None
         self._processed_instructions = 0
         self._active_request: messages.ScanQueueMessage | None = None
         self._user_callback = None
-        self._request_block_index = collections.defaultdict(lambda: 0)
-        self._request_block_id = None
         self._current_queue = None
         self._status_live: Live | None = None
 
@@ -68,9 +64,6 @@ class IPythonLiveUpdates:
         """
         if not self._active_request:
             return
-        scan_type = self._active_request.scan_type
-        if scan_type == "close_scan_group":
-            return
 
         if not report_instructions:
             return
@@ -90,62 +83,33 @@ class IPythonLiveUpdates:
             instr (dict): The instruction to process.
         """
         scan_report_type = list(instr.keys())[0]
-        scan_def_id = self.client.scans._scan_def_id
-        interactive_scan = self.client.scans._interactive_scan
         if self._active_request is None:
             # Already checked in caller method. It is just for type checking purposes.
             return
-        if scan_def_id is None or interactive_scan:
-            if scan_report_type == "readback":
-                LiveUpdatesReadbackProgressbar(
-                    self.client,
-                    report_instruction=instr,
-                    request=self._active_request,
-                    callbacks=self._user_callback,
-                ).run()
-            elif scan_report_type == "scan_progress":
-                LiveUpdatesTable(
-                    self.client,
-                    report_instruction=instr,
-                    request=self._active_request,
-                    callbacks=self._user_callback,
-                    print_table_data=self.print_table_data,
-                ).run()
-            elif scan_report_type == "device_progress":
-                LiveUpdatesDeviceProgress(
-                    self.client,
-                    report_instruction=instr,
-                    request=self._active_request,
-                    callbacks=self._user_callback,
-                ).run()
-            else:
-                raise ValueError(f"Unknown scan report type: {scan_report_type}")
-        else:
-            if self._active_callback:
-                if scan_report_type == "readback":
-                    LiveUpdatesReadbackProgressbar(
-                        self.client,
-                        report_instruction=instr,
-                        request=self._active_request,
-                        callbacks=self._user_callback,
-                    ).run()
-                else:
-                    self._active_callback.resume(
-                        request=self._active_request,
-                        report_instruction=instr,
-                        callbacks=self._user_callback,
-                    )
-
-                return
-
-            self._active_callback = LiveUpdatesTable(
+        if scan_report_type == "readback":
+            LiveUpdatesReadbackProgressbar(
+                self.client,
+                report_instruction=instr,
+                request=self._active_request,
+                callbacks=self._user_callback,
+            ).run()
+        elif scan_report_type == "scan_progress":
+            LiveUpdatesTable(
                 self.client,
                 report_instruction=instr,
                 request=self._active_request,
                 callbacks=self._user_callback,
                 print_table_data=self.print_table_data,
-            )
-            self._active_callback.run()
+            ).run()
+        elif scan_report_type == "device_progress":
+            LiveUpdatesDeviceProgress(
+                self.client,
+                report_instruction=instr,
+                request=self._active_request,
+                callbacks=self._user_callback,
+            ).run()
+        else:
+            raise ValueError(f"Unknown scan report type: {scan_report_type}")
 
     def _available_req_blocks(
         self, queue: QueueItem, request: messages.ScanQueueMessage
@@ -190,15 +154,14 @@ class IPythonLiveUpdates:
 
                 self._current_queue = queue = scan_request.scan_queue_request.queue
                 request_context.queue_status = queue.status
-                self._request_block_id = req_id = self._active_request.metadata.get("RID")
 
                 while queue.status not in ["COMPLETED", "ABORTED", "HALTED", "CANCELLED"]:
                     request_context.queue_status = queue.status
-                    if self._process_queue(queue, request, req_id):
+                    if self._process_queue(queue, request):
                         break
 
                 available_blocks = self._available_req_blocks(queue, request)
-                req_block = available_blocks[self._request_block_index[req_id]]
+                req_block = available_blocks[0]
                 report_instructions = req_block.report_instructions or []
                 self._process_report_instructions(report_instructions)
 
@@ -218,15 +181,15 @@ class IPythonLiveUpdates:
             self._interrupted_request = (request,)
             if self._current_queue and self.client._service_config.abort_on_ctrl_c:
                 self._wait_for_cleanup()
-            self._reset(forced=True)
+            self._reset()
             raise scan_interr
         except KeyboardInterrupt as exc:
             self._stop_status_live()
             if self.client._service_config.abort_on_ctrl_c and self._abort_pending_request():
                 self._wait_for_cleanup()
-                self._reset(forced=True)
+                self._reset()
                 raise ScanInterruption("User abort.") from exc
-            self._reset(forced=True)
+            self._reset()
             raise
         finally:
             if context_token is not None:
@@ -285,16 +248,13 @@ class IPythonLiveUpdates:
             return False
         return any(queue_item.queue_id == self._current_queue.queue_id for queue_item in queue_info)
 
-    def _process_queue(
-        self, queue: QueueItem, request: messages.ScanQueueMessage, req_id: str
-    ) -> bool:
+    def _process_queue(self, queue: QueueItem, request: messages.ScanQueueMessage) -> bool:
         """
         Process the queue and return True if the scan is completed.
 
         Args:
             queue(QueueItem): The queue item to process.
             request(messages.ScanQueueMessage): The request message.
-            req_id(str): The request ID.
 
         Returns:
             bool: True if the scan is completed.
@@ -321,10 +281,9 @@ class IPythonLiveUpdates:
         available_blocks = self._available_req_blocks(queue, request)
         if not available_blocks:
             return False
-        req_block = available_blocks[self._request_block_index[req_id]]
+        req_block = available_blocks[0]
         if req_block.msg.scan_type in [
-            "mv",
-            "_v4_mv",
+            "mv"
         ]:  # TODO: make this more general for all scan types that don't have report instructions
             return True
 
@@ -332,13 +291,6 @@ class IPythonLiveUpdates:
         if not report_instructions:
             return False
         self._process_report_instructions(report_instructions)
-
-        complete_rbl = len(available_blocks) == self._request_block_index[req_id] + 1
-        if self._active_callback and complete_rbl:
-            return True
-
-        if complete_rbl and self.client.scans._interactive_scan:
-            return True
 
         if not queue.active_request_block:
             return True
@@ -395,27 +347,15 @@ class IPythonLiveUpdates:
             self._status_live.update(Panel(message, title="[yellow]Scan Status[/yellow]"))
         return
 
-    def _reset(self, forced=False):
-        """Reset the active request and callback.
-
-        Args:
-            forced(bool): If True, the reset is forced.
-        """
+    def _reset(self):
+        """Reset the active request."""
         self._stop_status_live()
         self._interrupted_request = None
 
         self._current_queue = None
         self._user_callback = None
         self._processed_instructions = 0
-        scan_closed = forced or self._active_request is None
         self._active_request = None
-
-        if self.client.scans._scan_def_id and not scan_closed:
-            self._request_block_index[self._request_block_id] += 1
-            return
-
-        if scan_closed:
-            self._active_callback = None
 
     def continue_request(self):
         """Continue the interrupted request."""

--- a/bec_ipython_client/bec_ipython_client/callbacks/live_table.py
+++ b/bec_ipython_client/bec_ipython_client/callbacks/live_table.py
@@ -97,8 +97,6 @@ class LiveUpdatesTable(LiveUpdatesBase):
         """wait for scan completion"""
         while True:
             if self.scan_item.end_time:
-                if self.scan_item.open_queue_group:
-                    break
                 if self.scan_item.queue.queue_position is None:
                     break
             self.check_alarms()
@@ -109,13 +107,6 @@ class LiveUpdatesTable(LiveUpdatesBase):
     def check_alarms(self):
         """check for alarms"""
         check_alarms(self.bec)
-
-    def resume(self, request: messages.ScanQueueMessage, report_instruction: str, callbacks):
-        """resume the scan after a pause"""
-        super().__init__(
-            self.bec, request=request, report_instruction=report_instruction, callbacks=callbacks
-        )
-        self.process_request()
 
     @property
     def devices(self):

--- a/bec_ipython_client/demo.py
+++ b/bec_ipython_client/demo.py
@@ -145,13 +145,6 @@ scans.umv(dev.samx, 5, dev.samy, 20, relative=False)
 # s = scans.line_scan(dev.samy, -5, 40, steps=10, exp_time=0.1)
 # s = scans.round_roi_scan(dev.samx, 50, dev.samy, 20, dr=2, nth=3, exp_time=0.1)
 
-# scan_def_id = str(uuid.uuid4())
-# scans.open_interactive_scan(dev.samx, dev.samy, exp_time=0.1, md={"scan_def_id": scan_def_id})
-# for ii in range(5):
-#     scans.mv(dev.samx, ii, dev.samy, ii + 3, md={"scan_def_id": scan_def_id})
-#     scans.interactive_scan_trigger(dev.samx, dev.samy, md={"scan_def_id": scan_def_id})
-# scans.close_interactive_scan(md={"scan_def_id": scan_def_id})
-
 
 # for ii in range(10):
 #     scans.umv(dev.samx, ii * 10)
@@ -162,15 +155,6 @@ scans.umv(dev.samx, 5, dev.samy, 20, relative=False)
 # s = scans.grid_scan(dev.samx, -5, 5, 100, dev.samy, -5, 5, 100, exp_time=0.0, hide_report=True)
 # scans.umv(dev.samx, 0)
 # scans.grid_scan(dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=0.02)
-
-
-# @scans.scan_group
-# def scan_with_decorator():
-#     scans.umv(dev.samx, 5, relative=False)
-#     scans.line_scan(dev.samx, -5, 5, steps=100, exp_time=0.1, relative=True)
-#     scans.umv(dev.samx, 5, relative=False)
-#     scans.line_scan(dev.samx, -5, 5, steps=100, exp_time=0.1, relative=True)
-#     # scans.line_scan(dev.samx, -8, 8, steps=200, exp_time=0.1, relative=True)
 
 
 # with scans.dataset_id_on_hold:
@@ -185,22 +169,6 @@ scans.umv(dev.samx, 5, dev.samy, 20, relative=False)
 # scans.umv(dev.samx, 500)
 # print(dev.samx.read(cached=True, use_readback=True))
 # scans.umv(dev.samx, 1000)
-
-
-# @scans.scan_group
-# def alignment(*args, **kwargs):
-#     scans.grid_scan(dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=0.02)
-#     scans.umv(dev.samx, 10)
-#     scans.grid_scan(dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=0.02)
-#     scans.umv(dev.samx, 10)
-#     scans.grid_scan(dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=0.02)
-
-
-# with scans.scan_group:
-#     scans.grid_scan(dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=0.02, relative=True)
-#     scans.umv(dev.samx, 10, relative=True)
-
-# alignment()
 
 
 # scans.grid_scan(dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=0.02, md={"queue_group": queue_group})

--- a/bec_ipython_client/tests/client_tests/test_ipython_live_updates.py
+++ b/bec_ipython_client/tests/client_tests/test_ipython_live_updates.py
@@ -107,7 +107,7 @@ def test_live_updates_process_queue_pending(ipython_live_updates_with_mocked_liv
                 live_updates, "_available_req_blocks", return_value=[request_block]
             ):
                 with mock.patch.object(live_updates, "_process_report_instructions") as process:
-                    res = live_updates._process_queue(queue, request_msg, "req_id")
+                    res = live_updates._process_queue(queue, request_msg)
                     # Verify Live panel was created for showing queue status
                     mock_live.assert_called_once()
                     mock_live.return_value.start.assert_called_once()
@@ -141,7 +141,7 @@ def test_live_updates_process_queue_running(ipython_live_updates_with_mocked_liv
                 live_updates, "_available_req_blocks", return_value=[request_block]
             ):
                 with mock.patch.object(live_updates, "_process_instruction") as process:
-                    res = live_updates._process_queue(queue, request_msg, "req_id")
+                    res = live_updates._process_queue(queue, request_msg)
                     mock_live.assert_not_called()
                     process.assert_called_once_with({"wait_table": 10})
                     assert res is True
@@ -177,7 +177,7 @@ def test_live_updates_process_queue_waiting_for_device_locks(
     ):
         queue_pos.return_value = 0
 
-        assert live_updates._process_queue(queue, request_msg, "req_id") is False
+        assert live_updates._process_queue(queue, request_msg) is False
 
     process_pending.assert_called_once_with(queue)
 
@@ -214,7 +214,7 @@ def test_live_updates_process_queue_cancelled_pending_request_raises_interruptio
         mock.patch("bec_lib.queue_items.QueueItem.queue_position", new_callable=mock.PropertyMock),
         pytest.raises(ScanInterruption, match="Scan was cancelled."),
     ):
-        live_updates._process_queue(queue, request_msg, "something")
+        live_updates._process_queue(queue, request_msg)
 
 
 def test_live_updates_process_queue_stopped_started_request_raises_interruption(bec_client_mock):
@@ -259,7 +259,7 @@ def test_live_updates_process_queue_stopped_started_request_raises_interruption(
         mock.patch("bec_lib.queue_items.QueueItem.queue_position", new_callable=mock.PropertyMock),
         pytest.raises(ScanInterruption, match="Scan 1 was aborted by user."),
     ):
-        live_updates._process_queue(queue, request_msg, "something")
+        live_updates._process_queue(queue, request_msg)
 
 
 def test_live_updates_process_queue_stopped_restart_without_restart_message_waits_nonblocking(
@@ -300,7 +300,7 @@ def test_live_updates_process_queue_stopped_restart_without_restart_message_wait
             return_value=mock.MagicMock(status="aborted", restarted_msg=None),
         ),
     ):
-        assert live_updates._process_queue(queue, request_msg, "something") is False
+        assert live_updates._process_queue(queue, request_msg) is False
 
 
 def test_process_request_repeats_on_ScanRestart_error(
@@ -485,7 +485,7 @@ def test_process_request_keyboard_interrupt_pending_request_raises_scan_interrup
 
     abort_pending.assert_called_once()
     wait_for_cleanup.assert_called_once()
-    reset.assert_called_once_with(forced=True)
+    reset.assert_called_once_with()
 
 
 @pytest.mark.parametrize("queue_status", ["RUNNING", "LOCKED"])
@@ -515,7 +515,7 @@ def test_process_request_keyboard_interrupt_pending_request_aborts_local_request
 
     request_abort.assert_called_once_with(request_id="something")
     wait_for_cleanup.assert_called_once()
-    reset.assert_called_once_with(forced=True)
+    reset.assert_called_once_with()
 
 
 def test_process_request_keyboard_interrupt_non_pending_re_raises(
@@ -543,7 +543,7 @@ def test_process_request_keyboard_interrupt_non_pending_re_raises(
 
     abort_pending.assert_called_once()
     wait_for_cleanup.assert_not_called()
-    reset.assert_called_once_with(forced=True)
+    reset.assert_called_once_with()
 
 
 @pytest.mark.timeout(20)
@@ -552,7 +552,7 @@ def test_live_updates_process_queue_without_status(bec_client_mock, queue_elemen
     live_updates = IPythonLiveUpdates(client)
     queue, _, request_msg = queue_elements
     with mock.patch.object(queue, "_update_with_buffer"):
-        assert live_updates._process_queue(queue, request_msg, "req_id") is False
+        assert live_updates._process_queue(queue, request_msg) is False
 
 
 @pytest.mark.timeout(20)
@@ -574,7 +574,7 @@ def test_live_updates_process_queue_without_queue_number(bec_client_mock, queue_
         )
         queue_pos.return_value = None
         with mock.patch.object(queue, "_update_with_buffer"):
-            assert live_updates._process_queue(queue, request_msg, "req_id") is False
+            assert live_updates._process_queue(queue, request_msg) is False
 
 
 @pytest.mark.timeout(20)

--- a/bec_ipython_client/tests/end-2-end/test_acl_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_acl_e2e.py
@@ -12,6 +12,9 @@ from bec_lib.tests.utils import wait_for_empty_queue
 from bec_lib.utils.user_acls_test import BECAccessDemo
 from bec_server.bec_server_utils.service_handler import ServiceHandler
 
+CLIENT_SHUTDOWN_TIMEOUT_S = 10
+SERVICE_STOP_TIMEOUT_S = 20
+
 
 @pytest.fixture
 def acl_enabled_bec_services(
@@ -61,7 +64,7 @@ def acl_enabled_bec_services(
         yield bec_services_config_file_path
     finally:
         if processes is not None:
-            service_handler.stop(processes)
+            service_handler.stop(processes, timeout_s=SERVICE_STOP_TIMEOUT_S)
         restore_connector = RedisConnector(redis_url)
         try:
             BECAccessDemo(restore_connector).reset()
@@ -77,7 +80,7 @@ def test_acl_admin_server_allows_default_user_scan(acl_enabled_bec_services):
     try:
         admin_client.config.load_demo_config(force=True)
     finally:
-        admin_client.shutdown()
+        admin_client.shutdown(per_thread_timeout_s=CLIENT_SHUTDOWN_TIMEOUT_S)
         admin_client._client._reset_singleton()
 
     user_config = ServiceConfig(acl_enabled_bec_services, acl={"env_file": "", "user": "user"})
@@ -97,7 +100,7 @@ def test_acl_admin_server_allows_default_user_scan(acl_enabled_bec_services):
 
         assert status.scan.num_points == 3
     finally:
-        user_client.shutdown()
+        user_client.shutdown(per_thread_timeout_s=CLIENT_SHUTDOWN_TIMEOUT_S)
         user_client._client._reset_singleton()
 
 
@@ -136,5 +139,5 @@ def test_acl_account_endpoint_allows_user_read_but_admin_only_write(acl_enabled_
         assert user_client.username == "user"
         assert user_client.connector.get_last(account_endpoint, "data") == updated_account_msg
     finally:
-        user_client.shutdown()
+        user_client.shutdown(per_thread_timeout_s=CLIENT_SHUTDOWN_TIMEOUT_S)
         user_client._client._reset_singleton()

--- a/bec_ipython_client/tests/end-2-end/test_scans_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_scans_e2e.py
@@ -303,6 +303,7 @@ def test_umv_ctrl_c_stops_motion(bec_ipython_client_fixture: BECIPythonClient):
         dev.samx.velocity.set(original_velocity).wait()
 
 
+@pytest.mark.timeout(100)
 def test_limit_error(bec_ipython_client_fixture):
     bec = bec_ipython_client_fixture
     bec.metadata.update({"unit_test": "test_limit_error"})

--- a/bec_ipython_client/tests/end-2-end/test_scans_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_scans_e2e.py
@@ -31,16 +31,13 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 @pytest.mark.timeout(100)
-@pytest.mark.parametrize("scan_name", ["grid_scan", "_v4_grid_scan"])
-def test_grid_scan(capsys, bec_ipython_client_fixture, scan_name):
+def test_grid_scan(capsys, bec_ipython_client_fixture):
     bec = bec_ipython_client_fixture
     scans = bec.scans
     bec.metadata.update({"unit_test": "test_grid_scan"})
     dev = bec.device_manager.devices
     scans.umv(dev.samx, 0, dev.samy, 0, relative=False)
-    status = getattr(scans, scan_name)(
-        dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=0.01, relative=True
-    )
+    status = scans.grid_scan(dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=0.01, relative=True)
     assert len(status.scan.live_data) == 100
     assert status.scan.num_points == 100
     captured = capsys.readouterr()
@@ -48,13 +45,12 @@ def test_grid_scan(capsys, bec_ipython_client_fixture, scan_name):
 
 
 @pytest.mark.timeout(100)
-@pytest.mark.parametrize("scan_name", ["fermat_scan", "_v4_fermat_scan"])
-def test_fermat_scan(capsys, bec_ipython_client_fixture, scan_name):
+def test_fermat_scan(capsys, bec_ipython_client_fixture):
     bec = bec_ipython_client_fixture
     scans = bec.scans
     bec.metadata.update({"unit_test": "test_fermat_scan"})
     dev = bec.device_manager.devices
-    status = getattr(scans, scan_name)(
+    status = scans.fermat_scan(
         dev.samx,
         -5,
         5,
@@ -66,25 +62,19 @@ def test_fermat_scan(capsys, bec_ipython_client_fixture, scan_name):
         relative=True,
         optim_trajectory="corridor",
     )
-    if scan_name == "_v4_fermat_scan":
-        # NOTE: v4 scan calculates the angle more accurately, which results in a slightly different number of points
-        assert len(status.scan.live_data) == 400
-        assert status.scan.num_points == 400
-    else:
-        assert len(status.scan.live_data) == 393
-        assert status.scan.num_points == 393
+    assert len(status.scan.live_data) == 400
+    assert status.scan.num_points == 400
     captured = capsys.readouterr()
     assert "finished. Scan ID" in captured.out
 
 
 @pytest.mark.timeout(100)
-@pytest.mark.parametrize("scan_name", ["line_scan", "_v4_line_scan"])
-def test_line_scan(capsys, bec_ipython_client_fixture, scan_name):
+def test_line_scan(capsys, bec_ipython_client_fixture):
     bec = bec_ipython_client_fixture
     scans = bec.scans
     bec.metadata.update({"unit_test": "test_line_scan"})
     dev = bec.device_manager.devices
-    status = getattr(scans, scan_name)(
+    status = scans.line_scan(
         dev.samx, -5, 5, dev.samy, -5, 5, steps=10, exp_time=0.01, relative=True
     )
     assert len(status.scan.live_data) == 10
@@ -95,13 +85,12 @@ def test_line_scan(capsys, bec_ipython_client_fixture, scan_name):
 
 @pytest.mark.flaky  # marked as flaky as the simulation might return a new readback value within the tolerance
 @pytest.mark.timeout(100)
-@pytest.mark.parametrize("scan_name", [("mv", "umv"), ("_v4_mv", "_v4_umv")])
-def test_mv_scan(capsys, bec_ipython_client_fixture, scan_name):
+def test_mv_scan(capsys, bec_ipython_client_fixture):
     bec = bec_ipython_client_fixture
     scans = bec.scans
     bec.metadata.update({"unit_test": "test_mv_scan"})
     dev = bec.device_manager.devices
-    getattr(scans, scan_name[0])(dev.samx, 10, dev.samy, 20, relative=False).wait()
+    scans.mv(dev.samx, 10, dev.samy, 20, relative=False).wait()
     current_pos_samx = dev.samx.read(cached=True)["samx"]["value"]
     current_pos_samy = dev.samy.read(cached=True)["samy"]["value"]
     assert np.isclose(
@@ -110,7 +99,7 @@ def test_mv_scan(capsys, bec_ipython_client_fixture, scan_name):
     assert np.isclose(
         current_pos_samy, 20, atol=dev.samy._config["deviceConfig"].get("tolerance", 0.05)
     )
-    getattr(scans, scan_name[1])(dev.samx, 10, dev.samy, 20, relative=False)
+    scans.umv(dev.samx, 10, dev.samy, 20, relative=False)
     current_pos_samx = dev.samx.read(cached=True)["samx"]["value"]
     current_pos_samy = dev.samy.read(cached=True)["samy"]["value"]
     captured = capsys.readouterr()
@@ -122,13 +111,12 @@ def test_mv_scan(capsys, bec_ipython_client_fixture, scan_name):
 
 @pytest.mark.flaky  # marked as flaky as the simulation might return a new readback value within the tolerance
 @pytest.mark.timeout(100)
-@pytest.mark.parametrize("scan_name", [("mv", "umv"), ("_v4_mv", "_v4_umv")])
-def test_mv_scan_nested_device(capsys, bec_ipython_client_fixture, scan_name):
+def test_mv_scan_nested_device(capsys, bec_ipython_client_fixture):
     bec = bec_ipython_client_fixture
     scans = bec.scans
     bec.metadata.update({"unit_test": "test_mv_scan_nested_device"})
     dev = bec.device_manager.devices
-    getattr(scans, scan_name[0])(dev.hexapod.x, 10, dev.hexapod.y, 20, relative=False).wait()
+    scans.mv(dev.hexapod.x, 10, dev.hexapod.y, 20, relative=False).wait()
     if not bec.connector._managed_connection._message_callbacks_queue.empty():
         print("Waiting for messages to be processed")
         time.sleep(0.5)
@@ -140,7 +128,7 @@ def test_mv_scan_nested_device(capsys, bec_ipython_client_fixture, scan_name):
     assert np.isclose(
         current_pos_hexapod_y, 20, atol=dev.hexapod._config["deviceConfig"].get("tolerance", 0.5)
     )
-    getattr(scans, scan_name[1])(dev.hexapod.x, 10, dev.hexapod.y, 20, relative=False)
+    scans.umv(dev.hexapod.x, 10, dev.hexapod.y, 20, relative=False)
     if not bec.connector._managed_connection._message_callbacks_queue.empty():
         print("Waiting for messages to be processed")
         time.sleep(0.5)
@@ -159,8 +147,7 @@ def test_mv_scan_nested_device(capsys, bec_ipython_client_fixture, scan_name):
 
 
 @pytest.mark.timeout(100)
-@pytest.mark.parametrize("scan_name", [("umv", "grid_scan"), ("_v4_umv", "_v4_grid_scan")])
-def test_mv_scan_mv(bec_ipython_client_fixture, scan_name):
+def test_mv_scan_mv(bec_ipython_client_fixture):
     bec = bec_ipython_client_fixture
     scans = bec.scans
     bec.metadata.update({"unit_test": "test_mv_scan_mv"})
@@ -169,7 +156,7 @@ def test_mv_scan_mv(bec_ipython_client_fixture, scan_name):
 
     dev.samx.limits = [-50, 50]
     dev.samy.limits = [-50, 50]
-    getattr(scans, scan_name[0])(dev.samx, 10, dev.samy, 20, relative=False)
+    scans.umv(dev.samx, 10, dev.samy, 20, relative=False)
     tolerance_samx = dev.samx._config["deviceConfig"].get("tolerance", 0.05)
     tolerance_samy = dev.samy._config["deviceConfig"].get("tolerance", 0.05)
     current_pos_samx = dev.samx.read()["samx"]["value"]
@@ -179,9 +166,7 @@ def test_mv_scan_mv(bec_ipython_client_fixture, scan_name):
     assert np.isclose(current_pos_samx, 10, atol=tolerance_samx)
     assert np.isclose(current_pos_samy, 20, atol=tolerance_samy)
 
-    status = getattr(scans, scan_name[1])(
-        dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=0.01, relative=True
-    )
+    status = scans.grid_scan(dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=0.01, relative=True)
 
     # make sure the scan completed the expected number of positions
     assert len(status.scan.live_data) == 100
@@ -201,7 +186,7 @@ def test_mv_scan_mv(bec_ipython_client_fixture, scan_name):
     assert np.isclose(current_pos_samx, 10, atol=tolerance_samx * 2)
     assert np.isclose(current_pos_samy, 20, atol=tolerance_samy * 2)
 
-    getattr(scans, scan_name[0])(dev.samx, 20, dev.samy, -20, relative=False)
+    scans.umv(dev.samx, 20, dev.samy, -20, relative=False)
     current_pos_samx = dev.samx.read()["samx"]["value"]
     current_pos_samy = dev.samy.read()["samy"]["value"]
 
@@ -209,7 +194,7 @@ def test_mv_scan_mv(bec_ipython_client_fixture, scan_name):
     assert np.isclose(current_pos_samx, 20, atol=tolerance_samx)
     assert np.isclose(current_pos_samy, -20, atol=tolerance_samy)
 
-    status = getattr(scans, scan_name[1])(
+    status = scans.grid_scan(
         dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=0.01, relative=False
     )
 
@@ -226,8 +211,7 @@ def test_mv_scan_mv(bec_ipython_client_fixture, scan_name):
 
 
 @pytest.mark.timeout(100)
-@pytest.mark.parametrize("scan_name", ["line_scan", "_v4_line_scan"])
-def test_scan_abort(bec_ipython_client_fixture: BECIPythonClient, scan_name: str):
+def test_scan_abort(bec_ipython_client_fixture: BECIPythonClient):
     def send_abort(bec):
         while True:
             current_scan_info = bec.queue.scan_storage.current_scan_info
@@ -256,7 +240,7 @@ def test_scan_abort(bec_ipython_client_fixture: BECIPythonClient, scan_name: str
     aborted_scan = False
     try:
         threading.Thread(target=send_abort, args=(bec,), daemon=True).start()
-        getattr(scans, scan_name)(dev.samx, -5, 5, steps=200, exp_time=0.1, relative=True)
+        scans.line_scan(dev.samx, -5, 5, steps=200, exp_time=0.1, relative=True)
     except ScanInterruption:
         logger.info("Raised ScanInterruption")
         time.sleep(2)
@@ -273,7 +257,7 @@ def test_scan_abort(bec_ipython_client_fixture: BECIPythonClient, scan_name: str
 
     assert len(bec.queue.scan_storage.storage[-1].live_data) < 200
 
-    getattr(scans, scan_name)(dev.samx, -5, 5, steps=10, exp_time=0.1, relative=True)
+    scans.line_scan(dev.samx, -5, 5, steps=10, exp_time=0.1, relative=True)
     scan_number_end = bec.queue.next_scan_number
     assert scan_number_end == scan_number_start + 2
 
@@ -319,8 +303,7 @@ def test_umv_ctrl_c_stops_motion(bec_ipython_client_fixture: BECIPythonClient):
         dev.samx.velocity.set(original_velocity).wait()
 
 
-@pytest.mark.parametrize("scan_name", [("line_scan", "umv"), ("_v4_line_scan", "_v4_umv")])
-def test_limit_error(bec_ipython_client_fixture, scan_name):
+def test_limit_error(bec_ipython_client_fixture):
     bec = bec_ipython_client_fixture
     bec.metadata.update({"unit_test": "test_limit_error"})
     scan_number_start = bec.queue.next_scan_number
@@ -329,7 +312,7 @@ def test_limit_error(bec_ipython_client_fixture, scan_name):
     aborted_scan = False
     dev.samx.limits = [-50, 50]
     try:
-        getattr(scans, scan_name[0])(dev.samx, -520, 5, steps=200, exp_time=0.1, relative=False)
+        scans.line_scan(dev.samx, -520, 5, steps=200, exp_time=0.1, relative=False)
     except AlarmBase as alarm:
         assert alarm.alarm_type == "LimitError"
         aborted_scan = True
@@ -339,7 +322,7 @@ def test_limit_error(bec_ipython_client_fixture, scan_name):
     aborted_scan = False
     dev.samx.limits = [-50, 50]
     try:
-        getattr(scans, scan_name[1])(dev.samx, 500, relative=False)
+        scans.umv(dev.samx, 500, relative=False)
     except AlarmBase as alarm:
         assert alarm.alarm_type == "LimitError"
         aborted_scan = True
@@ -350,17 +333,16 @@ def test_limit_error(bec_ipython_client_fixture, scan_name):
 
 
 @pytest.mark.timeout(100)
-@pytest.mark.parametrize("scan_name", ["line_scan", "_v4_line_scan"])
-def test_queued_scan(bec_ipython_client_fixture, scan_name):
+def test_queued_scan(bec_ipython_client_fixture):
     bec = bec_ipython_client_fixture
     bec.metadata.update({"unit_test": "test_queued_scan"})
     scan_number_start = bec.queue.next_scan_number
     scans = bec.scans
     dev = bec.device_manager.devices
-    scan1 = getattr(scans, scan_name)(
+    scan1 = scans.line_scan(
         dev.samx, -5, 5, steps=100, exp_time=0.1, hide_report=True, relative=True
     )
-    scan2 = getattr(scans, scan_name)(
+    scan2 = scans.line_scan(
         dev.samx, -5, 5, steps=50, exp_time=0.1, hide_report=True, relative=True
     )
 
@@ -394,8 +376,7 @@ def test_fly_scan(bec_ipython_client_fixture):
 
 
 @pytest.mark.timeout(100)
-@pytest.mark.parametrize("scan_name", ["line_scan", "_v4_line_scan"])
-def test_scan_restart(bec_ipython_client_fixture, scan_name):
+def test_scan_restart(bec_ipython_client_fixture):
     bec = bec_ipython_client_fixture
     bec.metadata.update({"unit_test": "test_scan_restart"})
     scans = bec.scans
@@ -417,12 +398,10 @@ def test_scan_restart(bec_ipython_client_fixture, scan_name):
 
     # We start two scans to ensure that the scan restart logic works correctly in a queued scenario
     # The first scan is started without printout to allow us to submit the second scan immediately after
-    getattr(scans, scan_name)(
-        dev.samx, -5, 5, steps=50, exp_time=0.1, hide_report=True, relative=True
-    )
+    scans.line_scan(dev.samx, -5, 5, steps=50, exp_time=0.1, hide_report=True, relative=True)
 
     # The second scan is using the live table printout. It should properly continue after the restart
-    scan2 = getattr(scans, scan_name)(dev.samx, -5, 5, steps=50, exp_time=0.1, relative=True)
+    scan2 = scans.line_scan(dev.samx, -5, 5, steps=50, exp_time=0.1, relative=True)
 
     scan2.wait()
 
@@ -435,8 +414,7 @@ def test_scan_restart(bec_ipython_client_fixture, scan_name):
 
 
 @pytest.mark.timeout(100)
-@pytest.mark.parametrize("scan_name", ["line_scan", "_v4_line_scan"])
-def test_scan_observer_repeat_queued(bec_ipython_client_fixture: BECIPythonClient, scan_name):
+def test_scan_observer_repeat_queued(bec_ipython_client_fixture: BECIPythonClient):
     bec = bec_ipython_client_fixture
     bec.metadata.update({"unit_test": "test_scan_observer_repeat_queued"})
     scans = bec.scans
@@ -458,10 +436,10 @@ def test_scan_observer_repeat_queued(bec_ipython_client_fixture: BECIPythonClien
     # start repeat thread
     threading.Thread(target=send_repeat, args=(bec,), daemon=True).start()
     # start scan
-    scan1 = getattr(scans, scan_name)(
+    scan1 = scans.line_scan(
         dev.samx, -5, 5, steps=100, exp_time=0.1, hide_report=True, relative=True
     )
-    scan2 = getattr(scans, scan_name)(
+    scan2 = scans.line_scan(
         dev.samx, -5, 5, steps=100, exp_time=0.1, hide_report=True, relative=True
     )
 
@@ -476,8 +454,7 @@ def test_scan_observer_repeat_queued(bec_ipython_client_fixture: BECIPythonClien
 
 
 @pytest.mark.timeout(100)
-@pytest.mark.parametrize("scan_name", ["line_scan", "_v4_line_scan"])
-def test_scan_observer_repeat(bec_ipython_client_fixture, scan_name):
+def test_scan_observer_repeat(bec_ipython_client_fixture):
     bec = bec_ipython_client_fixture
     bec.metadata.update({"unit_test": "test_scan_observer_repeat"})
     scans = bec.scans
@@ -497,7 +474,7 @@ def test_scan_observer_repeat(bec_ipython_client_fixture, scan_name):
     threading.Thread(target=send_repeat, args=(bec,), daemon=True).start()
     # start scan
     with pytest.raises(ScanAbortion):
-        scan1 = getattr(scans, scan_name)(
+        scan1 = scans.line_scan(
             dev.samx, -5, 5, steps=50, exp_time=0.1, hide_report=True, relative=True
         )
         scan1.wait()
@@ -512,8 +489,7 @@ def test_scan_observer_repeat(bec_ipython_client_fixture, scan_name):
 
 
 @pytest.mark.timeout(100)
-@pytest.mark.parametrize("scan_name", ["grid_scan", "_v4_grid_scan"])
-def test_file_writer(bec_ipython_client_fixture, scan_name):
+def test_file_writer(bec_ipython_client_fixture):
     bec = bec_ipython_client_fixture
     bec.metadata.update({"unit_test": "test_file_writer"})
     scans = bec.scans
@@ -523,7 +499,7 @@ def test_file_writer(bec_ipython_client_fixture, scan_name):
     dev.samx.velocity.set(98).wait()
     dev.samy.velocity.set(101).wait()
 
-    scan = getattr(scans, scan_name)(
+    scan = scans.grid_scan(
         dev.samx,
         -5,
         5,
@@ -576,37 +552,21 @@ def test_file_writer(bec_ipython_client_fixture, scan_name):
 
 
 @pytest.mark.timeout(100)
-def test_group_def(bec_ipython_client_fixture):
-    bec = bec_ipython_client_fixture
-    bec.metadata.update({"unit_test": "test_group_def"})
-    scans = bec.scans
-    dev = bec.device_manager.devices
-    scan_number = bec.queue.next_scan_number
-    with scans.scan_group:
-        scans.line_scan(dev.samx, -5, 5, steps=10, exp_time=0.1, relative=False)
-        scans.umv(dev.samy, 5, relative=False)
-        scans.line_scan(dev.samx, -5, 5, steps=10, exp_time=0.1, relative=False)
-
-    assert scan_number == bec.queue.next_scan_number - 2
-
-
-@pytest.mark.timeout(100)
-@pytest.mark.parametrize("scan_name", ["list_scan", "_v4_list_scan"])
-def test_list_scan(bec_ipython_client_fixture, scan_name):
+def test_list_scan(bec_ipython_client_fixture):
     bec = bec_ipython_client_fixture
     bec.metadata.update({"unit_test": "test_list_scan"})
     scans = bec.scans
     dev = bec.device_manager.devices
 
-    status = getattr(scans, scan_name)(
+    status = scans.list_scan(
         dev.samx, [0, 1, 2, 3, 4], dev.samy, [0, 1, 2, 3, 4], exp_time=0.1, relative=False
     )
     assert len(status.scan.live_data) == 5
 
-    status = getattr(scans, scan_name)(dev.samx, [0, 1, 2, 3, 4, 5], exp_time=0.1, relative=False)
+    status = scans.list_scan(dev.samx, [0, 1, 2, 3, 4, 5], exp_time=0.1, relative=False)
     assert len(status.scan.live_data) == 6
 
-    status = getattr(scans, scan_name)(
+    status = scans.list_scan(
         dev.samx,
         [0, 1, 2, 3],
         dev.samy,
@@ -624,7 +584,7 @@ def test_time_scan(bec_ipython_client_fixture):
     bec = bec_ipython_client_fixture
     bec.metadata.update({"unit_test": "test_time_scan"})
     scans = bec.scans
-    status = scans.time_scan(points=5, interval=0.5, exp_time=0.1, relative=False)
+    status = scans.time_scan(points=5, interval=0.5, exp_time=0.1)
     assert len(status.scan.live_data) == 5
 
 
@@ -881,8 +841,7 @@ def test_grid_scan_secondary_queue(capsys, bec_ipython_client_fixture):
 
 
 @pytest.mark.timeout(100)
-@pytest.mark.parametrize("scan_name", ["line_scan", "_v4_line_scan"])
-def test_scan_after_scan_lock(capsys, bec_ipython_client_fixture, scan_name):
+def test_scan_after_scan_lock(capsys, bec_ipython_client_fixture):
     """
     Test that pending scans are properly executed after a scan lock is released.
     """
@@ -891,10 +850,8 @@ def test_scan_after_scan_lock(capsys, bec_ipython_client_fixture, scan_name):
     bec.metadata.update({"unit_test": "test_scan_after_scan_lock"})
     dev = bec.device_manager.devices
     bec.queue.add_queue_lock(queue="primary", reason="unit_test_scan_lock", lock_id="test_lock")
-    getattr(scans, scan_name)(
-        dev.samx, -5, 5, steps=10, exp_time=0.01, relative=True, hide_report=True
-    )
-    scan2 = getattr(scans, scan_name)(
+    scans.line_scan(dev.samx, -5, 5, steps=10, exp_time=0.01, relative=True, hide_report=True)
+    scan2 = scans.line_scan(
         dev.samx, -5, 5, steps=10, exp_time=0.01, relative=True, hide_report=True
     )
 
@@ -908,8 +865,7 @@ def test_scan_after_scan_lock(capsys, bec_ipython_client_fixture, scan_name):
 
 
 @pytest.mark.timeout(100)
-@pytest.mark.parametrize("scan_name", ["line_scan", "_v4_line_scan"])
-def test_scan_repeat_decorator(bec_ipython_client_fixture, scan_name):
+def test_scan_repeat_decorator(bec_ipython_client_fixture):
     """
     Test the scan_repeat decorator by simulating a communication failure during a scan.
     The scan should be retried according to the specified max_repeats and exc_handler.
@@ -953,9 +909,7 @@ def test_scan_repeat_decorator(bec_ipython_client_fixture, scan_name):
 
     @scan_repeat(max_repeats=2, exc_handler=exc_handler)
     def my_scan():
-        getattr(scans, scan_name)(
-            dev.positioner_with_failure, -5, 5, steps=10, exp_time=0.01, relative=True
-        )
+        scans.line_scan(dev.positioner_with_failure, -5, 5, steps=10, exp_time=0.01, relative=True)
 
     my_scan()
 
@@ -965,10 +919,7 @@ def test_scan_repeat_decorator(bec_ipython_client_fixture, scan_name):
 
 
 @pytest.mark.timeout(100)
-@pytest.mark.parametrize(
-    "scan_name", [("grid_scan", "line_scan"), ("_v4_grid_scan", "_v4_line_scan")]
-)
-def test_scan_set_completed(bec_ipython_client_fixture, scan_name):
+def test_scan_set_completed(bec_ipython_client_fixture):
     """
     Test that a scan can be manually set to completed.
     """
@@ -988,9 +939,7 @@ def test_scan_set_completed(bec_ipython_client_fixture, scan_name):
 
     threading.Thread(target=_set_scan_completed, args=(bec,), daemon=True).start()
 
-    getattr(scans, scan_name[0])(
-        dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=0.01, relative=True
-    )
+    scans.grid_scan(dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=0.01, relative=True)
 
     # Now add a second scan to ensure scans can continue after setting completed
-    getattr(scans, scan_name[1])(dev.samx, -5, 5, steps=10, exp_time=0.01, relative=True)
+    scans.line_scan(dev.samx, -5, 5, steps=10, exp_time=0.01, relative=True)

--- a/bec_ipython_client/tests/end-2-end/test_scans_lib_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_scans_lib_e2e.py
@@ -346,6 +346,7 @@ def test_dap_fit(bec_client_lib):
         "invalid_device_class",
     ],
 )
+@pytest.mark.timeout(100)
 def test_config_reload(
     bec_test_config_file_path, bec_client_lib, config, raises_error, deletes_config, disabled_device
 ):

--- a/bec_ipython_client/tests/end-2-end/test_scans_lib_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_scans_lib_e2e.py
@@ -16,31 +16,25 @@ logger = bec_logger.logger
 
 
 @pytest.mark.timeout(100)
-@pytest.mark.parametrize("scan_name", [("umv", "grid_scan"), ("_v4_umv", "_v4_grid_scan")])
-def test_grid_scan_lib(bec_client_lib, scan_name):
+def test_grid_scan_lib(bec_client_lib):
     bec = bec_client_lib
     scans = bec.scans
     bec.metadata.update({"unit_test": "test_grid_scan_bec_client_lib"})
     dev = bec.device_manager.devices
-    getattr(scans, scan_name[0])(dev.samx, 0, dev.samy, 0, relative=False)
-    status = getattr(scans, scan_name[1])(
-        dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=0.01, relative=True
-    )
+    scans.umv(dev.samx, 0, dev.samy, 0, relative=False)
+    status = scans.grid_scan(dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=0.01, relative=True)
     status.wait(num_points=True, file_written=True)
     assert len(status.scan.live_data) == 100
     assert status.scan.num_points == 100
 
 
 @pytest.mark.timeout(100)
-@pytest.mark.parametrize("scan_name", ["grid_scan", "_v4_grid_scan"])
-def test_grid_scan_lib_cancel(bec_client_lib, scan_name):
+def test_grid_scan_lib_cancel(bec_client_lib):
     bec = bec_client_lib
     scans = bec.scans
     bec.metadata.update({"unit_test": "test_grid_scan_bec_client_lib"})
     dev = bec.device_manager.devices
-    status = getattr(scans, scan_name)(
-        dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=1, relative=False
-    )
+    status = scans.grid_scan(dev.samx, -5, 5, 10, dev.samy, -5, 5, 10, exp_time=1, relative=False)
     time.sleep(0.5)
     status.cancel()
 
@@ -548,31 +542,6 @@ def test_cached_device_readout(bec_client_lib):
     dev.hexapod.x.readback.get(cached=True)
     timestamp_3 = dev.hexapod.x.readback.read(cached=True)["hexapod_x"]["timestamp"]
     assert timestamp_3 == timestamp_2
-
-
-@pytest.mark.timeout(100)
-@pytest.mark.skip(reason="Interactive scans are currently not supported in v4 scans.")
-def test_interactive_scan(bec_client_lib):
-    bec = bec_client_lib
-    bec.metadata.update({"unit_test": "test_interactive_scan"})
-    dev = bec.device_manager.devices
-    scans = bec.scans
-
-    with scans.interactive_scan(monitored=[dev.samx, dev.samy], exp_time=0.1) as scan:
-        for ii in range(10):
-            samx_status = dev.samx.set(ii)
-            samy_status = dev.samy.set(ii)
-            samx_status.wait()
-            samy_status.wait()
-            scan.trigger()
-            scan.read_monitored_devices(devices=[dev.samx, dev.samy])
-        report = scan.status
-
-    report.wait()
-
-    while len(report.scan.live_data) != 10:
-        time.sleep(0.1)
-    assert len(report.scan.live_data.samx.samx.val) == 10
 
 
 @pytest.mark.timeout(100)

--- a/bec_ipython_client/tests/end-2-end/test_scans_v4_lib_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_scans_v4_lib_e2e.py
@@ -16,7 +16,7 @@ from bec_server.scan_server.scans import position_generators
 
 
 def _get_v4_scan_runner(bec, scan_name: str):
-    return getattr(bec.scans, f"_v4_{scan_name}")
+    return getattr(bec.scans, scan_name)
 
 
 def _run_v4_scan(
@@ -67,15 +67,6 @@ def _wait_for_live_data_count(bec, status, expected_count: int, timeout: float =
         if len(status.scan.live_data) >= expected_count:
             return
         time.sleep(0.1)
-
-
-def _wait_for_scan_status(status, expected_status: str, timeout: float = 10):
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        if status.status == expected_status:
-            return
-        time.sleep(0.1)
-    raise TimeoutError(f"Timed out waiting for scan status {expected_status!r}.")
 
 
 def _wait_for_queue_status(bec, queue_name: str, expected_status: str, timeout: float = 10):
@@ -240,7 +231,7 @@ def test_v4_fixed_point_scans_lib(
 
 
 @pytest.mark.timeout(120)
-def test_v4_mv_scan_lib(bec_client_lib):
+def test_mv_scan_lib(bec_client_lib):
     bec = bec_client_lib
     dev = bec.device_manager.devices
 
@@ -252,7 +243,7 @@ def test_v4_mv_scan_lib(bec_client_lib):
 
 
 @pytest.mark.timeout(120)
-def test_v4_umv_scan_lib(bec_client_lib):
+def test_umv_scan_lib(bec_client_lib):
     bec = bec_client_lib
     dev = bec.device_manager.devices
 
@@ -264,7 +255,7 @@ def test_v4_umv_scan_lib(bec_client_lib):
 
 
 @pytest.mark.timeout(120)
-def test_v4_cont_line_scan_lib(bec_client_lib):
+def test_cont_line_scan_lib(bec_client_lib):
     bec = bec_client_lib
     dev = bec.device_manager.devices
     original_velocity = dev.samx.velocity.get()
@@ -282,7 +273,7 @@ def test_v4_cont_line_scan_lib(bec_client_lib):
 
 
 @pytest.mark.timeout(120)
-def test_v4_line_sweep_scan_lib(bec_client_lib):
+def test_line_sweep_scan_lib(bec_client_lib):
     bec = bec_client_lib
     dev = bec.device_manager.devices
     scans = bec.scans

--- a/bec_lib/bec_lib/device.py
+++ b/bec_lib/bec_lib/device.py
@@ -357,31 +357,20 @@ class DeviceBase:
             messages.ScanQueueMessage: The RPC message.
         """
         client: BECClient = self.root.parent.parent
-        scan_type = "_v4_device_rpc"
-        if scan_type == "_v4_device_rpc":
-            parameter = {
-                "args": [],
-                "kwargs": {
-                    "device": device,
-                    "func": func_call,
-                    "func_args": args,
-                    "func_kwargs": kwargs,
-                    "rpc_id": rpc_id,
-                    "system_config": client.system_config,
-                },
-            }
-        else:
-            # TODO: Remove once we've fully migrated to v4
-            parameter = {
+        parameter = {
+            "args": [],
+            "kwargs": {
                 "device": device,
-                "rpc_id": rpc_id,
                 "func": func_call,
-                "args": args,
-                "kwargs": kwargs,
-            }
+                "func_args": args,
+                "func_kwargs": kwargs,
+                "rpc_id": rpc_id,
+                "system_config": client.system_config,
+            },
+        }
 
         msg = messages.ScanQueueMessage(
-            scan_type=scan_type,
+            scan_type="device_rpc",
             parameter=parameter,
             queue=client.queue.get_default_scan_queue(),  # type: ignore
             metadata={"RID": request_id, "response": True},
@@ -467,9 +456,6 @@ class DeviceBase:
             msg = self._prepare_rpc_msg(rpc_id, request_id, device, func_call, *args, **kwargs)
 
             # pylint: disable=protected-access
-            if client.scans._scan_def_id:
-                msg.metadata["scan_def_id"] = client.scans._scan_def_id
-
             msg.metadata["client_info"] = {
                 "acl_user": client.username,
                 "username": client._system_user,

--- a/bec_lib/bec_lib/redis_connector/streams.py
+++ b/bec_lib/bec_lib/redis_connector/streams.py
@@ -50,7 +50,8 @@ StreamSubsRegistry = dict[str, StreamSubsEntry]
 class StreamSubs:
     def __init__(self) -> None:
         """Manager for stream subscriptions. Since operations often need to be combined,
-        use the lock directly at point of call, it is generally not used in the methods."""
+        use the lock directly at point of call, it is generally not used in the methods.
+        """
         self.lock = threading.RLock()
 
         self._subs: StreamSubsRegistry = {}

--- a/bec_lib/bec_lib/scan_data_container.py
+++ b/bec_lib/bec_lib/scan_data_container.py
@@ -680,7 +680,7 @@ class ScanDataContainer:
                 signal_name: SignalDataReference(
                     file_path=self._file_reference.file_path,
                     entry_path=entry_path,
-                    dict_entry=[device_name, signal_name] if grouped_cache else [signal_name],
+                    dict_entry=([device_name, signal_name] if grouped_cache else [signal_name]),
                 )
                 for signal_name in device_info
             }

--- a/bec_lib/bec_lib/scan_items.py
+++ b/bec_lib/bec_lib/scan_items.py
@@ -45,8 +45,6 @@ class ScanItem:
         status_message: Latest status message for this scan.
         data: Container for the scan's data points.
         live_data: Container for live/streaming scan data.
-        open_scan_defs: Set of open scan definition IDs.
-        open_queue_group: Queue group this scan belongs to.
         num_points: Total number of data points in the scan.
         num_monitored_readouts: Total number of monitored readouts in the scan.
         start_time: Unix timestamp when the scan started.
@@ -83,8 +81,6 @@ class ScanItem:
         self.status_message: messages.ScanStatusMessage | None = None
         self.data = ScanDataContainer()
         self.live_data = LiveScanData()
-        self.open_scan_defs = set()
-        self.open_queue_group = None
         self.num_points: int | None = None
         self.num_monitored_readouts: int | None = None
         self.start_time: float | None = None
@@ -384,17 +380,6 @@ class ScanStorage:
 
         # add scan report info
         scan_item.scan_report_instructions = scan_status.info.get("scan_report_instructions", [])
-
-        # add scan def id
-        scan_def_id = scan_status.info.get("scan_def_id")
-        if scan_def_id:
-            if scan_status.status in terminal_states:
-                scan_item.open_scan_defs.discard(scan_def_id)
-            else:
-                scan_item.open_scan_defs.add(scan_def_id)
-
-        # add queue group
-        scan_item.open_queue_group = scan_status.info.get("queue_group")
 
         # run status callbacks
         scan_item.emit_status(scan_status)

--- a/bec_lib/bec_lib/scan_report.py
+++ b/bec_lib/bec_lib/scan_report.py
@@ -68,7 +68,7 @@ class ScanReport:
         """returns the current status of the request"""
         scan_type = self.request.request.content["scan_type"]
         status = self.queue_item.status
-        if scan_type in ["mv", "_v4_mv"] and status == "COMPLETED":
+        if scan_type == "mv" and status == "COMPLETED":
             return "COMPLETED" if self._get_mv_status() else "RUNNING"
         return self.queue_item.status
 
@@ -147,7 +147,7 @@ class ScanReport:
             return self
         scan_type = self.request.request.content["scan_type"]
         try:
-            if scan_type in ["mv", "_v4_mv"]:
+            if scan_type == "mv":
                 self._wait_move(timeout, sleep_time)
             else:
                 self._wait_scan(
@@ -168,7 +168,7 @@ class ScanReport:
         if self._client is None:
             raise ValueError("Client is not set. Cannot cancel the scan.")
         scan_type = self.request.request.content["scan_type"]
-        if scan_type in ["mv", "_v4_mv"]:
+        if scan_type == "mv":
             motors = list(self.request.request.parameter["args"].keys())
             for motor in motors:
                 try:

--- a/bec_lib/bec_lib/scans.py
+++ b/bec_lib/bec_lib/scans.py
@@ -6,7 +6,6 @@ from the client side.
 from __future__ import annotations
 
 import builtins
-import time
 import uuid
 from collections.abc import Callable
 from contextlib import ContextDecorator
@@ -16,7 +15,6 @@ from typing import TYPE_CHECKING
 from toolz import partition
 from typeguard import typechecked
 
-from bec_lib.bec_errors import ScanAbortion
 from bec_lib.callback_handler import EventType
 from bec_lib.device import DeviceBase
 from bec_lib.endpoints import MessageEndpoints
@@ -133,10 +131,6 @@ class ScanObject:
 
         sys_config = sys_config.model_dump()
         # pylint: disable=protected-access
-        if scans._scan_group:
-            sys_config["queue_group"] = scans._scan_group
-        if scans._scan_def_id:
-            sys_config["scan_def_id"] = scans._scan_def_id
         if scans._dataset_id_on_hold:
             sys_config["dataset_id_on_hold"] = scans._dataset_id_on_hold
 
@@ -191,16 +185,11 @@ class Scans:
             MessageEndpoints.available_scans(), cb=self._available_scans_update
         )
         self._refresh_available_scans()
-        self._scan_group = None
-        self._scan_def_id = None
-        self._interactive_scan = False
-        self._scan_group_ctx = ScanGroup(parent=self)
         self._hide_report = None
         self._hide_report_ctx = HideReport(parent=self)
         self._dataset_id_on_hold = None
         self._dataset_id_on_hold_ctx = DatasetIdOnHold(parent=self)
         self._scan_export = None
-        setattr(self.interactive_scan, "__doc__", InteractiveScan.__doc__)
 
     def _refresh_available_scans(self) -> None:
         """Refresh scans from the scan server state."""
@@ -236,6 +225,8 @@ class Scans:
 
         self._available_scans = {}
         for scan_name, scan_info in available_scans.resource.items():
+            if scan_info.get("is_internal"):
+                continue
             scan_object = ScanObject(scan_name, scan_info, client=self.parent)
             self._available_scans[scan_name] = scan_object
             updated_scans[scan_name] = scan_object.run
@@ -376,11 +367,6 @@ class Scans:
         return params
 
     @property
-    def scan_group(self):
-        """Context manager / decorator for defining scan groups"""
-        return self._scan_group_ctx
-
-    @property
     def hide_report(self):
         """Context manager / decorator for hiding the report"""
         return self._hide_report_ctx
@@ -393,27 +379,6 @@ class Scans:
     def scan_export(self, output_file: str):
         """Context manager / decorator for exporting scans"""
         return ScanExport(output_file)
-
-    @property
-    def interactive_scan(self):
-        return InteractiveScan
-
-
-class ScanGroup(ContextDecorator):
-    """ScanGroup is a ContextDecorator for defining a scan group"""
-
-    def __init__(self, parent: Scans = None) -> None:
-        super().__init__()
-        self.parent = parent
-
-    def __enter__(self):
-        group_id = str(uuid.uuid4())
-        self.parent._scan_group = group_id
-        return self
-
-    def __exit__(self, *exc):
-        self.parent.close_scan_group()
-        self.parent._scan_group = None
 
 
 class HideReport(ContextDecorator):
@@ -547,128 +512,6 @@ class ScanExport:
                 self.scans = None
             except Exception as exc:
                 logger.warning(f"Could not export scans to csv file, due to exception {exc}")
-
-
-class InteractiveScan(ContextDecorator):
-    """
-    InteractiveScan is a context manager for running interactive scans.
-    Opening the interactive scan will stage all devices and perform the baseline reading.
-    Exiting the context manager will unstage all devices.
-    """
-
-    def __init__(
-        self, monitored: list[str] | list[DeviceBase], exp_time: float = 0, metadata=None, **kwargs
-    ) -> None:
-        """
-        InteractiveScan is a context manager for running interactive scans.
-        Opening the interactive scan will stage all devices and perform the baseline reading.
-        Exiting the context manager will unstage all devices.
-
-        Use "monitored" to specify the devices that should be monitored during the scan in addition
-        to the default monitored devices.
-
-        Args:
-            scan_motors (list[str] | list[DeviceBase]): List of scan motors that should be monitored.
-            exp_time (float): Exposure time for the scan. Default is 0.
-            metadata (dict): Metadata dictionary. Default is None.
-            kwargs: Keyword arguments that should be passed to the scan.
-
-        Example:
-            >>> with scans.interactive_scan(monitored=["samx"], exp_time=0.1, metadata={"sample": "A"}) as scan:
-            >>>     for i in range(10):
-            >>>         samx_status = dev.samx.set(i)
-            >>>         samx_status.wait()
-            >>>         scan.trigger()
-            >>>         scan.read_all_monitored_devices()
-        """
-
-        self._client = None
-        self._scans = None
-        self._point_id = 0
-        self._scan_kwargs = kwargs
-        self._scan_kwargs["exp_time"] = exp_time
-        self._scan_kwargs["metadata"] = metadata
-
-        self._input_monitored_devices = monitored
-
-    def _update_monitored_devices(self):
-        """
-        Update the monitored devices based on the scan_motors or monitored_devices arguments.
-        """
-        monitored_devices = self._input_monitored_devices
-        if monitored_devices is not None:
-            if not isinstance(monitored_devices, list):
-                monitored_devices = [monitored_devices]
-            self._scan_kwargs["monitored"] = monitored_devices
-
-        self._scan_kwargs["monitored"] = [
-            device.name if isinstance(device, DeviceBase) else device
-            for device in self._scan_kwargs["monitored"]
-        ]
-
-    def __enter__(self):
-        self._client = _get_client()
-        self._scans = self._client.scans
-        if self._scans._scan_def_id is not None:
-            raise ScanAbortion("Cannot run interactive scans within a scan definition.")
-        if self._scans._interactive_scan:
-            raise ScanAbortion("Cannot run interactive scans within another interactive scan.")
-        self._update_monitored_devices()
-        self._scans._interactive_scan = True
-        self._scans._scan_def_id = str(uuid.uuid4())
-        status = self._scans._open_interactive_scan(hide_report=True, **self._scan_kwargs)
-        self.status = status
-        return self
-
-    def __exit__(self, *exc):
-        self._scans._close_interactive_scan(hide_report=True, **self._scan_kwargs)
-        self._scans._scan_def_id = None
-        self._scans._interactive_scan = False
-        if not exc[0]:
-            self.status.wait()
-
-    def trigger(self):
-        """
-        Trigger all enabled devices that have softwareTrigger set to True
-        """
-        # self._client.alarm_handler.check_for_alarms()
-        # pylint: disable=protected-access
-        self._scans._interactive_trigger(hide_report=True, **self._scan_kwargs)
-
-    def read_monitored_devices(self, devices: list[str | DeviceBase] = None, wait: bool = False):
-        """
-        Read all monitored devices. If devices is specified, only read the specified devices.
-        Please note that in an interactive scan, scan motors are not automatically added to the monitored devices,
-        so they need to be specified explicitly.
-
-        Args:
-            devices(list[str | DeviceBase]): List of devices that should be added to the monitored devices
-
-        """
-        if devices is None:
-            devices = []
-        if not isinstance(devices, list):
-            devices = [devices]
-        devices = [device.name if isinstance(device, DeviceBase) else device for device in devices]
-        # pylint: disable=protected-access
-        self._scans._interactive_read_monitored(
-            devices=devices, point_id=self._point_id, hide_report=True, **self._scan_kwargs
-        )
-        self._point_id += 1
-        if wait:
-            self.wait()
-
-    def wait(self):
-        """
-        Wait for the all readings to arrive at the client
-        """
-        while len(self.status.scan.data) != self._point_id:
-            self._client.alarm_handler.raise_alarms()
-            time.sleep(0.1)
-
-
-# this is a workaround to make the InteractiveScan doc string available to the interactive_scan property
-Scans.interactive_scan.__doc__ = InteractiveScan.__init__.__doc__
 
 
 def _get_client():

--- a/bec_lib/bec_lib/signature_serializer.py
+++ b/bec_lib/bec_lib/signature_serializer.py
@@ -269,7 +269,7 @@ def signature_to_dict(
             {
                 "name": param_name,
                 "kind": param.kind.name,
-                "default": param.default if param.default != inspect._empty else "_empty",
+                "default": (param.default if param.default != inspect._empty else "_empty"),
                 "annotation": (
                     serialize_dtype(param_typehint)
                     if param_typehint is not inspect._empty
@@ -297,7 +297,7 @@ def dict_to_signature(params: list[dict]) -> inspect.Signature:
             inspect.Parameter(
                 name=param["name"],
                 kind=getattr(inspect.Parameter, param["kind"]),
-                default=param["default"] if param["default"] != "_empty" else inspect._empty,
+                default=(param["default"] if param["default"] != "_empty" else inspect._empty),
                 annotation=deserialize_dtype(param["annotation"]),
             )
         )

--- a/bec_lib/bec_lib/tests/utils.py
+++ b/bec_lib/bec_lib/tests/utils.py
@@ -60,9 +60,6 @@ class ScansMock(Scans):
     def _import_scans(self):
         pass
 
-    def close_scan_group(self):
-        pass
-
     def umv(self, *args, relative=False, **kwargs):
         pass
 
@@ -133,7 +130,6 @@ class ClientMock(BECClient):
             mv=self.scans.mv,
             umv=self.scans.umv,
             fermat_scan=self.scans.fermat_scan,
-            close_scan_group=self.scans.close_scan_group,
         )
 
     def get_global_var(self, name: str):

--- a/bec_lib/tests/test_config_helper.py
+++ b/bec_lib/tests/test_config_helper.py
@@ -553,7 +553,7 @@ def test_wait_for_service_response_raises_timeout(config_helper_plain):
 
 
 def test_wait_for_service_response_handles_one_by_one(config_helper_plain):
-    mock_msg_1, mock_msg_2, mock_msg_3 = mock.MagicMock(), mock.MagicMock(), mock.MagicMock()
+    mock_msg_1, mock_msg_2, mock_msg_3 = (mock.MagicMock(), mock.MagicMock(), mock.MagicMock())
     mock_msg_1.content = {"response": {"service": "DeviceServer"}}
     mock_msg_2.content = {"response": {"service": "ScanServer"}}
     mock_msg_3.content = {"response": {"service": "ServiceName123"}}

--- a/bec_lib/tests/test_devices.py
+++ b/bec_lib/tests/test_devices.py
@@ -313,12 +313,12 @@ def test_handle_rpc_response_returns_dict(dev: Any):
     assert dev.samx._handle_rpc_response(msg) == {"a": "b"}
 
 
-def test_prepare_rpc_msg_uses_v4_device_rpc_signature(dev: Any):
+def test_prepare_rpc_msg_uses_device_rpc_signature(dev: Any):
     dev.samx.root.parent.parent.queue.get_default_scan_queue.return_value = "primary"
 
     msg = dev.samx._prepare_rpc_msg("rpc-id", "request-id", "samx", "set", 1, "fast", armed=True)
 
-    assert msg.scan_type == "_v4_device_rpc"
+    assert msg.scan_type == "device_rpc"
     assert msg.parameter["args"] == []
     assert msg.parameter["kwargs"]["device"] == "samx"
     assert msg.parameter["kwargs"]["func"] == "set"

--- a/bec_lib/tests/test_scan_context.py
+++ b/bec_lib/tests/test_scan_context.py
@@ -1,20 +1,9 @@
 import builtins
-from typing import Annotated
 from unittest import mock
 
 import pytest
 
-from bec_lib.scan_args import ScanArgument
-from bec_lib.scans import (
-    DatasetIdOnHold,
-    FileWriter,
-    HideReport,
-    Metadata,
-    ScanExport,
-    ScanGroup,
-    Scans,
-)
-from bec_lib.signature_serializer import serialize_dtype
+from bec_lib.scans import DatasetIdOnHold, FileWriter, HideReport, Metadata, ScanExport
 
 # pylint: disable=no-member
 # pylint: disable=missing-function-docstring
@@ -94,16 +83,6 @@ def test_dataset_id_on_hold_cleanup_on_error(bec_client_mock):
     assert client.scans._dataset_id_on_hold is None
 
 
-def test_scan_group_cm(bec_client_mock):
-    client = bec_client_mock
-    client.scans._scan_group = None
-    scan_group_cm = ScanGroup(client.scans)
-    with scan_group_cm:
-        assert isinstance(client.scans._scan_group, str)
-
-    assert client.scans._scan_group is None
-
-
 @pytest.mark.parametrize("abort_on_ctrl_c", [True, False])
 def test_scan_export_cm(abort_on_ctrl_c):
     scan_export = ScanExport("temp")
@@ -148,94 +127,3 @@ def test_arg_matches_type_for_generic_containers(bec_client_mock, arg, dtype, ma
     client = bec_client_mock
 
     assert client.scans._input_validator._arg_matches_type(arg, dtype) is matches
-
-
-def test_strip_scan_signature_annotations_for_ipython_signature():
-    signature = [
-        {
-            "name": "step",
-            "kind": "POSITIONAL_OR_KEYWORD",
-            "default": "_empty",
-            "annotation": serialize_dtype(Annotated[float, ScanArgument(description="Step size")]),
-        },
-        {
-            "name": "optional_step",
-            "kind": "POSITIONAL_OR_KEYWORD",
-            "default": None,
-            "annotation": serialize_dtype(
-                Annotated[float, ScanArgument(description="Optional step size")] | None
-            ),
-        },
-        {"name": "kwargs", "kind": "VAR_KEYWORD", "default": "_empty", "annotation": "_empty"},
-    ]
-
-    assert Scans._strip_scan_signature_annotations(signature) == [
-        {
-            "name": "step",
-            "kind": "POSITIONAL_OR_KEYWORD",
-            "default": "_empty",
-            "annotation": "float",
-        },
-        {
-            "name": "optional_step",
-            "kind": "POSITIONAL_OR_KEYWORD",
-            "default": None,
-            "annotation": ["float", "NoneType"],
-        },
-    ]
-
-
-def test_interactive_scan_cm(bec_client_mock):
-    client = bec_client_mock
-    with mock.patch.dict(builtins.__dict__, {"bec": client}):
-        client.scans._open_interactive_scan = mock.MagicMock()
-        client.scans._close_interactive_scan = mock.MagicMock()
-        client.scans._interactive_trigger = mock.MagicMock()
-        client.scans._interactive_read_monitored = mock.MagicMock()
-
-        with client.scans.interactive_scan("samx") as scan:
-            scan.trigger()
-            scan.read_monitored_devices()
-
-        client.scans._open_interactive_scan.assert_called_once()
-        client.scans._close_interactive_scan.assert_called_once()
-        client.scans._interactive_trigger.assert_called_once()
-        client.scans._interactive_read_monitored.assert_called_once()
-
-
-def test_interactive_scan_cm_raise_calls_close(bec_client_mock):
-    client = bec_client_mock
-    with mock.patch.dict(builtins.__dict__, {"bec": client}):
-        client.scans._open_interactive_scan = mock.MagicMock()
-        client.scans._close_interactive_scan = mock.MagicMock()
-        client.scans._interactive_trigger = mock.MagicMock()
-        client.scans._interactive_read_monitored = mock.MagicMock()
-
-        with pytest.raises(AttributeError):
-            with client.scans.interactive_scan("samx") as scan:
-                scan.trigger()
-                scan.read_monitored_devices()
-                raise AttributeError()
-
-        client.scans._open_interactive_scan.assert_called_once()
-        client.scans._close_interactive_scan.assert_called_once()
-        client.scans._interactive_trigger.assert_called_once()
-        client.scans._interactive_read_monitored.assert_called_once()
-
-
-def test_interactive_scan_cm_raises_scan_motors(bec_client_mock):
-    client = bec_client_mock
-    client.scans._open_interactive_scan = mock.MagicMock()
-    client.scans._close_interactive_scan = mock.MagicMock()
-    client.scans._interactive_trigger = mock.MagicMock()
-    client.scans._interactive_read_monitored = mock.MagicMock()
-
-    with pytest.raises(TypeError):
-        with client.scans.interactive_scan() as scan:
-            scan.trigger()
-            scan.read_monitored_devices()
-
-    client.scans._open_interactive_scan.assert_not_called()
-    client.scans._close_interactive_scan.assert_not_called()
-    client.scans._interactive_trigger.assert_not_called()
-    client.scans._interactive_read_monitored.assert_not_called()

--- a/bec_lib/tests/test_scan_items.py
+++ b/bec_lib/tests/test_scan_items.py
@@ -345,66 +345,6 @@ def test_update_with_scan_status_updates_scan_number_already_existing():
         assert scan_item.scan_number == 1
 
 
-def test_update_with_scan_status_adds_scan_def_id():
-    scan_manager = ScanManager(ConnectorMock(""))
-    scan_manager.scan_storage.last_scan_number = 0
-    with mock.patch.object(scan_manager.scan_storage, "find_scan_by_ID") as mock_find_scan:
-        scan_item = mock.MagicMock()
-        scan_item.open_scan_defs = set()
-        mock_find_scan.return_value = scan_item
-        scan_manager.scan_storage.update_with_scan_status(
-            messages.ScanStatusMessage(
-                scan_id="scan_id",
-                status="open",
-                scan_number=1,
-                num_points=10,
-                info={"scan_def_id": "scan_def_id"},
-                timestamp=10,
-            )
-        )
-        assert "scan_def_id" in scan_item.open_scan_defs
-
-
-def test_update_with_scan_status_removes_scan_def_id():
-    scan_manager = ScanManager(ConnectorMock(""))
-    scan_manager.scan_storage.last_scan_number = 0
-    with mock.patch.object(scan_manager.scan_storage, "find_scan_by_ID") as mock_find_scan:
-        scan_item = mock.MagicMock()
-        scan_item.open_scan_defs = set(["scan_def_id"])
-        mock_find_scan.return_value = scan_item
-        scan_manager.scan_storage.update_with_scan_status(
-            messages.ScanStatusMessage(
-                scan_id="scan_id",
-                status="closed",
-                scan_number=1,
-                num_points=10,
-                info={"scan_def_id": "scan_def_id"},
-                timestamp=10,
-            )
-        )
-        assert "scan_def_id" not in scan_item.open_scan_defs
-
-
-def test_update_with_scan_status_keeps_scan_def_id_for_paused():
-    scan_manager = ScanManager(ConnectorMock(""))
-    scan_manager.scan_storage.last_scan_number = 0
-    with mock.patch.object(scan_manager.scan_storage, "find_scan_by_ID") as mock_find_scan:
-        scan_item = mock.MagicMock()
-        scan_item.open_scan_defs = {"scan_def_id"}
-        mock_find_scan.return_value = scan_item
-        scan_manager.scan_storage.update_with_scan_status(
-            messages.ScanStatusMessage(
-                scan_id="scan_id",
-                status="paused",
-                scan_number=1,
-                num_points=10,
-                info={"scan_def_id": "scan_def_id"},
-                timestamp=10,
-            )
-        )
-        assert "scan_def_id" in scan_item.open_scan_defs
-
-
 def test_add_scan_segment_emits_data():
     scan_manager = ScanManager(ConnectorMock(""))
     scan_item = mock.MagicMock()

--- a/bec_lib/tests/test_scan_object.py
+++ b/bec_lib/tests/test_scan_object.py
@@ -309,28 +309,6 @@ def test_scan_object_receives_sample_name(scan_obj, dev):
             )
 
 
-def test_scan_object_receives_scan_group(scan_obj, dev):
-    scan_obj.client.scans._scan_group = "group_id"
-    with mock.patch.object(scan_obj.client, "alarm_handler"):
-        with mock.patch("bec_lib.scan_report.ScanReport.from_request") as scan_report:
-            with mock.patch.object(scan_obj.client, "get_global_var", return_value="test_sample"):
-                scan_obj._run(
-                    dev.samx, -5, 5, dev.samy, -5, 5, step=0.5, exp_time=0.1, relative=False
-                )
-                assert scan_report.call_args.args[0].metadata["queue_group"] == "group_id"
-
-
-def test_scan_object_receives_scan_def_id(scan_obj, dev):
-    scan_obj.client.scans._scan_def_id = "scan_def_id"
-    with mock.patch.object(scan_obj.client, "alarm_handler"):
-        with mock.patch("bec_lib.scan_report.ScanReport.from_request") as scan_report:
-            with mock.patch.object(scan_obj.client, "get_global_var", return_value="test_sample"):
-                scan_obj._run(
-                    dev.samx, -5, 5, dev.samy, -5, 5, step=0.5, exp_time=0.1, relative=False
-                )
-                assert scan_report.call_args.args[0].metadata["scan_def_id"] == "scan_def_id"
-
-
 def test_scan_object_receives_dataset_id_on_hold(scan_obj, dev):
     scan_obj.client.scans._dataset_id_on_hold = "dataset_id_on_hold"
     with mock.patch.object(scan_obj.client, "alarm_handler"):

--- a/bec_server/bec_server/bec_server_utils/service_handler.py
+++ b/bec_server/bec_server/bec_server_utils/service_handler.py
@@ -207,7 +207,7 @@ class ServiceHandler:
             f"Unsupported interface: {self.interface}. Supported interfaces are: tmux, iterm2, systemctl, subprocess"
         )
 
-    def stop(self, processes=None):
+    def stop(self, processes=None, timeout_s: float | None = None):
         """
         Stop the BEC server using the available interface.
         """
@@ -220,7 +220,7 @@ class ServiceHandler:
         elif self.interface == "systemctl":
             subprocess.run(["sudo", "systemctl", "stop", "bec-server.service"], check=True)
         elif self.interface == "subprocess":
-            subprocess_stop(processes)
+            subprocess_stop(processes, timeout_s=timeout_s)
         else:
             raise ValueError(
                 f"Unsupported interface: {self.interface}. Supported interfaces are: tmux, iterm2, systemctl, subprocess"

--- a/bec_server/bec_server/bec_server_utils/subprocess_launch.py
+++ b/bec_server/bec_server/bec_server_utils/subprocess_launch.py
@@ -63,17 +63,42 @@ def subprocess_start(bec_path: str, services: dict[str, "ServiceDesc"]):
     return processes
 
 
-def _kill_process_and_children(pid):
-    parent = psutil.Process(pid)
+def _stop_psutil_process(process: psutil.Process, timeout_s: float | None = None):
+    try:
+        process.terminate()
+        process.wait(timeout=timeout_s)
+    except psutil.NoSuchProcess:
+        return
+    except psutil.TimeoutExpired:
+        process.kill()
+        try:
+            process.wait(timeout=timeout_s)
+        except psutil.NoSuchProcess:
+            return
+
+
+def _stop_subprocess(process: subprocess.Popen, timeout_s: float | None = None):
+    try:
+        process.terminate()
+        process.wait(timeout=timeout_s)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=timeout_s)
+
+
+def _kill_process_and_children(pid, timeout_s: float | None = None):
+    try:
+        parent = psutil.Process(pid)
+    except psutil.NoSuchProcess:
+        return
+
     children = parent.children(recursive=True)
     for child in children:
-        child.terminate()
-        child.wait()
-    parent.terminate()
-    parent.wait()
+        _stop_psutil_process(child, timeout_s=timeout_s)
+    _stop_psutil_process(parent, timeout_s=timeout_s)
 
 
-def subprocess_stop(processes=None):
+def subprocess_stop(processes=None, timeout_s: float | None = None):
     # For "bec-server stop" to be able to stop processes it would
     # need PID files for example... So, for now only consider to do
     # something considering we get Popen objects (like in tests)
@@ -84,13 +109,12 @@ def subprocess_stop(processes=None):
         for term in TERMINALS:
             if term.cmd == cmd:
                 if term.spawn_child:
-                    _kill_process_and_children(process.pid)
+                    _kill_process_and_children(process.pid, timeout_s=timeout_s)
                 else:
-                    process.terminate()
-                    process.wait()
+                    _stop_subprocess(process, timeout_s=timeout_s)
                 break
         else:
             # not in terminal
             # if command is launched via 'conda',
             # there might be children processes
-            _kill_process_and_children(process.pid)
+            _kill_process_and_children(process.pid, timeout_s=timeout_s)

--- a/bec_server/bec_server/procedures/constants.py
+++ b/bec_server/bec_server/procedures/constants.py
@@ -27,7 +27,8 @@ P = ParamSpec("P")
 class BecProcedure(Protocol[P]):
     """A procedure should not return anything, because it could be run in an isolated environment
     and data needs to be extracted in other ways. It may be a simple function, but it can also be
-    a class instance which implements __call__ and has its state initialised by its worker class."""
+    a class instance which implements __call__ and has its state initialised by its worker class.
+    """
 
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> None: ...
 

--- a/bec_server/bec_server/procedures/manager.py
+++ b/bec_server/bec_server/procedures/manager.py
@@ -183,7 +183,7 @@ class ProcedureManagerBase(ABC, Generic[_ReqMsgT, _ExecMsgT]):
     def worker_statuses(self) -> dict[str, ProcedureWorkerStatus]:
         with self.lock:
             return {
-                q: w["worker"].status if w["worker"] is not None else ProcedureWorkerStatus.NONE
+                q: (w["worker"].status if w["worker"] is not None else ProcedureWorkerStatus.NONE)
                 for q, w in self._active_workers.items()
             }
 
@@ -233,7 +233,8 @@ class ProcedureManagerBase(ABC, Generic[_ReqMsgT, _ExecMsgT]):
     @abstractmethod
     def _respond_to_valid_request(self, message: _ReqMsgT) -> _ExecMsgT:
         """If _validate_request passed successfully, the valid request message received here should
-        be propagated to Redis, and the execution message returned to be passed on to spawn()."""
+        be propagated to Redis, and the execution message returned to be passed on to spawn().
+        """
 
     @abstractmethod
     def _cleanup_worker_function(self, queue: str) -> Callable[[Future], None]:

--- a/bec_server/bec_server/scan_server/scan_guard.py
+++ b/bec_server/bec_server/scan_server/scan_guard.py
@@ -115,7 +115,7 @@ class ScanGuard:
         if scan_type not in avail_scans.resource:
             raise ScanRejection(f"Unknown scan type {scan_type}.")
 
-        if scan_type in ["device_rpc", "_v4_device_rpc"]:
+        if scan_type == "device_rpc":
             # ensure that the requested rpc is allowed for this particular device
             device, func = self._extract_device_rpc_target(request)
             if not self._device_rpc_is_valid(device=device, func=func):
@@ -141,7 +141,7 @@ class ScanGuard:
             ScanRejection: If any motor is not enabled or movable
         """
         parameter = request.parameter
-        if request.scan_type in ["device_rpc", "_v4_device_rpc"]:
+        if request.scan_type == "device_rpc":
             device, _ = self._extract_device_rpc_target(request)
             if not isinstance(device, list):
                 device = [device]
@@ -214,7 +214,7 @@ class ScanGuard:
             logger.info(f"Request was rejected: {scan_status.message}")
             return
 
-        if msg.scan_type in ["device_rpc", "_v4_device_rpc"]:
+        if msg.scan_type == "device_rpc":
             _, func = self._extract_device_rpc_target(msg)
             if func in ["get", "read"] or func.endswith(".get") or func.endswith(".read"):
                 logger.info("Scan request is a read operation, not enqueuing.")
@@ -227,10 +227,8 @@ class ScanGuard:
         msg: messages.ScanQueueMessage,
     ) -> tuple[str | list[str] | None, str]:
         params = msg.content.get("parameter", {})
-        if msg.scan_type == "_v4_device_rpc":
-            rpc_kwargs = params.get("kwargs", {})
-            return rpc_kwargs.get("device"), rpc_kwargs.get("func", "")
-        return params.get("device"), params.get("func", "")
+        rpc_kwargs = params.get("kwargs", {})
+        return rpc_kwargs.get("device"), rpc_kwargs.get("func", "")
 
     def _direct_device_rpc(self, msg: messages.ScanQueueMessage):
         """
@@ -247,15 +245,15 @@ class ScanGuard:
         if not params:
             logger.error("No parameters provided for device RPC request.")
             return
-        if msg.scan_type == "_v4_device_rpc":
-            rpc_kwargs = params.get("kwargs", {})
-            params = {
-                "device": device,
-                "rpc_id": rpc_kwargs.get("rpc_id"),
-                "func": rpc_kwargs.get("func"),
-                "args": rpc_kwargs.get("func_args", []),
-                "kwargs": rpc_kwargs.get("func_kwargs", {}),
-            }
+
+        rpc_kwargs = params.get("kwargs", {})
+        params = {
+            "device": device,
+            "rpc_id": rpc_kwargs.get("rpc_id"),
+            "func": rpc_kwargs.get("func"),
+            "args": rpc_kwargs.get("func_args", []),
+            "kwargs": rpc_kwargs.get("func_kwargs", {}),
+        }
         instr = messages.DeviceInstructionMessage(
             device=device,
             action="rpc",

--- a/bec_server/bec_server/scan_server/scan_manager.py
+++ b/bec_server/bec_server/scan_server/scan_manager.py
@@ -16,7 +16,7 @@ from bec_lib.device import DeviceBase
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.logger import bec_logger
 from bec_lib.messages import AvailableResourceMessage, ErrorInfo
-from bec_lib.signature_serializer import serialize_dtype, signature_to_dict
+from bec_lib.signature_serializer import serialize_dtype
 from bec_server.scan_server.scan_gui_models import GUIConfig
 from bec_server.scan_server.scans.scan_argument_modifier import (
     get_scan_modifier,
@@ -32,6 +32,15 @@ if TYPE_CHECKING:
     from bec_server.scan_server.scan_server import ScanServer
 
 logger = bec_logger.logger
+
+INTERNAL_SCAN_CLASSES = {
+    "ScanStubs",
+    "ScanComponent",
+    "AsyncFlyScanBase",
+    "SyncFlyScanBase",
+    "ScanBase",
+    "DeviceRpc",
+}
 
 _SCAN_ARG_TYPE_TO_DTYPE = {
     scans_module.ScanArgType.DEVICE: DeviceBase,
@@ -63,25 +72,53 @@ class ScanManager:
         self.update_available_scans()
         self.publish_available_scans()
 
-    @functools.lru_cache(maxsize=1)
+    @functools.lru_cache(maxsize=2)
     @staticmethod
-    def get_available_scans() -> list[tuple[str, Type]]:
+    def get_available_scans(allow_duplicates: bool = False) -> list[tuple[str, Type]]:
         """
         Get all available scans, including legacy scans, v4 scans and plugin scans.
+
+        Args:
+            allow_duplicates (bool): If True, allow duplicate scan names. Default is False.
 
         Returns:
             list[tuple[str, Type]]: list of scan name and scan class tuples
         """
-        # internal, legacy scans
-        members: list[tuple[str, Type]] = inspect.getmembers(
-            scans_module, predicate=inspect.isclass
-        )
+
+        def _append_new_scan_members(
+            members: list[tuple[str, Type]],
+            candidates: list[tuple[str, Type]],
+            skip_duplicates: bool = False,
+        ) -> None:
+            seen_scan_names = {
+                scan_cls.scan_name
+                for _, scan_cls in members
+                if hasattr(scan_cls, "scan_name") and scan_cls.scan_name
+            }
+            for name, scan_cls in candidates:
+                scan_name = getattr(scan_cls, "scan_name", None)
+                if skip_duplicates and scan_name and scan_name in seen_scan_names:
+                    continue
+                members.append((name, scan_cls))
+                if scan_name:
+                    seen_scan_names.add(scan_name)
 
         # internal, v4 scans
-        members.extend(ScanManager._get_v4_scan_members())
+        members: list[tuple[str, Type]] = ScanManager._get_v4_scan_members()
+
+        # internal, legacy scans. We skip duplicates here because we want to prioritize v4 scans over legacy scans.
+        _append_new_scan_members(
+            members,
+            inspect.getmembers(scans_module, predicate=inspect.isclass),
+            skip_duplicates=True,
+        )
 
         # plugin scans
-        members.extend((name, cls) for name, cls in ScanManager._get_scan_plugins().items())
+        _append_new_scan_members(
+            members,
+            list((name, cls) for name, cls in ScanManager._get_scan_plugins().items()),
+            skip_duplicates=not allow_duplicates,
+        )
 
         to_remove = []
         for name, scan_cls in members:
@@ -95,6 +132,7 @@ class ScanManager:
                 to_remove.append((name, scan_cls))
         for item in to_remove:
             members.remove(item)
+
         return members
 
     @classmethod
@@ -110,7 +148,7 @@ class ScanManager:
 
         self.available_scans = {}
         self.scan_dict = {}
-        members = ScanManager.get_available_scans()
+        members = ScanManager.get_available_scans(allow_duplicates=True)
 
         for name, scan_cls in members:
 
@@ -165,6 +203,8 @@ class ScanManager:
             self.available_scans[scan_cls.scan_name] = {
                 "class": scan_cls.__name__,
                 "base_class": base_cls,
+                "is_scan": scan_cls.is_scan if hasattr(scan_cls, "is_scan") else False,
+                "is_internal": self.scan_is_internal(scan_cls),
                 "arg_input": self.convert_arg_input(scan_cls.arg_input),
                 "required_kwargs": getattr(scan_cls, "required_kwargs", []),
                 "arg_bundle_size": scan_cls.arg_bundle_size,
@@ -173,6 +213,21 @@ class ScanManager:
                 "gui_visibility": gui_visibility,
                 "gui_config": gui_config,  # deprecated! - should be removed
             }
+
+    @staticmethod
+    def scan_is_internal(scan_cls) -> bool:
+        """
+        Determine if a scan class is internal.
+
+        Args:
+            scan_cls: class
+
+        Returns:
+            bool: True if the scan class is internal, False otherwise.
+        """
+        if scan_cls.__name__ in INTERNAL_SCAN_CLASSES:
+            return True
+        return getattr(scan_cls, "is_internal", False)
 
     def validate_gui_config(self, scan_cls, gui_config_override: dict | None = None) -> dict:
         """

--- a/bec_server/bec_server/scan_server/scans/acquire.py
+++ b/bec_server/bec_server/scan_server/scans/acquire.py
@@ -34,7 +34,7 @@ class Acquire(ScanBase):
     # Scan name: This is the name of the scan, e.g. "line_scan". This is used for display purposes and to identify the scan type in user interfaces.
     # Choose a descriptive name that does not conflict with existing scan names.
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
-    scan_name = "_v4_acquire"
+    scan_name = "acquire"
 
     gui_config = {
         "Scan Parameters": [

--- a/bec_server/bec_server/scan_server/scans/cont_line_scan.py
+++ b/bec_server/bec_server/scan_server/scans/cont_line_scan.py
@@ -38,7 +38,7 @@ class ContLineScan(ScanBase):
     # Scan name: This is the name of the scan, e.g. "line_scan". This is used for display purposes and to identify the scan type in user interfaces.
     # Choose a descriptive name that does not conflict with existing scan names.
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
-    scan_name = "_v4_cont_line_scan"
+    scan_name = "cont_line_scan"
     gui_config = {
         "Device": ["device", "start", "stop"],
         "Movement Parameters": ["steps", "relative", "offset", "atol"],

--- a/bec_server/bec_server/scan_server/scans/device_rpc.py
+++ b/bec_server/bec_server/scan_server/scans/device_rpc.py
@@ -39,7 +39,7 @@ class DeviceRpc(ScanBase):
     # Scan name: This is the name of the scan, e.g. "line_scan". This is used for display purposes and to identify the scan type in user interfaces.
     # Choose a descriptive name that does not conflict with existing scan names.
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
-    scan_name = "_v4_device_rpc"
+    scan_name = "device_rpc"
 
     def __init__(
         self,

--- a/bec_server/bec_server/scan_server/scans/fermat_scan.py
+++ b/bec_server/bec_server/scan_server/scans/fermat_scan.py
@@ -43,7 +43,7 @@ class FermatSpiralScan(ScanBase):
     # Scan name: This is the name of the scan, e.g. "line_scan". This is used for display purposes and to identify the scan type in user interfaces.
     # Choose a descriptive name that does not conflict with existing scan names.
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
-    scan_name = "_v4_fermat_scan"
+    scan_name = "fermat_scan"
 
     gui_config = {
         "Device 1": ["motor1", "start_motor1", "stop_motor1"],

--- a/bec_server/bec_server/scan_server/scans/grid_scan.py
+++ b/bec_server/bec_server/scan_server/scans/grid_scan.py
@@ -42,7 +42,7 @@ class GridScan(ScanBase):
     # Scan name: This is the name of the scan, e.g. "line_scan". This is used for display purposes and to identify the scan type in user interfaces.
     # Choose a descriptive name that does not conflict with existing scan names.
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
-    scan_name = "_v4_grid_scan"
+    scan_name = "grid_scan"
 
     # arg_input and arg_bundle_size are only relevant for scans that accept an arbitrary number of motor / position arguments (e.g. line scans, grid scans).
     # For scans with a fixed set of parameters (e.g. Fermat spiral), these can be simply removed.

--- a/bec_server/bec_server/scan_server/scans/hexagonal_scan.py
+++ b/bec_server/bec_server/scan_server/scans/hexagonal_scan.py
@@ -38,7 +38,7 @@ class HexagonalScan(ScanBase):
     # Scan name: This is the name of the scan, e.g. "line_scan". This is used for display purposes and to identify the scan type in user interfaces.
     # Choose a descriptive name that does not conflict with existing scan names.
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
-    scan_name = "_v4_hexagonal_scan"
+    scan_name = "hexagonal_scan"
     gui_config = {
         "Device 1": ["motor1", "start_motor1", "stop_motor1", "step_motor1"],
         "Device 2": ["motor2", "start_motor2", "stop_motor2", "step_motor2"],

--- a/bec_server/bec_server/scan_server/scans/line_scan.py
+++ b/bec_server/bec_server/scan_server/scans/line_scan.py
@@ -38,7 +38,7 @@ class LineScan(ScanBase):
     # Scan name: This is the name of the scan, e.g. "line_scan". This is used for display purposes and to identify the scan type in user interfaces.
     # Choose a descriptive name that does not conflict with existing scan names.
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
-    scan_name = "_v4_line_scan"
+    scan_name = "line_scan"
 
     # arg_input and arg_bundle_size are only relevant for scans that accept an arbitrary number of motor / position arguments (e.g. line scans, grid scans).
     # For scans with a fixed set of parameters (e.g. Fermat spiral), these can be simply removed.

--- a/bec_server/bec_server/scan_server/scans/line_sweep_scan.py
+++ b/bec_server/bec_server/scan_server/scans/line_sweep_scan.py
@@ -41,7 +41,7 @@ class LineSweepScan(ScanBase):
     # Scan name: This is the name of the scan, e.g. "line_scan". This is used for display purposes and to identify the scan type in user interfaces.
     # Choose a descriptive name that does not conflict with existing scan names.
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
-    scan_name = "_v4_line_sweep_scan"
+    scan_name = "line_sweep_scan"
     gui_config = {
         "Device": ["device", "start", "stop"],
         "Scan Parameters": ["min_update", "relative"],

--- a/bec_server/bec_server/scan_server/scans/list_scan.py
+++ b/bec_server/bec_server/scan_server/scans/list_scan.py
@@ -35,7 +35,7 @@ class ListScan(ScanBase):
     # Scan name: This is the name of the scan, e.g. "line_scan". This is used for display purposes and to identify the scan type in user interfaces.
     # Choose a descriptive name that does not conflict with existing scan names.
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
-    scan_name = "_v4_list_scan"
+    scan_name = "list_scan"
 
     # arg_input and arg_bundle_size are only relevant for scans that accept an arbitrary number of motor / position arguments (e.g. line scans, grid scans).
     # For scans with a fixed set of parameters (e.g. Fermat spiral), these can be simply removed.

--- a/bec_server/bec_server/scan_server/scans/log_scan.py
+++ b/bec_server/bec_server/scan_server/scans/log_scan.py
@@ -38,7 +38,7 @@ class LogScan(ScanBase):
     # Scan name: This is the name of the scan, e.g. "line_scan". This is used for display purposes and to identify the scan type in user interfaces.
     # Choose a descriptive name that does not conflict with existing scan names.
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
-    scan_name = "_v4_log_scan"
+    scan_name = "log_scan"
 
     # arg_input and arg_bundle_size are only relevant for scans that accept an arbitrary number of motor / position arguments (e.g. line scans, grid scans).
     # For scans with a fixed set of parameters (e.g. Fermat spiral), these can be simply removed.

--- a/bec_server/bec_server/scan_server/scans/move.py
+++ b/bec_server/bec_server/scan_server/scans/move.py
@@ -37,7 +37,7 @@ class MoveScan(ScanBase):
     # Scan name: This is the name of the scan, e.g. "line_scan". This is used for display purposes and to identify the scan type in user interfaces.
     # Choose a descriptive name that does not conflict with existing scan names.
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
-    scan_name = "_v4_mv"
+    scan_name = "mv"
 
     # arg_input and arg_bundle_size are only relevant for scans that accept an arbitrary number of motor / position arguments (e.g. line scans, grid scans).
     # For scans with a fixed set of parameters (e.g. Fermat spiral), these can be simply removed.

--- a/bec_server/bec_server/scan_server/scans/multi_region_grid_scan.py
+++ b/bec_server/bec_server/scan_server/scans/multi_region_grid_scan.py
@@ -36,7 +36,7 @@ class MultiRegionGridScan(ScanBase):
     # Scan name: This is the name of the scan, e.g. "line_scan". This is used for display purposes and to identify the scan type in user interfaces.
     # Choose a descriptive name that does not conflict with existing scan names.
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
-    scan_name = "_v4_multi_region_grid_scan"
+    scan_name = "multi_region_grid_scan"
 
     gui_config = {
         "Motors": ["motor1", "motor2"],

--- a/bec_server/bec_server/scan_server/scans/multi_region_line_scan.py
+++ b/bec_server/bec_server/scan_server/scans/multi_region_line_scan.py
@@ -36,7 +36,7 @@ class MultiRegionLineScan(ScanBase):
     # Scan name: This is the name of the scan, e.g. "line_scan". This is used for display purposes and to identify the scan type in user interfaces.
     # Choose a descriptive name that does not conflict with existing scan names.
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
-    scan_name = "_v4_multi_region_line_scan"
+    scan_name = "multi_region_line_scan"
 
     gui_config = {
         "Movement Parameters": ["regions", "relative"],

--- a/bec_server/bec_server/scan_server/scans/round_roi_scan.py
+++ b/bec_server/bec_server/scan_server/scans/round_roi_scan.py
@@ -38,7 +38,7 @@ class RoundROIScan(ScanBase):
     # Scan name: This is the name of the scan, e.g. "line_scan". This is used for display purposes and to identify the scan type in user interfaces.
     # Choose a descriptive name that does not conflict with existing scan names.
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
-    scan_name = "_v4_round_roi_scan"
+    scan_name = "round_roi_scan"
     gui_config = {
         "Motor 1": ["motor_1", "start_motor_1", "stop_motor_1", "center_1"],
         "Motor 2": ["motor_2", "start_motor_2", "stop_motor_2", "center_2"],

--- a/bec_server/bec_server/scan_server/scans/round_scan.py
+++ b/bec_server/bec_server/scan_server/scans/round_scan.py
@@ -38,7 +38,7 @@ class RoundScan(ScanBase):
     # Scan name: This is the name of the scan, e.g. "line_scan". This is used for display purposes and to identify the scan type in user interfaces.
     # Choose a descriptive name that does not conflict with existing scan names.
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
-    scan_name = "_v4_round_scan"
+    scan_name = "round_scan"
     gui_config = {
         "Motors": ["motor_1", "motor_2"],
         "Ring Parameters": [

--- a/bec_server/bec_server/scan_server/scans/scan_argument_modifier.py
+++ b/bec_server/bec_server/scan_server/scans/scan_argument_modifier.py
@@ -141,7 +141,7 @@ def _build_signature_from_arguments(
         annotation = arguments[name]
         parameters.append(
             param.replace(
-                annotation=annotation if annotation is not None else inspect.Parameter.empty,
+                annotation=(annotation if annotation is not None else inspect.Parameter.empty),
                 default=defaults.get(name, inspect.Parameter.empty),
             )
         )
@@ -155,7 +155,7 @@ def _build_signature_from_arguments(
                 name=name,
                 kind=inspect.Parameter.KEYWORD_ONLY,
                 default=defaults.get(name, inspect.Parameter.empty),
-                annotation=annotation if annotation is not None else inspect.Parameter.empty,
+                annotation=(annotation if annotation is not None else inspect.Parameter.empty),
             )
         )
 
@@ -163,7 +163,7 @@ def _build_signature_from_arguments(
         annotation = arguments[trailing_var_keyword.name]
         parameters.append(
             trailing_var_keyword.replace(
-                annotation=annotation if annotation is not None else inspect.Parameter.empty,
+                annotation=(annotation if annotation is not None else inspect.Parameter.empty),
                 default=defaults.get(trailing_var_keyword.name, inspect.Parameter.empty),
             )
         )

--- a/bec_server/bec_server/scan_server/scans/scan_base.py
+++ b/bec_server/bec_server/scan_server/scans/scan_base.py
@@ -160,10 +160,11 @@ class ScanInfo(BaseModel):
 
 class ScanBase(ABC):
     scan_type = ScanType.SOFTWARE_TRIGGERED
-    scan_name = "_v4_base_scan"
+    scan_name = "base_scan"
     arg_input = {}
     arg_bundle_size = {"bundle": len(arg_input), "min": None, "max": None}
     is_scan = True
+    is_internal = False
 
     def __init__(
         self,

--- a/bec_server/bec_server/scan_server/scans/time_scan.py
+++ b/bec_server/bec_server/scan_server/scans/time_scan.py
@@ -36,7 +36,7 @@ class TimeScan(ScanBase):
     # Scan name: This is the name of the scan, e.g. "line_scan". This is used for display purposes and to identify the scan type in user interfaces.
     # Choose a descriptive name that does not conflict with existing scan names.
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
-    scan_name = "_v4_time_scan"
+    scan_name = "time_scan"
 
     gui_config = {"Scan Parameters": ["points", "interval", "exp_time", "settling_time"]}
 

--- a/bec_server/bec_server/scan_server/scans/updated_move.py
+++ b/bec_server/bec_server/scan_server/scans/updated_move.py
@@ -37,7 +37,7 @@ class UpdatedMoveScan(ScanBase):
     # Scan name: This is the name of the scan, e.g. "line_scan". This is used for display purposes and to identify the scan type in user interfaces.
     # Choose a descriptive name that does not conflict with existing scan names.
     # It must be a valid Python identifier, that is, it can only contain letters, numbers, and underscores, and must not start with a number.
-    scan_name = "_v4_umv"
+    scan_name = "umv"
 
     # arg_input and arg_bundle_size are only relevant for scans that accept an arbitrary number of motor / position arguments (e.g. line scans, grid scans).
     # For scans with a fixed set of parameters (e.g. Fermat spiral), these can be simply removed.

--- a/bec_server/bec_server/scihub/atlas/atlas_metadata_handler.py
+++ b/bec_server/bec_server/scihub/atlas/atlas_metadata_handler.py
@@ -108,7 +108,9 @@ class AtlasMetadataHandler:
         service_info = messages.AvailableMessagingServicesMessage(
             config=info.messaging_config,
             deployment_services=info.messaging_services,
-            session_services=info.active_session.messaging_services if info.active_session else [],
+            session_services=(
+                info.active_session.messaging_services if info.active_session else []
+            ),
         )
         self.atlas_connector.connector.xadd(
             MessageEndpoints.available_messaging_services(),

--- a/bec_server/tests/tests_bec_server_utils/test_service_handler.py
+++ b/bec_server/tests/tests_bec_server_utils/test_service_handler.py
@@ -38,6 +38,18 @@ def test_service_handler_stop():
         mock_tmux_stop.assert_called()
 
 
+def test_service_handler_stop_subprocess_forwards_timeout():
+    with mock.patch(
+        "bec_server.bec_server_utils.service_handler.subprocess_stop"
+    ) as mock_subprocess_stop:
+        service_handler = ServiceHandler("/path/to/bec", interface="subprocess")
+        processes = [object()]
+
+        service_handler.stop(processes, timeout_s=12)
+
+        mock_subprocess_stop.assert_called_once_with(processes, timeout_s=12)
+
+
 def test_service_handler_restart():
     bec_path = "/path/to/bec"
     config_path = "/path/to/config"

--- a/bec_server/tests/tests_bec_server_utils/test_subprocess_launch.py
+++ b/bec_server/tests/tests_bec_server_utils/test_subprocess_launch.py
@@ -1,0 +1,152 @@
+import subprocess
+from string import Template
+from unittest import mock
+
+import psutil
+
+from bec_server.bec_server_utils.service_handler import ServiceDesc
+from bec_server.bec_server_utils.subprocess_launch import (
+    TerminalProc,
+    _kill_process_and_children,
+    _stop_psutil_process,
+    _stop_subprocess,
+    detect_terminal,
+    subprocess_start,
+    subprocess_stop,
+)
+
+
+def test_detect_terminal_returns_first_available():
+    detect_terminal.cache_clear()
+    try:
+        with mock.patch(
+            "bec_server.bec_server_utils.subprocess_launch.shutil.which",
+            side_effect=[None, "/usr/bin/konsole"],
+        ):
+            terminal = detect_terminal()
+    finally:
+        detect_terminal.cache_clear()
+
+    assert terminal.cmd == "konsole"
+
+
+def test_subprocess_start_without_terminal_runs_processes_in_background():
+    services = {
+        "scan_server": ServiceDesc(
+            Template("$base_path/scan_server"), "bec-scan-server", args=["--flag"]
+        )
+    }
+
+    with (
+        mock.patch(
+            "bec_server.bec_server_utils.subprocess_launch.detect_terminal",
+            side_effect=RuntimeError,
+        ),
+        mock.patch("bec_server.bec_server_utils.subprocess_launch.subprocess.Popen") as mock_popen,
+    ):
+        processes = subprocess_start("/tmp/bec", services)
+
+    mock_popen.assert_called_once_with(
+        ["bec-scan-server", "--flag"], cwd="/tmp/bec", stdout=subprocess.DEVNULL
+    )
+    assert processes == [mock_popen.return_value]
+
+
+def test_subprocess_stop_uses_stop_subprocess_for_terminal_process():
+    process = mock.Mock(args=["xterm"], pid=123)
+
+    with (
+        mock.patch(
+            "bec_server.bec_server_utils.subprocess_launch._stop_subprocess"
+        ) as mock_stop_subprocess,
+        mock.patch(
+            "bec_server.bec_server_utils.subprocess_launch._kill_process_and_children"
+        ) as mock_kill_processes,
+    ):
+        subprocess_stop([process], timeout_s=7)
+
+    mock_stop_subprocess.assert_called_once_with(process, timeout_s=7)
+    mock_kill_processes.assert_not_called()
+
+
+def test_subprocess_stop_uses_kill_processes_for_spawn_child_terminal():
+    process = mock.Mock(args=["custom-term"], pid=456)
+    terminals = (TerminalProc("custom-term", args=["-e"], spawn_child=True),)
+
+    with (
+        mock.patch("bec_server.bec_server_utils.subprocess_launch.TERMINALS", terminals),
+        mock.patch(
+            "bec_server.bec_server_utils.subprocess_launch._stop_subprocess"
+        ) as mock_stop_subprocess,
+        mock.patch(
+            "bec_server.bec_server_utils.subprocess_launch._kill_process_and_children"
+        ) as mock_kill_processes,
+    ):
+        subprocess_stop([process], timeout_s=9)
+
+    mock_kill_processes.assert_called_once_with(456, timeout_s=9)
+    mock_stop_subprocess.assert_not_called()
+
+
+def test_subprocess_stop_uses_kill_processes_for_non_terminal_process():
+    process = mock.Mock(args=["python"], pid=789)
+
+    with mock.patch(
+        "bec_server.bec_server_utils.subprocess_launch._kill_process_and_children"
+    ) as mock_kill_processes:
+        subprocess_stop([process], timeout_s=11)
+
+    mock_kill_processes.assert_called_once_with(789, timeout_s=11)
+
+
+def test_stop_subprocess_kills_after_timeout():
+    process = mock.Mock()
+    process.wait.side_effect = [subprocess.TimeoutExpired(cmd="cmd", timeout=3), None]
+
+    _stop_subprocess(process, timeout_s=3)
+
+    process.terminate.assert_called_once_with()
+    process.kill.assert_called_once_with()
+    assert process.wait.call_args_list == [mock.call(timeout=3), mock.call(timeout=3)]
+
+
+def test_stop_psutil_process_kills_after_timeout():
+    process = mock.Mock()
+    process.wait.side_effect = [psutil.TimeoutExpired(seconds=4, pid=55), None]
+
+    _stop_psutil_process(process, timeout_s=4)
+
+    process.terminate.assert_called_once_with()
+    process.kill.assert_called_once_with()
+    assert process.wait.call_args_list == [mock.call(timeout=4), mock.call(timeout=4)]
+
+
+def test_kill_process_and_children_stops_children_before_parent():
+    child1 = mock.Mock()
+    child2 = mock.Mock()
+    parent = mock.Mock()
+    parent.children.return_value = [child1, child2]
+
+    with (
+        mock.patch(
+            "bec_server.bec_server_utils.subprocess_launch.psutil.Process", return_value=parent
+        ),
+        mock.patch(
+            "bec_server.bec_server_utils.subprocess_launch._stop_psutil_process"
+        ) as mock_stop_psutil_process,
+    ):
+        _kill_process_and_children(999, timeout_s=5)
+
+    assert mock_stop_psutil_process.call_args_list == [
+        mock.call(child1, timeout_s=5),
+        mock.call(child2, timeout_s=5),
+        mock.call(parent, timeout_s=5),
+    ]
+
+
+def test_kill_process_and_children_ignores_missing_parent_process():
+    with mock.patch(
+        "bec_server.bec_server_utils.subprocess_launch.psutil.Process",
+        side_effect=psutil.NoSuchProcess(pid=12),
+    ):
+        _kill_process_and_children(12, timeout_s=2)

--- a/bec_server/tests/tests_scan_server/scans_v4/test_acquire.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_acquire.py
@@ -24,13 +24,13 @@ ACQUIRE_DEFAULT_HOOK_TESTS = [
 
 @pytest.mark.parametrize(("hook_name", "hook_tests"), ACQUIRE_DEFAULT_HOOK_TESTS)
 def test_acquire_default_hooks(v4_scan_assembler, nth_done_status_mock, hook_name, hook_tests):
-    scan = v4_scan_assembler("_v4_acquire", exp_time=0.2, burst_at_each_point=3)
+    scan = v4_scan_assembler("acquire", exp_time=0.2, burst_at_each_point=3)
 
     run_scan_tests(scan, [(hook_name, hook_tests)], nth_done_status_mock=nth_done_status_mock)
 
 
 def test_acquire_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_acquire", exp_time=0.2, burst_at_each_point=3)
+    scan = v4_scan_assembler("acquire", exp_time=0.2, burst_at_each_point=3)
 
     scan.prepare_scan()
 
@@ -43,7 +43,7 @@ def test_acquire_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler):
 
 
 def test_acquire_scan_core_triggers_and_reads_for_each_burst(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_acquire", exp_time=0.2, burst_at_each_point=3)
+    scan = v4_scan_assembler("acquire", exp_time=0.2, burst_at_each_point=3)
     scan.at_each_point = mock.MagicMock()
 
     scan.scan_core()
@@ -52,7 +52,7 @@ def test_acquire_scan_core_triggers_and_reads_for_each_burst(v4_scan_assembler):
 
 
 def test_acquire_at_each_point_triggers_and_reads(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_acquire", exp_time=0.2, burst_at_each_point=3)
+    scan = v4_scan_assembler("acquire", exp_time=0.2, burst_at_each_point=3)
     scan.components.trigger_and_read = mock.MagicMock()
 
     scan.at_each_point()
@@ -61,7 +61,7 @@ def test_acquire_at_each_point_triggers_and_reads(v4_scan_assembler):
 
 
 def test_acquire_post_scan_completes_all_devices(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_acquire", exp_time=0.2, burst_at_each_point=3)
+    scan = v4_scan_assembler("acquire", exp_time=0.2, burst_at_each_point=3)
     scan.actions.complete_all_devices = mock.MagicMock()
 
     scan.post_scan()

--- a/bec_server/tests/tests_scan_server/scans_v4/test_cont_line_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_cont_line_scan.py
@@ -68,7 +68,7 @@ def _assemble_cont_line_scan(
     )
     device_manager.add_device(custom_samx, replace=True)
     return v4_scan_assembler(
-        "_v4_cont_line_scan", "samx", start, stop, steps=steps, exp_time=exp_time, relative=relative
+        "cont_line_scan", "samx", start, stop, steps=steps, exp_time=exp_time, relative=relative
     )
 
 
@@ -136,7 +136,7 @@ def test_cont_line_scan_example_custom_device_manager_integration(
     device_manager.add_device(custom_samx, replace=True)
 
     scan = v4_scan_assembler(
-        "_v4_cont_line_scan", "samx", -1.0, 1.0, steps=3, exp_time=0.1, relative=False
+        "cont_line_scan", "samx", -1.0, 1.0, steps=3, exp_time=0.1, relative=False
     )
 
     assert scan.device is custom_samx
@@ -174,7 +174,7 @@ def test_mock_custom_device_supports_generated_signal_values():
 
 def test_cont_line_scan_at_each_point_triggers_and_reads(v4_scan_assembler):
     scan = v4_scan_assembler(
-        "_v4_cont_line_scan", "samx", -1.0, 1.0, steps=3, exp_time=0.1, relative=False
+        "cont_line_scan", "samx", -1.0, 1.0, steps=3, exp_time=0.1, relative=False
     )
     scan.components.trigger_and_read = mock.MagicMock()
 
@@ -234,7 +234,7 @@ def test_cont_line_scan_prepare_scan_raises_when_motor_too_fast(v4_scan_assemble
 
 def test_cont_line_scan_post_scan_moves_back_when_relative(v4_scan_assembler, nth_done_status_mock):
     scan = v4_scan_assembler(
-        "_v4_cont_line_scan", "samx", -1.0, 1.0, steps=3, exp_time=0.1, relative=True
+        "cont_line_scan", "samx", -1.0, 1.0, steps=3, exp_time=0.1, relative=True
     )
     completion_status = nth_done_status_mock(resolve_after=2)
     scan.start_positions = [1.5]
@@ -250,7 +250,7 @@ def test_cont_line_scan_post_scan_moves_back_when_relative(v4_scan_assembler, nt
 
 def test_cont_line_scan_on_exception_moves_back_when_relative(v4_scan_assembler):
     scan = v4_scan_assembler(
-        "_v4_cont_line_scan", "samx", -1.0, 1.0, steps=3, exp_time=0.1, relative=True
+        "cont_line_scan", "samx", -1.0, 1.0, steps=3, exp_time=0.1, relative=True
     )
     scan.start_positions = [1.5]
     scan.components.move_and_wait = mock.MagicMock()

--- a/bec_server/tests/tests_scan_server/scans_v4/test_device_rpc_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_device_rpc_scan.py
@@ -16,14 +16,14 @@ import pytest
     ],
 )
 def test_device_rpc_scan_default_noop_hooks_do_not_raise(v4_scan_assembler, hook_name):
-    scan = v4_scan_assembler("_v4_device_rpc", "samx", "read", [], {}, rpc_id="rpc-id-123")
+    scan = v4_scan_assembler("device_rpc", "samx", "read", [], {}, rpc_id="rpc-id-123")
 
     getattr(scan, hook_name)()
 
 
 def test_device_rpc_scan_core_sends_fire_and_forget_rpc(v4_scan_assembler):
     scan = v4_scan_assembler(
-        "_v4_device_rpc",
+        "device_rpc",
         "samx",
         "controller.set_mode",
         [1, "fast"],
@@ -43,8 +43,8 @@ def test_device_rpc_scan_core_sends_fire_and_forget_rpc(v4_scan_assembler):
 
 
 def test_device_rpc_scan_is_registered_as_non_scan(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_device_rpc", "samx", "read", [], {}, rpc_id="rpc-id-123")
+    scan = v4_scan_assembler("device_rpc", "samx", "read", [], {}, rpc_id="rpc-id-123")
 
-    assert scan.scan_name == "_v4_device_rpc"
+    assert scan.scan_name == "device_rpc"
     assert scan.is_scan is False
     assert scan.scan_info.scan_type is None

--- a/bec_server/tests/tests_scan_server/scans_v4/test_fermat_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_fermat_scan.py
@@ -17,7 +17,7 @@ from bec_server.scan_server.tests.scan_hook_tests import (
 )
 def test_fermat_scan_default_hooks(v4_scan_assembler, nth_done_status_mock, hook_name, hook_tests):
     scan = v4_scan_assembler(
-        "_v4_fermat_scan", "samx", -1.0, 1.0, "samy", -2.0, 2.0, step=0.5, relative=False
+        "fermat_scan", "samx", -1.0, 1.0, "samy", -2.0, 2.0, step=0.5, relative=False
     )
 
     run_scan_tests(scan, [(hook_name, hook_tests)], nth_done_status_mock=nth_done_status_mock)
@@ -25,7 +25,7 @@ def test_fermat_scan_default_hooks(v4_scan_assembler, nth_done_status_mock, hook
 
 def test_fermat_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler):
     scan = v4_scan_assembler(
-        "_v4_fermat_scan", "samx", -1.0, 1.0, "samy", -2.0, 2.0, step=0.5, relative=False
+        "fermat_scan", "samx", -1.0, 1.0, "samy", -2.0, 2.0, step=0.5, relative=False
     )
 
     scan.prepare_scan()
@@ -50,7 +50,7 @@ def test_fermat_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler)
 
 def test_fermat_scan_prepare_scan_uses_first_axis_as_corridor_axis(v4_scan_assembler):
     scan = v4_scan_assembler(
-        "_v4_fermat_scan",
+        "fermat_scan",
         "samx",
         -1.0,
         1.0,
@@ -76,7 +76,7 @@ def test_fermat_scan_prepare_scan_uses_first_axis_as_corridor_axis(v4_scan_assem
 
 def test_fermat_scan_prepare_scan_uses_first_axis_range_for_preferred_direction(v4_scan_assembler):
     scan = v4_scan_assembler(
-        "_v4_fermat_scan",
+        "fermat_scan",
         "samx",
         1.0,
         -1.0,

--- a/bec_server/tests/tests_scan_server/scans_v4/test_grid_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_grid_scan.py
@@ -15,7 +15,7 @@ from bec_server.scan_server.tests.scan_hook_tests import (
 )
 def test_grid_scan_default_hooks(v4_scan_assembler, nth_done_status_mock, hook_name, hook_tests):
     scan = v4_scan_assembler(
-        "_v4_grid_scan", "samx", -1.0, 1.0, 3, "samy", -2.0, 2.0, 5, snaked=True, relative=False
+        "grid_scan", "samx", -1.0, 1.0, 3, "samy", -2.0, 2.0, 5, snaked=True, relative=False
     )
 
     run_scan_tests(scan, [(hook_name, hook_tests)], nth_done_status_mock=nth_done_status_mock)
@@ -23,7 +23,7 @@ def test_grid_scan_default_hooks(v4_scan_assembler, nth_done_status_mock, hook_n
 
 def test_grid_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler):
     scan = v4_scan_assembler(
-        "_v4_grid_scan", "samx", -1.0, 1.0, 3, "samy", -2.0, 2.0, 5, snaked=True, relative=False
+        "grid_scan", "samx", -1.0, 1.0, 3, "samy", -2.0, 2.0, 5, snaked=True, relative=False
     )
 
     scan.prepare_scan()
@@ -39,7 +39,7 @@ def test_grid_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler):
 
 def test_grid_scan_uses_first_axis_as_fast_axis(v4_scan_assembler):
     scan = v4_scan_assembler(
-        "_v4_grid_scan", "samx", 0.0, 2.0, 3, "samy", 0.0, 1.0, 2, snaked=True, relative=False
+        "grid_scan", "samx", 0.0, 2.0, 3, "samy", 0.0, 1.0, 2, snaked=True, relative=False
     )
 
     scan.prepare_scan()

--- a/bec_server/tests/tests_scan_server/scans_v4/test_hexagonal_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_hexagonal_scan.py
@@ -18,7 +18,7 @@ def test_hexagonal_scan_default_hooks(
     v4_scan_assembler, nth_done_status_mock, hook_name, hook_tests
 ):
     scan = v4_scan_assembler(
-        "_v4_hexagonal_scan", "samx", -1.0, 1.0, 1.0, "samy", -1.0, 1.0, 1.0, relative=False
+        "hexagonal_scan", "samx", -1.0, 1.0, 1.0, "samy", -1.0, 1.0, 1.0, relative=False
     )
 
     run_scan_tests(scan, [(hook_name, hook_tests)], nth_done_status_mock=nth_done_status_mock)
@@ -26,7 +26,7 @@ def test_hexagonal_scan_default_hooks(
 
 def test_hexagonal_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler):
     scan = v4_scan_assembler(
-        "_v4_hexagonal_scan", "samx", -1.0, 1.0, 1.0, "samy", -1.0, 1.0, 1.0, relative=False
+        "hexagonal_scan", "samx", -1.0, 1.0, 1.0, "samy", -1.0, 1.0, 1.0, relative=False
     )
 
     scan.prepare_scan()
@@ -41,7 +41,7 @@ def test_hexagonal_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembl
 
 def test_hexagonal_scan_uses_first_axis_as_fast_axis(v4_scan_assembler):
     scan = v4_scan_assembler(
-        "_v4_hexagonal_scan", "samx", 0.0, 2.0, 1.0, "samy", 0.0, 1.0, 1.0, relative=False
+        "hexagonal_scan", "samx", 0.0, 2.0, 1.0, "samy", 0.0, 1.0, 1.0, relative=False
     )
 
     scan.prepare_scan()
@@ -52,7 +52,7 @@ def test_hexagonal_scan_uses_first_axis_as_fast_axis(v4_scan_assembler):
 
 def test_hexagonal_scan_prepare_scan_offsets_positions_when_relative(v4_scan_assembler):
     scan = v4_scan_assembler(
-        "_v4_hexagonal_scan", "samx", -1.0, 1.0, 1.0, "samy", -1.0, 1.0, 1.0, relative=True
+        "hexagonal_scan", "samx", -1.0, 1.0, 1.0, "samy", -1.0, 1.0, 1.0, relative=True
     )
     scan.components.get_start_positions = lambda motors: [5.0, -2.0]
 

--- a/bec_server/tests/tests_scan_server/scans_v4/test_line_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_line_scan.py
@@ -15,7 +15,7 @@ from bec_server.scan_server.tests.scan_hook_tests import (
 )
 def test_line_scan_default_hooks(v4_scan_assembler, nth_done_status_mock, hook_name, hook_tests):
     scan = v4_scan_assembler(
-        "_v4_line_scan", "samx", -1.0, 1.0, "samy", -2.0, 2.0, steps=5, relative=False
+        "line_scan", "samx", -1.0, 1.0, "samy", -2.0, 2.0, steps=5, relative=False
     )
 
     run_scan_tests(scan, [(hook_name, hook_tests)], nth_done_status_mock=nth_done_status_mock)
@@ -23,7 +23,7 @@ def test_line_scan_default_hooks(v4_scan_assembler, nth_done_status_mock, hook_n
 
 def test_line_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler):
     scan = v4_scan_assembler(
-        "_v4_line_scan", "samx", -1.0, 1.0, "samy", -2.0, 2.0, steps=5, relative=False
+        "line_scan", "samx", -1.0, 1.0, "samy", -2.0, 2.0, steps=5, relative=False
     )
 
     scan.prepare_scan()
@@ -39,7 +39,7 @@ def test_line_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler):
 
 def test_line_scan_prepare_scan_offsets_positions_when_relative(v4_scan_assembler):
     scan = v4_scan_assembler(
-        "_v4_line_scan", "samx", -1.0, 1.0, "samy", -2.0, 2.0, steps=5, relative=True
+        "line_scan", "samx", -1.0, 1.0, "samy", -2.0, 2.0, steps=5, relative=True
     )
     scan.components.get_start_positions = lambda motors: [2.0, 3.0]
 

--- a/bec_server/tests/tests_scan_server/scans_v4/test_line_sweep_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_line_sweep_scan.py
@@ -40,14 +40,14 @@ def _device_readback_message(device_name: str, value: float) -> MessageObject:
 def test_line_sweep_scan_default_hooks(
     v4_scan_assembler, nth_done_status_mock, hook_name, hook_tests
 ):
-    scan = v4_scan_assembler("_v4_line_sweep_scan", "samx", -5.0, 5.0, relative=True)
+    scan = v4_scan_assembler("line_sweep_scan", "samx", -5.0, 5.0, relative=True)
 
     run_scan_tests(scan, [(hook_name, hook_tests)], nth_done_status_mock=nth_done_status_mock)
 
 
 def test_line_sweep_scan_prepare_scan_updates_scan_info(v4_scan_assembler):
     scan = v4_scan_assembler(
-        "_v4_line_sweep_scan",
+        "line_sweep_scan",
         "samx",
         -5.0,
         5.0,
@@ -70,7 +70,7 @@ def test_line_sweep_scan_prepare_scan_updates_scan_info(v4_scan_assembler):
 
 
 def test_line_sweep_scan_at_each_point_triggers_and_reads(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_line_sweep_scan", "samx", -5.0, 5.0, relative=False)
+    scan = v4_scan_assembler("line_sweep_scan", "samx", -5.0, 5.0, relative=False)
     scan.components.trigger_and_read = mock.MagicMock()
 
     scan.at_each_point()
@@ -81,9 +81,7 @@ def test_line_sweep_scan_at_each_point_triggers_and_reads(v4_scan_assembler):
 def test_line_sweep_scan_scan_core_moves_and_reads_until_done(
     v4_scan_assembler, nth_done_status_mock
 ):
-    scan = v4_scan_assembler(
-        "_v4_line_sweep_scan", "samx", -5.0, 5.0, min_update=0.1, relative=False
-    )
+    scan = v4_scan_assembler("line_sweep_scan", "samx", -5.0, 5.0, min_update=0.1, relative=False)
     scan.prepare_scan()
     done_status = nth_done_status_mock(resolve_after=4)
     scan.device.set = mock.MagicMock(return_value=done_status)
@@ -112,7 +110,7 @@ def test_line_sweep_scan_scan_core_moves_and_reads_until_done(
 def test_line_sweep_scan_scan_core_coalesces_multiple_readback_updates(
     v4_scan_assembler, nth_done_status_mock
 ):
-    scan = v4_scan_assembler("_v4_line_sweep_scan", "samx", -5.0, 5.0, relative=False)
+    scan = v4_scan_assembler("line_sweep_scan", "samx", -5.0, 5.0, relative=False)
     scan.prepare_scan()
     done_status = nth_done_status_mock(resolve_after=2)
     scan.device.set = mock.MagicMock(return_value=done_status)
@@ -134,7 +132,7 @@ def test_line_sweep_scan_scan_core_coalesces_multiple_readback_updates(
 def test_line_sweep_scan_scan_core_reads_final_pending_update(
     v4_scan_assembler, nth_done_status_mock
 ):
-    scan = v4_scan_assembler("_v4_line_sweep_scan", "samx", -5.0, 5.0, relative=False)
+    scan = v4_scan_assembler("line_sweep_scan", "samx", -5.0, 5.0, relative=False)
     scan.prepare_scan()
     done_status = nth_done_status_mock(resolve_after=2)
     scan.device.set = mock.MagicMock(return_value=done_status)
@@ -155,7 +153,7 @@ def test_line_sweep_scan_scan_core_reads_final_pending_update(
 def test_line_sweep_scan_scan_core_waits_for_event_when_no_update(
     v4_scan_assembler, nth_done_status_mock
 ):
-    scan = v4_scan_assembler("_v4_line_sweep_scan", "samx", -5.0, 5.0, relative=False)
+    scan = v4_scan_assembler("line_sweep_scan", "samx", -5.0, 5.0, relative=False)
     scan.prepare_scan()
     done_status = nth_done_status_mock(resolve_after=2)
     scan.device.set = mock.MagicMock(return_value=done_status)
@@ -180,9 +178,7 @@ def test_line_sweep_scan_scan_core_waits_for_event_when_no_update(
 def test_line_sweep_scan_scan_core_triggers_read_when_max_update_expires(
     v4_scan_assembler, nth_done_status_mock
 ):
-    scan = v4_scan_assembler(
-        "_v4_line_sweep_scan", "samx", -5.0, 5.0, max_update=0.1, relative=False
-    )
+    scan = v4_scan_assembler("line_sweep_scan", "samx", -5.0, 5.0, max_update=0.1, relative=False)
     scan.prepare_scan()
     done_status = nth_done_status_mock(resolve_after=3)
     scan.device.set = mock.MagicMock(return_value=done_status)
@@ -205,7 +201,7 @@ def test_line_sweep_scan_scan_core_triggers_read_when_max_update_expires(
 
 
 def test_line_sweep_scan_device_readback_callback_sets_update_event(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_line_sweep_scan", "samx", -5.0, 5.0, relative=False)
+    scan = v4_scan_assembler("line_sweep_scan", "samx", -5.0, 5.0, relative=False)
     assert scan._readback_update_event.is_set() is False
 
     scan._device_readback_callback(_device_readback_message("samx", 2.0))
@@ -216,7 +212,7 @@ def test_line_sweep_scan_device_readback_callback_sets_update_event(v4_scan_asse
 def test_line_sweep_scan_post_scan_moves_back_when_relative(
     v4_scan_assembler, nth_done_status_mock
 ):
-    scan = v4_scan_assembler("_v4_line_sweep_scan", "samx", -5.0, 5.0, relative=True)
+    scan = v4_scan_assembler("line_sweep_scan", "samx", -5.0, 5.0, relative=True)
     completion_status = nth_done_status_mock(resolve_after=2)
     scan.start_positions = [1.0]
     scan.actions.complete_all_devices = mock.MagicMock(return_value=completion_status)
@@ -230,7 +226,7 @@ def test_line_sweep_scan_post_scan_moves_back_when_relative(
 
 
 def test_line_sweep_scan_on_exception_moves_back_when_relative(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_line_sweep_scan", "samx", -5.0, 5.0, relative=True)
+    scan = v4_scan_assembler("line_sweep_scan", "samx", -5.0, 5.0, relative=True)
     scan.start_positions = [1.0]
     scan.components.move_and_wait = mock.MagicMock()
 

--- a/bec_server/tests/tests_scan_server/scans_v4/test_list_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_list_scan.py
@@ -14,13 +14,13 @@ from bec_server.scan_server.tests.scan_hook_tests import (
     [*DEFAULT_HOOK_TESTS, *PREMOVE_HOOK_TESTS, *STANDARD_STEP_SCAN_TESTS],
 )
 def test_list_scan_default_hooks(v4_scan_assembler, nth_done_status_mock, hook_name, hook_tests):
-    scan = v4_scan_assembler("_v4_list_scan", "samx", [0, 1, 2], "samy", [3, 4, 5], relative=False)
+    scan = v4_scan_assembler("list_scan", "samx", [0, 1, 2], "samy", [3, 4, 5], relative=False)
 
     run_scan_tests(scan, [(hook_name, hook_tests)], nth_done_status_mock=nth_done_status_mock)
 
 
 def test_list_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_list_scan", "samx", [0, 1, 2], "samy", [3, 4, 5], relative=False)
+    scan = v4_scan_assembler("list_scan", "samx", [0, 1, 2], "samy", [3, 4, 5], relative=False)
 
     scan.prepare_scan()
 
@@ -31,7 +31,7 @@ def test_list_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler):
 
 
 def test_list_scan_prepare_scan_offsets_positions_when_relative(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_list_scan", "samx", [0, 1, 2], "samy", [3, 4, 5], relative=True)
+    scan = v4_scan_assembler("list_scan", "samx", [0, 1, 2], "samy", [3, 4, 5], relative=True)
     scan.components.get_start_positions = lambda motors: [1.0, -1.0]
 
     scan.prepare_scan()
@@ -43,4 +43,4 @@ def test_list_scan_prepare_scan_offsets_positions_when_relative(v4_scan_assemble
 
 def test_list_scan_raises_for_different_lengths(v4_scan_assembler):
     with pytest.raises(ValueError, match="equal length"):
-        v4_scan_assembler("_v4_list_scan", "samx", [0, 1], "samy", [0, 1, 2], relative=False)
+        v4_scan_assembler("list_scan", "samx", [0, 1], "samy", [0, 1, 2], relative=False)

--- a/bec_server/tests/tests_scan_server/scans_v4/test_log_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_log_scan.py
@@ -15,7 +15,7 @@ from bec_server.scan_server.tests.scan_hook_tests import (
 )
 def test_log_scan_default_hooks(v4_scan_assembler, nth_done_status_mock, hook_name, hook_tests):
     scan = v4_scan_assembler(
-        "_v4_log_scan", "samx", 0.1, 10.0, "samy", 0.01, 1.0, steps=3, relative=False
+        "log_scan", "samx", 0.1, 10.0, "samy", 0.01, 1.0, steps=3, relative=False
     )
 
     run_scan_tests(scan, [(hook_name, hook_tests)], nth_done_status_mock=nth_done_status_mock)
@@ -23,7 +23,7 @@ def test_log_scan_default_hooks(v4_scan_assembler, nth_done_status_mock, hook_na
 
 def test_log_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler):
     scan = v4_scan_assembler(
-        "_v4_log_scan", "samx", 0.1, 10.0, "samy", 0.01, 1.0, steps=3, relative=False
+        "log_scan", "samx", 0.1, 10.0, "samy", 0.01, 1.0, steps=3, relative=False
     )
 
     scan.prepare_scan()
@@ -42,7 +42,7 @@ def test_log_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler):
 
 def test_log_scan_prepare_scan_offsets_positions_when_relative(v4_scan_assembler):
     scan = v4_scan_assembler(
-        "_v4_log_scan", "samx", -1.0, 1.0, "samy", 0.0, 1.0, steps=3, relative=True
+        "log_scan", "samx", -1.0, 1.0, "samy", 0.0, 1.0, steps=3, relative=True
     )
     scan.components.get_start_positions = lambda motors: [2.0, 3.0]
 

--- a/bec_server/tests/tests_scan_server/scans_v4/test_move_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_move_scan.py
@@ -8,13 +8,13 @@ import pytest
     [("open_scan",), ("stage",), ("pre_scan",), ("post_scan",), ("unstage",), ("close_scan",)],
 )
 def test_move_scan_default_noop_hooks_do_not_raise(v4_scan_assembler, hook_name):
-    scan = v4_scan_assembler("_v4_mv", "samx", 1.5, "samy", -2.0, relative=False)
+    scan = v4_scan_assembler("mv", "samx", 1.5, "samy", -2.0, relative=False)
 
     getattr(scan, hook_name)()
 
 
 def test_move_scan_prepare_scan_registers_required_response_devices(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_mv", "samx", 1.5, "samy", -2.0, relative=False)
+    scan = v4_scan_assembler("mv", "samx", 1.5, "samy", -2.0, relative=False)
     scan.actions.add_device_with_required_response = mock.MagicMock()
 
     scan.prepare_scan()
@@ -23,7 +23,7 @@ def test_move_scan_prepare_scan_registers_required_response_devices(v4_scan_asse
 
 
 def test_move_scan_scan_core_sets_absolute_targets_without_wait(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_mv", "samx", 1.5, "samy", -2.0, relative=False)
+    scan = v4_scan_assembler("mv", "samx", 1.5, "samy", -2.0, relative=False)
     scan.actions.set = mock.MagicMock()
 
     scan.scan_core()
@@ -32,7 +32,7 @@ def test_move_scan_scan_core_sets_absolute_targets_without_wait(v4_scan_assemble
 
 
 def test_move_scan_scan_core_sets_relative_targets_without_wait(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_mv", "samx", 1.5, "samy", -2.0, relative=True)
+    scan = v4_scan_assembler("mv", "samx", 1.5, "samy", -2.0, relative=True)
     scan.components.get_start_positions = mock.MagicMock(return_value=[0.5, 3.0])
     scan.actions.set = mock.MagicMock()
 

--- a/bec_server/tests/tests_scan_server/scans_v4/test_multi_region_grid_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_multi_region_grid_scan.py
@@ -17,7 +17,7 @@ def test_multi_region_grid_scan_default_hooks(
     v4_scan_assembler, nth_done_status_mock, hook_name, hook_tests
 ):
     scan = v4_scan_assembler(
-        "_v4_multi_region_grid_scan",
+        "multi_region_grid_scan",
         "samx",
         "samy",
         regions=[[(-3.0, -1.0, 2), (-2.0, 2.0, 3)], [(1.0, 3.0, 2), (-2.0, 2.0, 3)]],
@@ -30,7 +30,7 @@ def test_multi_region_grid_scan_default_hooks(
 
 def test_multi_region_grid_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler):
     scan = v4_scan_assembler(
-        "_v4_multi_region_grid_scan",
+        "multi_region_grid_scan",
         "samx",
         "samy",
         regions=[[(-3.0, -1.0, 2), (-2.0, 2.0, 3)], [(1.0, 3.0, 2), (-2.0, 2.0, 3)]],
@@ -66,7 +66,7 @@ def test_multi_region_grid_scan_prepare_scan_updates_scan_info_and_queue(v4_scan
 
 def test_multi_region_grid_scan_prepare_scan_offsets_positions_when_relative(v4_scan_assembler):
     scan = v4_scan_assembler(
-        "_v4_multi_region_grid_scan",
+        "multi_region_grid_scan",
         "samx",
         "samy",
         regions=[[(-3.0, -1.0, 2), (-2.0, 2.0, 3)], [(1.0, 3.0, 2), (-2.0, 2.0, 3)]],
@@ -99,7 +99,7 @@ def test_multi_region_grid_scan_prepare_scan_offsets_positions_when_relative(v4_
 
 def test_multi_region_grid_scan_prepare_scan_rejects_empty_region_list(v4_scan_assembler):
     scan = v4_scan_assembler(
-        "_v4_multi_region_grid_scan", "samx", "samy", regions=[], snaked=True, relative=False
+        "multi_region_grid_scan", "samx", "samy", regions=[], snaked=True, relative=False
     )
 
     with pytest.raises(ValueError, match="at least one paired region"):

--- a/bec_server/tests/tests_scan_server/scans_v4/test_multi_region_line_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_multi_region_line_scan.py
@@ -17,10 +17,7 @@ def test_multi_region_line_scan_default_hooks(
     v4_scan_assembler, nth_done_status_mock, hook_name, hook_tests
 ):
     scan = v4_scan_assembler(
-        "_v4_multi_region_line_scan",
-        "samx",
-        regions=[(-5.0, -2.0, 4), (-1.0, 6.0, 4)],
-        relative=False,
+        "multi_region_line_scan", "samx", regions=[(-5.0, -2.0, 4), (-1.0, 6.0, 4)], relative=False
     )
 
     run_scan_tests(scan, [(hook_name, hook_tests)], nth_done_status_mock=nth_done_status_mock)
@@ -28,10 +25,7 @@ def test_multi_region_line_scan_default_hooks(
 
 def test_multi_region_line_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler):
     scan = v4_scan_assembler(
-        "_v4_multi_region_line_scan",
-        "samx",
-        regions=[(-5.0, -2.0, 4), (-1.0, 6.0, 4)],
-        relative=False,
+        "multi_region_line_scan", "samx", regions=[(-5.0, -2.0, 4), (-1.0, 6.0, 4)], relative=False
     )
 
     scan.prepare_scan()
@@ -49,10 +43,7 @@ def test_multi_region_line_scan_prepare_scan_updates_scan_info_and_queue(v4_scan
 
 def test_multi_region_line_scan_prepare_scan_offsets_positions_when_relative(v4_scan_assembler):
     scan = v4_scan_assembler(
-        "_v4_multi_region_line_scan",
-        "samx",
-        regions=[(-5.0, -2.0, 4), (-1.0, 6.0, 4)],
-        relative=True,
+        "multi_region_line_scan", "samx", regions=[(-5.0, -2.0, 4), (-1.0, 6.0, 4)], relative=True
     )
     scan.components.get_start_positions = lambda motors: [2.0]
 

--- a/bec_server/tests/tests_scan_server/scans_v4/test_relative_scan_return_to_start.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_relative_scan_return_to_start.py
@@ -3,20 +3,16 @@ from unittest import mock
 import pytest
 
 RELATIVE_SCAN_CASES = [
-    ("_v4_cont_line_scan", ("samx", -1.0, 1.0), {"steps": 3, "exp_time": 0.1, "relative": True}),
-    ("_v4_fermat_scan", ("samx", -1.0, 1.0, "samy", -2.0, 2.0), {"step": 0.5, "relative": True}),
+    ("cont_line_scan", ("samx", -1.0, 1.0), {"steps": 3, "exp_time": 0.1, "relative": True}),
+    ("fermat_scan", ("samx", -1.0, 1.0, "samy", -2.0, 2.0), {"step": 0.5, "relative": True}),
+    ("grid_scan", ("samx", -1.0, 1.0, 3, "samy", -2.0, 2.0, 5), {"snaked": True, "relative": True}),
+    ("hexagonal_scan", ("samx", -1.0, 1.0, 1.0, "samy", -1.0, 1.0, 1.0), {"relative": True}),
+    ("line_scan", ("samx", -1.0, 1.0, "samy", -2.0, 2.0), {"steps": 5, "relative": True}),
+    ("list_scan", ("samx", [0, 1, 2], "samy", [3, 4, 5]), {"relative": True}),
+    ("log_scan", ("samx", 0.1, 1.0, "samy", 0.01, 1.0), {"steps": 3, "relative": True}),
+    ("line_sweep_scan", ("samx", -5.0, 5.0), {"relative": True}),
     (
-        "_v4_grid_scan",
-        ("samx", -1.0, 1.0, 3, "samy", -2.0, 2.0, 5),
-        {"snaked": True, "relative": True},
-    ),
-    ("_v4_hexagonal_scan", ("samx", -1.0, 1.0, 1.0, "samy", -1.0, 1.0, 1.0), {"relative": True}),
-    ("_v4_line_scan", ("samx", -1.0, 1.0, "samy", -2.0, 2.0), {"steps": 5, "relative": True}),
-    ("_v4_list_scan", ("samx", [0, 1, 2], "samy", [3, 4, 5]), {"relative": True}),
-    ("_v4_log_scan", ("samx", 0.1, 1.0, "samy", 0.01, 1.0), {"steps": 3, "relative": True}),
-    ("_v4_line_sweep_scan", ("samx", -5.0, 5.0), {"relative": True}),
-    (
-        "_v4_multi_region_grid_scan",
+        "multi_region_grid_scan",
         ("samx", "samy"),
         {
             "regions": [((-5.0, -1.0, 5), (-4.0, 0.0, 5)), ((1.0, 5.0, 3), (-4.0, 0.0, 5))],
@@ -25,16 +21,16 @@ RELATIVE_SCAN_CASES = [
         },
     ),
     (
-        "_v4_multi_region_line_scan",
+        "multi_region_line_scan",
         ("samx",),
         {"regions": [(-5.0, -2.0, 4), (-1.0, 6.0, 4)], "relative": True},
     ),
     (
-        "_v4_round_roi_scan",
+        "round_roi_scan",
         ("samx", -3.0, 3.0, "samy", -2.0, 2.0),
         {"shell_spacing": 1.0, "pos_in_first_ring": 4, "relative": True},
     ),
-    ("_v4_round_scan", ("samx", "samy", 0.0, 2.0, 2, 3), {"relative": True}),
+    ("round_scan", ("samx", "samy", 0.0, 2.0, 2, 3), {"relative": True}),
 ]
 
 

--- a/bec_server/tests/tests_scan_server/scans_v4/test_round_roi_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_round_roi_scan.py
@@ -18,7 +18,7 @@ def test_round_roi_scan_default_hooks(
     v4_scan_assembler, nth_done_status_mock, hook_name, hook_tests
 ):
     scan = v4_scan_assembler(
-        "_v4_round_roi_scan",
+        "round_roi_scan",
         "samx",
         -3.0,
         3.0,
@@ -35,7 +35,7 @@ def test_round_roi_scan_default_hooks(
 
 def test_round_roi_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler):
     scan = v4_scan_assembler(
-        "_v4_round_roi_scan",
+        "round_roi_scan",
         "samx",
         -3.0,
         3.0,
@@ -59,7 +59,7 @@ def test_round_roi_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembl
 
 def test_round_roi_scan_prepare_scan_offsets_positions_when_relative(v4_scan_assembler):
     scan = v4_scan_assembler(
-        "_v4_round_roi_scan",
+        "round_roi_scan",
         "samx",
         -3.0,
         3.0,

--- a/bec_server/tests/tests_scan_server/scans_v4/test_round_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_round_scan.py
@@ -15,13 +15,13 @@ from bec_server.scan_server.tests.scan_hook_tests import (
     [*DEFAULT_HOOK_TESTS, *PREMOVE_HOOK_TESTS, *STANDARD_STEP_SCAN_TESTS],
 )
 def test_round_scan_default_hooks(v4_scan_assembler, nth_done_status_mock, hook_name, hook_tests):
-    scan = v4_scan_assembler("_v4_round_scan", "samx", "samy", 0.0, 2.0, 2, 3, relative=False)
+    scan = v4_scan_assembler("round_scan", "samx", "samy", 0.0, 2.0, 2, 3, relative=False)
 
     run_scan_tests(scan, [(hook_name, hook_tests)], nth_done_status_mock=nth_done_status_mock)
 
 
 def test_round_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_round_scan", "samx", "samy", 0.0, 2.0, 2, 3, relative=False)
+    scan = v4_scan_assembler("round_scan", "samx", "samy", 0.0, 2.0, 2, 3, relative=False)
 
     scan.prepare_scan()
 
@@ -32,7 +32,7 @@ def test_round_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler):
 
 
 def test_round_scan_prepare_scan_offsets_positions_when_relative(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_round_scan", "samx", "samy", 0.0, 2.0, 2, 3, relative=True)
+    scan = v4_scan_assembler("round_scan", "samx", "samy", 0.0, 2.0, 2, 3, relative=True)
     scan.components.get_start_positions = lambda motors: [1.0, -1.0]
 
     scan.prepare_scan()

--- a/bec_server/tests/tests_scan_server/scans_v4/test_scan_components.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_scan_components.py
@@ -7,7 +7,7 @@ from bec_server.scan_server.errors import LimitError
 
 
 def test_move_and_wait_only_moves_changed_motors(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_mv", "samx", 1.5, "samy", -2.0, relative=False)
+    scan = v4_scan_assembler("mv", "samx", 1.5, "samy", -2.0, relative=False)
     scan.actions.set = mock.MagicMock()
 
     scan.components.move_and_wait(
@@ -18,7 +18,7 @@ def test_move_and_wait_only_moves_changed_motors(v4_scan_assembler):
 
 
 def test_move_and_wait_skips_set_when_positions_do_not_change(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_mv", "samx", 1.5, "samy", -2.0, relative=False)
+    scan = v4_scan_assembler("mv", "samx", 1.5, "samy", -2.0, relative=False)
     scan.actions.set = mock.MagicMock()
 
     scan.components.move_and_wait(
@@ -29,7 +29,7 @@ def test_move_and_wait_skips_set_when_positions_do_not_change(v4_scan_assembler)
 
 
 def test_trigger_and_read_waits_triggers_and_reads(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_mv", "samx", 1.5, "samy", -2.0, relative=False)
+    scan = v4_scan_assembler("mv", "samx", 1.5, "samy", -2.0, relative=False)
     scan.scan_info.exp_time = 0.2
     scan.scan_info.frames_per_trigger = 3
     scan.scan_info.settling_time = 0.1
@@ -47,7 +47,7 @@ def test_trigger_and_read_waits_triggers_and_reads(v4_scan_assembler):
 
 
 def test_step_scan_reuses_previous_position_across_points_and_bursts(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_mv", "samx", 1.5, "samy", -2.0, relative=False)
+    scan = v4_scan_assembler("mv", "samx", 1.5, "samy", -2.0, relative=False)
     scan.scan_info.burst_at_each_point = 2
     at_each_point = mock.MagicMock()
     positions = np.array([[1.0, 2.0], [3.0, 4.0]])
@@ -75,7 +75,7 @@ def test_step_scan_reuses_previous_position_across_points_and_bursts(v4_scan_ass
 
 
 def test_step_scan_at_each_point_moves_then_triggers(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_mv", "samx", 1.5, "samy", -2.0, relative=False)
+    scan = v4_scan_assembler("mv", "samx", 1.5, "samy", -2.0, relative=False)
     scan.components.move_and_wait = mock.MagicMock()
     scan.components.trigger_and_read = mock.MagicMock()
     pos = np.array([1.0, 2.0])
@@ -90,7 +90,7 @@ def test_step_scan_at_each_point_moves_then_triggers(v4_scan_assembler):
 
 
 def test_get_start_positions_supports_motor_names_and_instances(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_mv", "samx", 1.5, "samy", -2.0, relative=False)
+    scan = v4_scan_assembler("mv", "samx", 1.5, "samy", -2.0, relative=False)
     scan.dev["samx"]._value = 1.25
     scan.dev["samy"]._value = -3.5
 
@@ -100,7 +100,7 @@ def test_get_start_positions_supports_motor_names_and_instances(v4_scan_assemble
 
 
 def test_optimize_trajectory_uses_corridor_defaults(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_mv", "samx", 1.5, "samy", -2.0, relative=False)
+    scan = v4_scan_assembler("mv", "samx", 1.5, "samy", -2.0, relative=False)
     positions = np.array([[0.0, 1.0], [1.0, 0.0]])
     optimized = np.array([[1.0, 0.0], [0.0, 1.0]])
     scan.components._path_optimizer.optimize_corridor = mock.MagicMock(return_value=optimized)
@@ -121,7 +121,7 @@ def test_optimize_trajectory_uses_corridor_defaults(v4_scan_assembler):
 
 
 def test_optimize_trajectory_passes_first_direction_for_corridor(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_mv", "samx", 1.5, "samy", -2.0, relative=False)
+    scan = v4_scan_assembler("mv", "samx", 1.5, "samy", -2.0, relative=False)
     positions = np.array([[0.0, 1.0], [1.0, 0.0]])
     scan.components._path_optimizer.optimize_corridor = mock.MagicMock(return_value=positions)
 
@@ -148,7 +148,7 @@ def test_optimize_trajectory_passes_first_direction_for_corridor(v4_scan_assembl
 def test_optimize_trajectory_passes_first_direction_when_first_axis_is_corridor_axis(
     v4_scan_assembler,
 ):
-    scan = v4_scan_assembler("_v4_mv", "samx", 1.5, "samy", -2.0, relative=False)
+    scan = v4_scan_assembler("mv", "samx", 1.5, "samy", -2.0, relative=False)
     positions = np.array([[0.0, 1.0], [1.0, 0.0]])
     scan.components._path_optimizer.optimize_corridor = mock.MagicMock(return_value=positions)
 
@@ -179,7 +179,7 @@ def test_optimize_trajectory_passes_first_direction_when_first_axis_is_corridor_
 def test_optimize_trajectory_dispatches_to_other_optimizers(
     v4_scan_assembler, optimization_type, optimizer_name
 ):
-    scan = v4_scan_assembler("_v4_mv", "samx", 1.5, "samy", -2.0, relative=False)
+    scan = v4_scan_assembler("mv", "samx", 1.5, "samy", -2.0, relative=False)
     positions = np.array([[0.0, 1.0], [1.0, 0.0]])
     optimized = np.array([[1.0, 0.0], [0.0, 1.0]])
     optimizer = mock.MagicMock(return_value=optimized)
@@ -197,27 +197,27 @@ def test_optimize_trajectory_dispatches_to_other_optimizers(
 
 
 def test_optimize_trajectory_rejects_unknown_optimization_type(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_mv", "samx", 1.5, "samy", -2.0, relative=False)
+    scan = v4_scan_assembler("mv", "samx", 1.5, "samy", -2.0, relative=False)
 
     with pytest.raises(ValueError, match="Invalid optimization type"):
         scan.components.optimize_trajectory(np.array([[0.0, 1.0]]), optimization_type="bad")
 
 
 def test_check_limits_accepts_positions_inside_motor_limits(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_mv", "samx", 1.5, "samy", -2.0, relative=False)
+    scan = v4_scan_assembler("mv", "samx", 1.5, "samy", -2.0, relative=False)
 
     scan.components.check_limits(scan.motors, np.array([[0.0, -1.0], [1.0, 2.0]]))
 
 
 def test_check_limits_ignores_motors_without_configured_limits(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_mv", "samx", 1.5, "samy", -2.0, relative=False)
+    scan = v4_scan_assembler("mv", "samx", 1.5, "samy", -2.0, relative=False)
     scan.dev["samx"]._limits = (5.0, 5.0)
 
     scan.components.check_limits(scan.motors, np.array([[100.0, -1.0], [200.0, 2.0]]))
 
 
 def test_check_limits_raises_limit_error_for_out_of_bounds_position(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_mv", "samx", 1.5, "samy", -2.0, relative=False)
+    scan = v4_scan_assembler("mv", "samx", 1.5, "samy", -2.0, relative=False)
 
     with pytest.raises(LimitError, match="Target position 12.0"):
         scan.components.check_limits(scan.motors, np.array([[12.0, 0.0]]))

--- a/bec_server/tests/tests_scan_server/scans_v4/test_time_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_time_scan.py
@@ -24,13 +24,13 @@ TIME_SCAN_DEFAULT_HOOK_TESTS = [
 
 @pytest.mark.parametrize(("hook_name", "hook_tests"), TIME_SCAN_DEFAULT_HOOK_TESTS)
 def test_time_scan_default_hooks(v4_scan_assembler, nth_done_status_mock, hook_name, hook_tests):
-    scan = v4_scan_assembler("_v4_time_scan", 3, 1.5, exp_time=0.2)
+    scan = v4_scan_assembler("time_scan", 3, 1.5, exp_time=0.2)
 
     run_scan_tests(scan, [(hook_name, hook_tests)], nth_done_status_mock=nth_done_status_mock)
 
 
 def test_time_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_time_scan", 3, 1.5, exp_time=0.2)
+    scan = v4_scan_assembler("time_scan", 3, 1.5, exp_time=0.2)
 
     scan.prepare_scan()
 
@@ -42,7 +42,7 @@ def test_time_scan_prepare_scan_updates_scan_info_and_queue(v4_scan_assembler):
 
 
 def test_time_scan_scan_core_triggers_reads_and_waits_between_points(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_time_scan", 3, 1.5, exp_time=0.2)
+    scan = v4_scan_assembler("time_scan", 3, 1.5, exp_time=0.2)
     scan.at_each_point = mock.MagicMock()
 
     with mock.patch("bec_server.scan_server.scans.time_scan.time.sleep") as sleep_mock:
@@ -53,7 +53,7 @@ def test_time_scan_scan_core_triggers_reads_and_waits_between_points(v4_scan_ass
 
 
 def test_time_scan_at_each_point_triggers_and_reads(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_time_scan", 3, 1.5, exp_time=0.2)
+    scan = v4_scan_assembler("time_scan", 3, 1.5, exp_time=0.2)
     scan.components.trigger_and_read = mock.MagicMock()
 
     scan.at_each_point()
@@ -62,7 +62,7 @@ def test_time_scan_at_each_point_triggers_and_reads(v4_scan_assembler):
 
 
 def test_time_scan_post_scan_completes_all_devices(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_time_scan", 3, 1.5, exp_time=0.2)
+    scan = v4_scan_assembler("time_scan", 3, 1.5, exp_time=0.2)
     scan.actions.complete_all_devices = mock.MagicMock()
 
     scan.post_scan()

--- a/bec_server/tests/tests_scan_server/scans_v4/test_updated_move_scan.py
+++ b/bec_server/tests/tests_scan_server/scans_v4/test_updated_move_scan.py
@@ -16,13 +16,13 @@ import pytest
     ],
 )
 def test_updated_move_scan_default_noop_hooks_do_not_raise(v4_scan_assembler, hook_name):
-    scan = v4_scan_assembler("_v4_umv", "samx", 1.5, "samy", -2.0, relative=False)
+    scan = v4_scan_assembler("umv", "samx", 1.5, "samy", -2.0, relative=False)
 
     getattr(scan, hook_name)()
 
 
 def test_updated_move_scan_scan_core_adds_readback_and_moves_to_absolute_targets(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_umv", "samx", 1.5, "samy", -2.0, relative=False)
+    scan = v4_scan_assembler("umv", "samx", 1.5, "samy", -2.0, relative=False)
     scan.scan_info.metadata["RID"] = "rid-123"
     scan.components.get_start_positions = mock.MagicMock(return_value=[0.5, 3.0])
     scan.actions.add_scan_report_instruction_readback = mock.MagicMock()
@@ -38,7 +38,7 @@ def test_updated_move_scan_scan_core_adds_readback_and_moves_to_absolute_targets
 
 
 def test_updated_move_scan_scan_core_adds_readback_and_moves_to_relative_targets(v4_scan_assembler):
-    scan = v4_scan_assembler("_v4_umv", "samx", 1.5, "samy", -2.0, relative=True)
+    scan = v4_scan_assembler("umv", "samx", 1.5, "samy", -2.0, relative=True)
     scan.scan_info.metadata["RID"] = "rid-123"
     scan.components.get_start_positions = mock.MagicMock(return_value=[0.5, 3.0])
     scan.actions.add_scan_report_instruction_readback = mock.MagicMock()

--- a/bec_server/tests/tests_scan_server/test_scan_argument_modifier.py
+++ b/bec_server/tests/tests_scan_server/test_scan_argument_modifier.py
@@ -179,6 +179,6 @@ def test_scan_doc_with_modifiers_renders_defaulted_acquire_parameters_as_kwargs_
 
     assert "Full:" in doc
     assert (
-        ">>> scans._v4_acquire(exp_time=0, frames_per_trigger=1, settling_time=0, "
+        ">>> scans.acquire(exp_time=0, frames_per_trigger=1, settling_time=0, "
         "settling_time_after_trigger=0, readout_time=0, burst_at_each_point=1)"
     ) in doc

--- a/bec_server/tests/tests_scan_server/test_scan_assembler.py
+++ b/bec_server/tests/tests_scan_server/test_scan_assembler.py
@@ -693,10 +693,10 @@ def test_scan_assembler_maps_optional_positional_direct_scan_args_to_request_kwa
     assembler = ScanAssembler(parent=parent)
 
     class MockScanManager:
-        scan_dict = {"_v4_acquire": Acquire}
+        scan_dict = {"acquire": Acquire}
 
     msg = messages.ScanQueueMessage(
-        scan_type="_v4_acquire",
+        scan_type="acquire",
         parameter={
             "args": [0, 1, 0, 0, 0, 1],
             "kwargs": {"system_config": {"file_directory": "/tmp/data"}},
@@ -731,10 +731,10 @@ def test_scan_assembler_maps_mixed_direct_scan_args_and_kwargs_for_acquire(dm_wi
     assembler = ScanAssembler(parent=parent)
 
     class MockScanManager:
-        scan_dict = {"_v4_acquire": Acquire}
+        scan_dict = {"acquire": Acquire}
 
     msg = messages.ScanQueueMessage(
-        scan_type="_v4_acquire",
+        scan_type="acquire",
         parameter={
             "args": [0, 1],
             "kwargs": {
@@ -771,10 +771,10 @@ def test_scan_assembler_extracts_user_metadata_for_direct_scans(dm_with_devices)
     assembler = ScanAssembler(parent=parent)
 
     class MockScanManager:
-        scan_dict = {"_v4_acquire": Acquire}
+        scan_dict = {"acquire": Acquire}
 
     msg = messages.ScanQueueMessage(
-        scan_type="_v4_acquire",
+        scan_type="acquire",
         parameter={"args": [], "kwargs": {"exp_time": 0.2, "system_config": {}}},
         queue="primary",
         metadata={"RID": "rid-123", "user_metadata": {"sample": "my_sample"}},

--- a/bec_server/tests/tests_scan_server/test_scan_guard.py
+++ b/bec_server/tests/tests_scan_server/test_scan_guard.py
@@ -11,6 +11,26 @@ from bec_server.scan_server.scan_queue import ScanQueueStatus
 from bec_server.scan_server.tests.fixtures import scan_server_mock
 
 
+def _device_rpc_scan_queue_message(
+    device, *, func="read", func_args=None, func_kwargs=None, metadata=None, queue="primary"
+):
+    return messages.ScanQueueMessage(
+        scan_type="device_rpc",
+        parameter={
+            "args": [],
+            "kwargs": {
+                "device": device,
+                "func": func,
+                "func_args": func_args or [],
+                "func_kwargs": func_kwargs or {},
+                "rpc_id": "rpc-id",
+            },
+        },
+        queue=queue,
+        metadata=metadata or {},
+    )
+
+
 @pytest.fixture
 def scan_guard_mock(scan_server_mock):
     sg = ScanGuard(parent=scan_server_mock)
@@ -28,36 +48,9 @@ def scan_guard_mock(scan_server_mock):
                 queue="primary",
             )
         ),
-        (
-            messages.ScanQueueMessage(
-                scan_type="device_rpc",
-                parameter={"device": "samy", "args": {}, "kwargs": {}},
-                queue="primary",
-            )
-        ),
-        (
-            messages.ScanQueueMessage(
-                scan_type="device_rpc",
-                parameter={"device": ["samy"], "args": {}, "kwargs": {}},
-                queue="primary",
-            )
-        ),
-        (
-            messages.ScanQueueMessage(
-                scan_type="_v4_device_rpc",
-                parameter={
-                    "args": [],
-                    "kwargs": {
-                        "device": "samy",
-                        "func": "set",
-                        "func_args": [1],
-                        "func_kwargs": {},
-                        "rpc_id": "rpc-id",
-                    },
-                },
-                queue="primary",
-            )
-        ),
+        (_device_rpc_scan_queue_message("samy", func="set", func_args=[1])),
+        (_device_rpc_scan_queue_message(["samy"], func="set", func_args=[1])),
+        (_device_rpc_scan_queue_message("samy", func="set", func_args=[1])),
     ],
 )
 def test_check_motors_movable_enabled(scan_server_mock, scan_queue_msg):
@@ -96,38 +89,23 @@ def test_device_rpc_is_valid(scan_guard_mock, device, func, is_valid):
             True,
         ),
         (
-            messages.ScanQueueMessage(
-                scan_type="device_rpc",
-                parameter={"device": "samy", "args": {}, "kwargs": {}},
-                queue="primary",
+            _device_rpc_scan_queue_message(
+                "samy", func="set", func_args=[1], metadata={"client_info": {"acl_user": "default"}}
+            ),
+            True,
+        ),
+        (
+            _device_rpc_scan_queue_message(
+                ["samy"],
+                func="set",
+                func_args=[1],
                 metadata={"client_info": {"acl_user": "default"}},
             ),
             True,
         ),
         (
-            messages.ScanQueueMessage(
-                scan_type="device_rpc",
-                parameter={"device": ["samy"], "args": {}, "kwargs": {}},
-                queue="primary",
-                metadata={"client_info": {"acl_user": "default"}},
-            ),
-            True,
-        ),
-        (
-            messages.ScanQueueMessage(
-                scan_type="_v4_device_rpc",
-                parameter={
-                    "args": [],
-                    "kwargs": {
-                        "device": "samy",
-                        "func": "set",
-                        "func_args": [1],
-                        "func_kwargs": {},
-                        "rpc_id": "rpc-id",
-                    },
-                },
-                queue="primary",
-                metadata={"client_info": {"acl_user": "default"}},
+            _device_rpc_scan_queue_message(
+                "samy", func="set", func_args=[1], metadata={"client_info": {"acl_user": "default"}}
             ),
             True,
         ),
@@ -189,11 +167,7 @@ def test_check_valid_scan_device_rpc(scan_guard_mock):
     sg.connector.get.return_value = messages.AvailableResourceMessage(
         resource={"device_rpc": "device_rpc"}
     )
-    request = messages.ScanQueueMessage(
-        scan_type="device_rpc",
-        parameter={"device": "samy", "func": "read", "args": {}, "kwargs": {}},
-        queue="primary",
-    )
+    request = _device_rpc_scan_queue_message("samy")
     with mock.patch.object(sg, "_device_rpc_is_valid") as rpc_valid:
         sg._check_valid_scan(request)
         rpc_valid.assert_called_once_with(device="samy", func="read")
@@ -205,11 +179,7 @@ def test_check_valid_scan_device_rpc_raises(scan_guard_mock):
     sg.connector.get.return_value = messages.AvailableResourceMessage(
         resource={"device_rpc": "device_rpc"}
     )
-    request = messages.ScanQueueMessage(
-        scan_type="device_rpc",
-        parameter={"device": "samy", "func": "read", "args": {}, "kwargs": {}},
-        queue="primary",
-    )
+    request = _device_rpc_scan_queue_message("samy")
     with pytest.raises(ScanRejection) as scan_rejection:
         with mock.patch.object(sg, "_device_rpc_is_valid") as rpc_valid:
             rpc_valid.return_value = False
@@ -306,11 +276,14 @@ def test_handle_scan_request(scan_guard_mock):
             metadata={"RID": "ed2c85e4-d1ed-44d3-a1ed-ec99ea5991a2", "response": True},
             scan_type="device_rpc",
             parameter={
-                "device": "samx",
-                "rpc_id": "0e5c0ca1-e471-4e30-bb45-b94d4b713e2f",
-                "func": "read",
                 "args": [],
-                "kwargs": {},
+                "kwargs": {
+                    "device": "samx",
+                    "rpc_id": "0e5c0ca1-e471-4e30-bb45-b94d4b713e2f",
+                    "func": "read",
+                    "func_args": [],
+                    "func_kwargs": {},
+                },
             },
             queue="primary",
         ),
@@ -318,11 +291,14 @@ def test_handle_scan_request(scan_guard_mock):
             metadata={"RID": "4be1449d-af68-457f-8e86-24fd9ddca803", "response": True},
             scan_type="device_rpc",
             parameter={
-                "device": "hexapod",
-                "rpc_id": "bc5fc2c3-540c-4881-b84e-89ba2c4ed3aa",
-                "func": "x.read",
                 "args": [],
-                "kwargs": {},
+                "kwargs": {
+                    "device": "hexapod",
+                    "rpc_id": "bc5fc2c3-540c-4881-b84e-89ba2c4ed3aa",
+                    "func": "x.read",
+                    "func_args": [],
+                    "func_kwargs": {},
+                },
             },
             queue="primary",
         ),
@@ -330,11 +306,14 @@ def test_handle_scan_request(scan_guard_mock):
             metadata={"RID": "ed2c85e4-d1ed-44d3-a1ed-ec99ea5991a2", "response": True},
             scan_type="device_rpc",
             parameter={
-                "device": "samx",
-                "rpc_id": "0e5c0ca1-e471-4e30-bb45-b94d4b713e2f",
-                "func": "get",
                 "args": [],
-                "kwargs": {},
+                "kwargs": {
+                    "device": "samx",
+                    "rpc_id": "0e5c0ca1-e471-4e30-bb45-b94d4b713e2f",
+                    "func": "get",
+                    "func_args": [],
+                    "func_kwargs": {},
+                },
             },
             queue="primary",
         ),
@@ -342,17 +321,20 @@ def test_handle_scan_request(scan_guard_mock):
             metadata={"RID": "4be1449d-af68-457f-8e86-24fd9ddca803", "response": True},
             scan_type="device_rpc",
             parameter={
-                "device": "hexapod",
-                "rpc_id": "bc5fc2c3-540c-4881-b84e-89ba2c4ed3aa",
-                "func": "x.get",
                 "args": [],
-                "kwargs": {},
+                "kwargs": {
+                    "device": "hexapod",
+                    "rpc_id": "bc5fc2c3-540c-4881-b84e-89ba2c4ed3aa",
+                    "func": "x.get",
+                    "func_args": [],
+                    "func_kwargs": {},
+                },
             },
             queue="primary",
         ),
         messages.ScanQueueMessage(
             metadata={"RID": "9db0c540-c1e0-4f44-872d-f41209512316", "response": True},
-            scan_type="_v4_device_rpc",
+            scan_type="device_rpc",
             parameter={
                 "args": [],
                 "kwargs": {
@@ -367,7 +349,7 @@ def test_handle_scan_request(scan_guard_mock):
         ),
         messages.ScanQueueMessage(
             metadata={"RID": "7d28d801-8e33-484d-af34-9cc061eefe0e", "response": True},
-            scan_type="_v4_device_rpc",
+            scan_type="device_rpc",
             parameter={
                 "args": [],
                 "kwargs": {
@@ -395,22 +377,15 @@ def test_handle_scan_request_bypassed_for_read(scan_guard_mock, msg):
                 append.assert_not_called()
                 send.assert_called_once_with(MessageEndpoints.device_instructions(), mock.ANY)
                 sent_msg = send.call_args.args[1]
-                expected_device = (
-                    msg.parameter["kwargs"]["device"]
-                    if msg.scan_type == "_v4_device_rpc"
-                    else msg.parameter["device"]
-                )
+                expected_device = msg.parameter["kwargs"]["device"]
                 assert sent_msg.device == expected_device
-                if msg.scan_type == "_v4_device_rpc":
-                    assert sent_msg.parameter == {
-                        "device": expected_device,
-                        "rpc_id": msg.parameter["kwargs"]["rpc_id"],
-                        "func": msg.parameter["kwargs"]["func"],
-                        "args": msg.parameter["kwargs"]["func_args"],
-                        "kwargs": msg.parameter["kwargs"]["func_kwargs"],
-                    }
-                else:
-                    assert sent_msg.parameter == msg.parameter
+                assert sent_msg.parameter == {
+                    "device": expected_device,
+                    "rpc_id": msg.parameter["kwargs"]["rpc_id"],
+                    "func": msg.parameter["kwargs"]["func"],
+                    "args": msg.parameter["kwargs"]["func_args"],
+                    "kwargs": msg.parameter["kwargs"]["func_kwargs"],
+                }
 
 
 def test_handle_scan_request_rejected(scan_guard_mock):

--- a/bec_server/tests/tests_scan_server/test_scan_server_queue.py
+++ b/bec_server/tests/tests_scan_server/test_scan_server_queue.py
@@ -93,6 +93,17 @@ def _build_dummy_v4_scan(
     return scan
 
 
+def _queued_scan_message(
+    *, queue: str = "primary", rid: str = "something", start: float = -1, stop: float = 1
+) -> messages.ScanQueueMessage:
+    return messages.ScanQueueMessage(
+        scan_type="monitor_scan",
+        parameter={"args": {"samx": (start, stop)}, "kwargs": {"relative": False}},
+        queue=queue,
+        metadata={"RID": rid},
+    )
+
+
 def test_queuemanager_queue_contains_primary(queuemanager_mock):
     queue_manager = queuemanager_mock()
     assert "primary" in queue_manager.queues
@@ -101,12 +112,7 @@ def test_queuemanager_queue_contains_primary(queuemanager_mock):
 @pytest.mark.parametrize("queue", ["primary", "alignment"])
 def test_queuemanager_add_to_queue(queuemanager_mock, queue):
     queue_manager = queuemanager_mock()
-    msg = messages.ScanQueueMessage(
-        scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
-        queue=queue,
-        metadata={"RID": "something"},
-    )
+    msg = _queued_scan_message(queue=queue)
     queue_manager.add_queue(queue)
     queue_manager.add_to_queue(scan_queue=queue, msg=msg)
     assert queue_manager.queues[queue].queue.popleft().scan_msgs[0] == msg
@@ -114,12 +120,7 @@ def test_queuemanager_add_to_queue(queuemanager_mock, queue):
 
 def test_queuemanager_add_to_queue_publishes_status_for_default_append(queuemanager_mock):
     queue_manager = queuemanager_mock()
-    msg = messages.ScanQueueMessage(
-        scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
-        queue="primary",
-        metadata={"RID": "something"},
-    )
+    msg = _queued_scan_message()
 
     with mock.patch.object(queue_manager, "send_queue_status") as send_queue_status:
         queue_manager.add_to_queue(scan_queue="primary", msg=msg)
@@ -158,12 +159,7 @@ def test_queuemanager_add_to_queue_restarts_queue_if_worker_is_dead(queuemanager
 
     assert original_worker.is_alive() is False
 
-    msg = messages.ScanQueueMessage(
-        scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
-        queue="primary",
-        metadata={"RID": "something"},
-    )
+    msg = _queued_scan_message()
     queue_manager.add_queue("primary")
     queue_manager.add_to_queue(scan_queue="primary", msg=msg)
     assert queue_manager.queues["primary"].queue.popleft().scan_msgs[0] == msg
@@ -173,12 +169,7 @@ def test_queuemanager_add_to_queue_restarts_queue_if_worker_is_dead(queuemanager
 
 def test_queuemanager_add_to_queue_error_send_alarm(queuemanager_mock):
     queue_manager = queuemanager_mock()
-    msg = messages.ScanQueueMessage(
-        scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
-        queue="primary",
-        metadata={"RID": "something"},
-    )
+    msg = _queued_scan_message()
     with mock.patch.object(queue_manager, "connector") as connector:
         with mock.patch.object(queue_manager, "add_queue", side_effects=KeyError):
             queue_manager.add_to_queue(scan_queue="dummy", msg=msg)
@@ -189,12 +180,7 @@ def test_queuemanager_add_to_queue_error_send_alarm(queuemanager_mock):
 
 def test_queuemanager_scan_queue_callback(queuemanager_mock):
     queue_manager = queuemanager_mock()
-    msg = messages.ScanQueueMessage(
-        scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
-        queue="primary",
-        metadata={"RID": "something"},
-    )
+    msg = _queued_scan_message()
     obj = MessageObject("scan_queue", msg)
     with mock.patch.object(queue_manager, "add_to_queue") as add_to_queue:
         queue_manager._scan_queue_callback(obj)
@@ -308,7 +294,7 @@ def test_direct_instruction_queue_append_scan_request_assembles_and_stores_scan(
     )
     msg = messages.ScanQueueMessage(
         scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        parameter={"args": {"samx": (1,)}, "kwargs": {"relative": False}},
         queue="primary",
         metadata={"RID": "rid-1"},
     )
@@ -351,7 +337,7 @@ def test_direct_instruction_queue_describe_active_scan_returns_request_block(que
     scan.scan_info.scan_report_instructions = [{"device": "samx"}]
     msg = messages.ScanQueueMessage(
         scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        parameter={"args": {"samx": (1,)}, "kwargs": {"relative": False}},
         queue="primary",
         metadata={"RID": "rid-1"},
     )
@@ -379,13 +365,12 @@ def test_direct_instruction_queue_move_to_next_scan_activates_and_assigns_number
     queue_manager = queuemanager_mock()
     scan_queue = queue_manager.queues["primary"]
     queue = DirectInstructionQueueItem(scan_queue, mock.MagicMock(), scan_queue.scan_worker)
-    scan_queue.queue.append(queue)
     first_scan = _build_dummy_v4_scan("scan-1", scan_number=None)
     second_scan = _build_dummy_v4_scan("scan-2", scan_number=None)
     second_scan.scan_info.metadata["dataset_id_on_hold"] = True
     msg1 = messages.ScanQueueMessage(
         scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        parameter={"args": {"samx": (1,)}, "kwargs": {"relative": False}},
         queue="primary",
         metadata={"RID": "rid-1"},
     )
@@ -417,11 +402,10 @@ def test_direct_instruction_queue_non_scan_does_not_allocate_scan_number(queuema
     queue_manager = queuemanager_mock()
     scan_queue = queue_manager.queues["primary"]
     queue = DirectInstructionQueueItem(scan_queue, mock.MagicMock(), scan_queue.scan_worker)
-    scan_queue.queue.append(queue)
     scan = _build_dummy_v4_scan("scan-1", is_scan=False)
     msg = messages.ScanQueueMessage(
-        scan_type="_v4_umv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        scan_type="umv",
+        parameter={"args": {"samx": (1,)}, "kwargs": {"relative": False}},
         queue="primary",
         metadata={"RID": "rid-1"},
     )
@@ -445,14 +429,14 @@ def test_direct_instruction_queue_non_scan_does_not_allocate_scan_id(queuemanage
     queue_manager = queuemanager_mock()
     scan_queue = queue_manager.queues["primary"]
     assembler = mock.MagicMock()
-    assembler.scan_manager.scan_dict = {"_v4_umv": mock.MagicMock(is_scan=False)}
+    assembler.scan_manager.scan_dict = {"umv": mock.MagicMock(is_scan=False)}
     scan = _build_dummy_v4_scan("placeholder-scan-id", is_scan=False)
     scan.scan_info.scan_id = None
     assembler.assemble_direct_scan.return_value = scan
     queue = DirectInstructionQueueItem(scan_queue, assembler, scan_queue.scan_worker)
 
     msg = messages.ScanQueueMessage(
-        scan_type="_v4_umv",
+        scan_type="umv",
         parameter={"args": {"samx": (1,)}, "kwargs": {"relative": False}},
         queue="primary",
         metadata={"RID": "rid-1"},
@@ -483,7 +467,7 @@ def test_direct_instruction_queue_move_to_next_scan_raises_when_empty_or_exhaust
     scan = _build_dummy_v4_scan("scan-id-test")
     msg = messages.ScanQueueMessage(
         scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        parameter={"args": {"samx": (1,)}, "kwargs": {"relative": False}},
         queue="primary",
         metadata={"RID": "rid-1"},
     )
@@ -554,12 +538,7 @@ def test_set_pause(queuemanager_mock):
     queue_manager = queuemanager_mock()
 
     # Add a queue item so worker_status has something to operate on
-    msg = messages.ScanQueueMessage(
-        scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
-        queue="primary",
-        metadata={"RID": "something"},
-    )
+    msg = _queued_scan_message()
     queue_manager.add_to_queue(scan_queue="primary", msg=msg)
 
     # Set worker status to RUNNING
@@ -578,12 +557,7 @@ def test_set_pause_does_not_change_non_running_worker(queuemanager_mock):
     queue_manager = queuemanager_mock()
 
     # Add a queue item
-    msg = messages.ScanQueueMessage(
-        scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
-        queue="primary",
-        metadata={"RID": "something"},
-    )
+    msg = _queued_scan_message()
     queue_manager.add_to_queue(scan_queue="primary", msg=msg)
 
     # Set worker status to PENDING (not RUNNING)
@@ -628,25 +602,20 @@ def test_set_abort(queuemanager_mock):
     queue_manager.parent.device_lock_registry.get_owned_devices = mock.MagicMock(
         return_value=["samx"]
     )
-    msg = messages.ScanQueueMessage(
-        scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
-        queue="primary",
-        metadata={"RID": "something"},
-    )
+    msg = _queued_scan_message()
     queue_manager.add_to_queue(scan_queue="primary", msg=msg)
     queue_manager.add_to_queue(scan_queue="primary", msg=msg)
     scan_queue = queue_manager.queues["primary"]
     while scan_queue.scan_worker.current_instruction_queue_item is None:
         time.sleep(0.1)
-    queue_id = scan_queue.queue[0].queue_id
+    stop_id = scan_queue.queue[0].scan_id
     queue_manager.set_abort(queue="primary")
     wait_to_reach_state(queue_manager, "primary", ScanQueueStatus.PAUSED)
     while len(queue_manager.connector.message_sent) < 5:
         time.sleep(0.1)
     assert {
         "queue": MessageEndpoints.stop_devices(),
-        "msg": messages.VariableMessage(value=["samx"], metadata={"stop_id": queue_id}),
+        "msg": messages.VariableMessage(value=["samx"], metadata={"stop_id": stop_id}),
     } in queue_manager.connector.message_sent
     assert (
         queue_manager.connector.message_sent[0].get("queue") == MessageEndpoints.scan_queue_status()
@@ -661,8 +630,8 @@ def test_set_abort_with_scan_id(queuemanager_mock):
         return_value=["samx", "samy"]
     )
     msg = messages.ScanQueueMessage(
-        scan_type="line_scan",
-        parameter={"args": {"samx": (-1, 1)}, "kwargs": {"steps": 10, "relative": False}},
+        scan_type="monitor_scan",
+        parameter={"args": {"samx": (-1, 1)}, "kwargs": {"relative": False}},
         queue="primary",
         metadata={"RID": "something"},
     )
@@ -692,8 +661,8 @@ def test_set_abort_with_scan_id_not_active(queuemanager_mock):
     queue_manager = queuemanager_mock()
     queue_manager.connector.message_sent = []
     msg = messages.ScanQueueMessage(
-        scan_type="line_scan",
-        parameter={"args": {"samx": (-1, 1)}, "kwargs": {"steps": 10, "relative": False}},
+        scan_type="monitor_scan",
+        parameter={"args": {"samx": (-1, 1)}, "kwargs": {"relative": False}},
         queue="primary",
         metadata={"RID": "something"},
     )
@@ -714,18 +683,8 @@ def test_set_abort_with_scan_id_not_active(queuemanager_mock):
 def test_set_abort_with_request_id_not_active(queuemanager_mock):
     queue_manager = queuemanager_mock()
     queue_manager.connector.message_sent = []
-    msg1 = messages.ScanQueueMessage(
-        scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
-        queue="primary",
-        metadata={"RID": "rid-1"},
-    )
-    msg2 = messages.ScanQueueMessage(
-        scan_type="mv",
-        parameter={"args": {"samx": (2,)}, "kwargs": {}},
-        queue="primary",
-        metadata={"RID": "rid-2"},
-    )
+    msg1 = _queued_scan_message(rid="rid-1")
+    msg2 = _queued_scan_message(rid="rid-2", start=-2, stop=2)
     queue_manager.add_to_queue(scan_queue="primary", msg=msg1)
     queue_manager.add_to_queue(scan_queue="primary", msg=msg2)
     scan_queue = queue_manager.queues["primary"]
@@ -757,8 +716,8 @@ def test_set_abort_with_wrong_scan_id(queuemanager_mock):
     queue_manager = queuemanager_mock()
     queue_manager.connector.message_sent = []
     msg = messages.ScanQueueMessage(
-        scan_type="line_scan",
-        parameter={"args": {"samx": (-1, 1)}, "kwargs": {"steps": 10, "relative": False}},
+        scan_type="monitor_scan",
+        parameter={"args": {"samx": (-1, 1)}, "kwargs": {"relative": False}},
         queue="primary",
         metadata={"RID": "something"},
     )
@@ -817,24 +776,19 @@ def test_set_abort_with_no_owned_devices_sends_stop_all_for_legacy_queue(queuema
     queue_manager = queuemanager_mock()
     queue_manager.connector.message_sent = []
     queue_manager.parent.device_lock_registry.get_owned_devices = mock.MagicMock(return_value=[])
-    msg = messages.ScanQueueMessage(
-        scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
-        queue="primary",
-        metadata={"RID": "something"},
-    )
+    msg = _queued_scan_message()
     queue_manager.add_to_queue(scan_queue="primary", msg=msg)
     scan_queue = queue_manager.queues["primary"]
     while scan_queue.scan_worker.current_instruction_queue_item is None:
         time.sleep(0.1)
 
-    queue_id = scan_queue.queue[0].queue_id
+    stop_id = scan_queue.queue[0].scan_id
     queue_manager.set_abort(queue="primary")
     wait_to_reach_state(queue_manager, "primary", ScanQueueStatus.PAUSED)
 
     assert {
         "queue": MessageEndpoints.stop_devices(),
-        "msg": messages.VariableMessage(value=None, metadata={"stop_id": queue_id}),
+        "msg": messages.VariableMessage(value=None, metadata={"stop_id": stop_id}),
     } in queue_manager.connector.message_sent
 
 
@@ -870,7 +824,10 @@ def test_set_restart(queuemanager_mock):
     queue_manager.queues["primary"] = ScanQueue(queue_manager, queue_name="primary")
     msg = messages.ScanQueueMessage(
         scan_type="grid_scan",
-        parameter={"args": {"samx": (-5, 5, 3)}, "kwargs": {}},
+        parameter={
+            "args": {"samx": (-5, 5, 3), "samy": (-5, 5, 3)},
+            "kwargs": {"relative": False, "system_config": {}},
+        },
         queue="primary",
         metadata={"RID": "something"},
     )
@@ -919,7 +876,10 @@ def test_set_restart_no_active_scan(queuemanager_mock):
     queue_manager.queues["primary"] = ScanQueue(queue_manager, queue_name="primary")
     msg = messages.ScanQueueMessage(
         scan_type="grid_scan",
-        parameter={"args": {"samx": (-5, 5, 3)}, "kwargs": {}},
+        parameter={
+            "args": {"samx": (-5, 5, 3), "samy": (-5, 5, 3)},
+            "kwargs": {"relative": False, "system_config": {}},
+        },
         queue="primary",
         metadata={"RID": "something"},
     )
@@ -943,72 +903,46 @@ def test_set_restart_no_active_scan(queuemanager_mock):
 @pytest.mark.timeout(5)
 def test_set_user_completed(queuemanager_mock):
     queue_manager = queuemanager_mock()
-    msg = messages.ScanQueueMessage(
-        scan_type="line_scan",
-        parameter={"args": {"samx": (-1, 1)}, "kwargs": {"steps": 10, "relative": False}},
-        queue="primary",
-        metadata={"RID": "something"},
-    )
-    queue_manager.add_to_queue(scan_queue="primary", msg=msg)
-    queue_manager.add_to_queue(scan_queue="primary", msg=msg)
-    scan_queue = queue_manager.queues["primary"]
-    while scan_queue.scan_worker.current_instruction_queue_item is None:
-        time.sleep(0.1)
-    queue_manager.set_user_completed(queue="primary")
+    queue_manager.queues["primary"].status = ScanQueueStatus.RUNNING
 
-    # The queue should return to RUNNING state after user completion
-    wait_to_reach_state(queue_manager, "primary", ScanQueueStatus.RUNNING)
-    while len(scan_queue.queue) > 1:
-        time.sleep(0.1)
+    def _set_abort_side_effect(*, scan_id=None, request_id=None, queue="primary", exit_info=None):
+        queue_manager.queues[queue].status = ScanQueueStatus.PAUSED
 
-
-def test_request_block(scan_server_mock):
-    scan_server = scan_server_mock
-    msg = messages.ScanQueueMessage(
-        scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
-        queue="primary",
-        metadata={"RID": "something"},
-    )
-    request_block = RequestBlock(
-        msg, assembler=ScanAssembler(parent=scan_server), parent=mock.MagicMock()
-    )
-
-
-@pytest.mark.parametrize(
-    "scan_queue_msg",
-    [
-        (
-            messages.ScanQueueMessage(
-                scan_type="mv",
-                parameter={"args": {"samx": (1,)}, "kwargs": {}},
-                queue="primary",
-                metadata={"RID": "something"},
-            )
-        ),
-        (
-            messages.ScanQueueMessage(
-                scan_type="grid_scan",
-                parameter={"args": {"samx": (-5, 5, 3)}, "kwargs": {}},
-                queue="primary",
-                metadata={"RID": "something"},
-            )
-        ),
-    ],
-)
-def test_request_block_scan_number(scan_server_mock, scan_queue_msg):
-    scan_server = scan_server_mock
-    request_block = RequestBlock(
-        scan_queue_msg, assembler=ScanAssembler(parent=scan_server), parent=mock.MagicMock()
-    )
-    if not request_block.is_scan:
-        assert request_block.scan_number is None
-        return
     with mock.patch.object(
-        RequestBlock, "_scan_server_scan_number", new_callable=mock.PropertyMock, return_value=5
+        queue_manager, "set_abort", side_effect=_set_abort_side_effect
+    ) as set_abort:
+        queue_manager.set_user_completed(queue="primary")
+
+    set_abort.assert_called_once_with(
+        scan_id=None, request_id=None, queue="primary", exit_info=("user_completed", "user")
+    )
+    assert queue_manager.queues["primary"].status == ScanQueueStatus.RUNNING
+
+
+@pytest.mark.parametrize("is_scan", [False, True])
+def test_request_block_scan_number(queuemanager_mock, is_scan):
+    queue_manager = queuemanager_mock()
+    scan_queue = queue_manager.queues["primary"]
+    instruction_queue = DirectInstructionQueueItem(
+        scan_queue, mock.MagicMock(), scan_queue.scan_worker
+    )
+    scan_queue.queue.append(instruction_queue)
+
+    scan = _build_dummy_v4_scan("scan-1", is_scan=is_scan)
+    instruction_queue.scans = [scan]
+
+    if not scan.is_scan:
+        assert instruction_queue.scan_number == [None]
+        return
+
+    with mock.patch.object(
+        DirectInstructionQueueItem,
+        "_scan_server_scan_number",
+        new_callable=mock.PropertyMock,
+        return_value=5,
     ):
-        with mock.patch.object(RequestBlock, "scan_ids_head", return_value=0):
-            assert request_block.scan_number == 5
+        with mock.patch.object(DirectInstructionQueueItem, "scan_ids_head", return_value=0):
+            assert instruction_queue.scan_number == [5]
 
 
 def test_direct_instruction_queue_item_scan_number_projection_within_item(queuemanager_mock):
@@ -1049,39 +983,41 @@ def test_direct_instruction_queue_item_scan_number_projection_across_queue_items
 
 def test_remove_queue_item(queuemanager_mock):
     queue_manager = queuemanager_mock()
+    scan_queue = ScanQueue(queue_manager)
     msg = messages.ScanQueueMessage(
         scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        parameter={"args": {"samx": (1,)}, "kwargs": {"relative": False, "system_config": {}}},
         queue="primary",
         metadata={"RID": "something"},
     )
-    queue_manager.add_to_queue(scan_queue="primary", msg=msg)
-    queue_manager.queues["primary"].queue[0].queue.request_blocks[0].scan_id = "random"
-    queue_manager.queues["primary"].remove_queue_item(scan_id=["random"])
-    assert len(queue_manager.queues["primary"].queue) == 0
+    scan_queue.insert(msg)
+    scan_queue.queue[0].scans[0].scan_info.scan_id = "random"
+    scan_queue.remove_queue_item(scan_id=["random"])
+    assert len(scan_queue.queue) == 0
 
 
 def test_remove_queue_item_by_request_id(queuemanager_mock):
     queue_manager = queuemanager_mock()
+    scan_queue = ScanQueue(queue_manager)
     msg1 = messages.ScanQueueMessage(
         scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        parameter={"args": {"samx": (1,)}, "kwargs": {"relative": False, "system_config": {}}},
         queue="primary",
         metadata={"RID": "rid-1"},
     )
     msg2 = messages.ScanQueueMessage(
         scan_type="mv",
-        parameter={"args": {"samx": (2,)}, "kwargs": {}},
+        parameter={"args": {"samx": (2,)}, "kwargs": {"relative": False, "system_config": {}}},
         queue="primary",
         metadata={"RID": "rid-2"},
     )
-    queue_manager.add_to_queue(scan_queue="primary", msg=msg1)
-    queue_manager.add_to_queue(scan_queue="primary", msg=msg2)
+    scan_queue.insert(msg1)
+    scan_queue.insert(msg2)
 
-    queue_manager.queues["primary"].remove_queue_item_by_request_id("rid-2")
+    scan_queue.remove_queue_item_by_request_id("rid-2")
 
-    assert len(queue_manager.queues["primary"].queue) == 1
-    remaining = queue_manager.queues["primary"].queue[0].describe().request_blocks[0]
+    assert len(scan_queue.queue) == 1
+    remaining = scan_queue.queue[0].describe().request_blocks[0]
     assert remaining.RID == "rid-1"
 
 
@@ -1089,7 +1025,7 @@ def test_invalid_scan_specified_in_message(queuemanager_mock):
     queue_manager = queuemanager_mock()
     msg = messages.ScanQueueMessage(
         scan_type="fake test scan which does not exist!",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        parameter={"args": {"samx": (1,)}, "kwargs": {"relative": False, "system_config": {}}},
         queue="primary",
         metadata={"RID": "something"},
     )
@@ -1104,7 +1040,7 @@ def test_set_clear(queuemanager_mock):
     queue_manager = queuemanager_mock()
     msg = messages.ScanQueueMessage(
         scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        parameter={"args": {"samx": (1,)}, "kwargs": {"relative": False, "system_config": {}}},
         queue="primary",
         metadata={"RID": "something"},
     )
@@ -1115,13 +1051,13 @@ def test_set_clear(queuemanager_mock):
 
 def test_scan_queue_next_instruction_queue(queuemanager_mock):
     queue_manager = queuemanager_mock()
-    queue = ScanQueue(queue_manager, InstructionQueueMock)
+    queue = ScanQueue(queue_manager, instruction_queue_item_cls=InstructionQueueMock)
     assert queue._next_instruction_queue() is False
 
 
 def test_scan_queue_next_instruction_queue_pops(queuemanager_mock):
     queue_manager = queuemanager_mock()
-    queue = ScanQueue(queue_manager, InstructionQueueMock)
+    queue = ScanQueue(queue_manager, instruction_queue_item_cls=InstructionQueueMock)
     queue.queue.append(InstructionQueueItem(queue, mock.MagicMock(), mock.MagicMock()))
     queue.queue[0].status = InstructionQueueStatus.RUNNING
     queue.active_instruction_queue = queue.queue[0]
@@ -1131,7 +1067,7 @@ def test_scan_queue_next_instruction_queue_pops(queuemanager_mock):
 
 def test_scan_queue_next_instruction_queue_does_not_pop(queuemanager_mock):
     queue_manager = queuemanager_mock()
-    queue = ScanQueue(queue_manager, InstructionQueueMock)
+    queue = ScanQueue(queue_manager, instruction_queue_item_cls=InstructionQueueMock)
     queue.queue.append(InstructionQueueItem(queue, mock.MagicMock(), mock.MagicMock()))
     queue.queue[0].status = InstructionQueueStatus.PENDING
     queue.active_instruction_queue = queue.queue[0]
@@ -1144,7 +1080,7 @@ def test_scan_queue_next_instruction_queue_pops_stopped_elements(queuemanager_mo
     Test that the scan queue pops the stopped elements from the queue.
     """
     queue_manager = queuemanager_mock()
-    queue = ScanQueue(queue_manager, InstructionQueueMock)
+    queue = ScanQueue(queue_manager, instruction_queue_item_cls=InstructionQueueMock)
     queue.queue.append(InstructionQueueItem(queue, mock.MagicMock(), mock.MagicMock()))
     queue.queue.append(InstructionQueueItem(queue, mock.MagicMock(), mock.MagicMock()))
     queue.queue[0].status = InstructionQueueStatus.STOPPED
@@ -1159,14 +1095,14 @@ def test_scan_queue_next_instruction_queue_pops_stopped_elements(queuemanager_mo
 
 def test_scan_queue_insert_defers_while_head_is_stopped(queuemanager_mock):
     queue_manager = queuemanager_mock()
-    queue = ScanQueue(queue_manager, InstructionQueueMock)
+    queue = ScanQueue(queue_manager, instruction_queue_item_cls=InstructionQueueMock)
     stopped_item = InstructionQueueItem(queue, mock.MagicMock(), mock.MagicMock())
     stopped_item.status = InstructionQueueStatus.STOPPED
     queue.queue.append(stopped_item)
 
     msg = messages.ScanQueueMessage(
         scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        parameter={"args": {"samx": (1,)}, "kwargs": {"relative": False}},
         queue="primary",
         metadata={"RID": "rid-stopped"},
     )
@@ -1188,7 +1124,7 @@ def test_scan_queue_insert_defers_while_head_is_stopped(queuemanager_mock):
 
 def test_scan_queue_flushes_deferred_inserts_once_stopped_head_is_removed(queuemanager_mock):
     queue_manager = queuemanager_mock()
-    queue = ScanQueue(queue_manager, InstructionQueueMock)
+    queue = ScanQueue(queue_manager, instruction_queue_item_cls=InstructionQueueMock)
     stopped_item = InstructionQueueItem(queue, mock.MagicMock(), mock.MagicMock())
     stopped_item.status = InstructionQueueStatus.STOPPED
     queued_item = InstructionQueueItem(queue, mock.MagicMock(), mock.MagicMock())
@@ -1197,7 +1133,7 @@ def test_scan_queue_flushes_deferred_inserts_once_stopped_head_is_removed(queuem
 
     msg = messages.ScanQueueMessage(
         scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        parameter={"args": {"samx": (1,)}, "kwargs": {"relative": False}},
         queue="primary",
         metadata={"RID": "rid-flush"},
     )
@@ -1211,7 +1147,7 @@ def test_scan_queue_flushes_deferred_inserts_once_stopped_head_is_removed(queuem
 
 def test_scan_queue_insert_does_not_block_while_worker_waits_on_lock(queuemanager_mock):
     queue_manager = queuemanager_mock()
-    queue = ScanQueue(queue_manager, InstructionQueueMock)
+    queue = ScanQueue(queue_manager, instruction_queue_item_cls=InstructionQueueMock)
     pending_item = InstructionQueueItem(queue, mock.MagicMock(), mock.MagicMock())
     pending_item.status = InstructionQueueStatus.PENDING
     queue.queue.append(pending_item)
@@ -1238,7 +1174,7 @@ def test_scan_queue_insert_does_not_block_while_worker_waits_on_lock(queuemanage
 
     msg = messages.ScanQueueMessage(
         scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        parameter={"args": {"samx": (1,)}, "kwargs": {"relative": False}},
         queue="primary",
         metadata={"RID": "rid-locked-insert"},
     )
@@ -1270,7 +1206,7 @@ def test_queue_manager_wait_for_queue_to_appear_in_history_raises_timeout(queuem
 
 def test_queue_manager_wait_for_queue_to_appear_in_history(queuemanager_mock):
     queue_manager = queuemanager_mock()
-    scan_queue = ScanQueue(queue_manager, InstructionQueueMock)
+    scan_queue = ScanQueue(queue_manager, instruction_queue_item_cls=InstructionQueueMock)
     instruction_queue = InstructionQueueItem(scan_queue, mock.MagicMock(), mock.MagicMock())
     request_queue = RequestBlockQueue(instruction_queue, mock.MagicMock())
     request_block = RequestBlock(mock.MagicMock(), mock.MagicMock(), request_queue)
@@ -1301,7 +1237,7 @@ def test_request_block_queue_append():
     req_block_queue = RequestBlockQueue(mock.MagicMock(), mock.MagicMock())
     msg = messages.ScanQueueMessage(
         scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        parameter={"args": {"samx": (1,)}, "kwargs": {"relative": False}},
         queue="primary",
         metadata={"RID": "something"},
     )
@@ -1319,7 +1255,7 @@ def test_request_block_queue_append():
         (
             messages.ScanQueueMessage(
                 scan_type="mv",
-                parameter={"args": {"samx": (1,)}, "kwargs": {}},
+                parameter={"args": {"samx": (1,)}, "kwargs": {"relative": False}},
                 queue="primary",
                 metadata={"RID": "something"},
             ),
@@ -1441,7 +1377,7 @@ def test_update_point_id_takes_max(scan_queue_msg, scan_id):
         (
             messages.ScanQueueMessage(
                 scan_type="mv",
-                parameter={"args": {"samx": (1,)}, "kwargs": {}},
+                parameter={"args": {"samx": (1,)}, "kwargs": {"relative": False}},
                 queue="primary",
                 metadata={"RID": "something"},
             ),
@@ -1555,15 +1491,18 @@ def test_request_block_queue_raises_alarm_on_error(
 def test_queue_manager_get_active_scan_id(queuemanager_mock):
     queue_manager = queuemanager_mock()
     msg = messages.ScanQueueMessage(
-        scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        scan_type="grid_scan",
+        parameter={
+            "args": {"samx": (-1, 1, 10), "samy": (-1, 1, 10)},
+            "kwargs": {"relative": False, "system_config": {}},
+        },
         queue="primary",
         metadata={"RID": "something"},
     )
     queue_manager.add_to_queue(scan_queue="primary", msg=msg)
-    rbl = RequestBlockMock(msg, "scan_id")
-    queue_manager.queues["primary"].queue[0].queue.active_rb = rbl
-    assert queue_manager._get_active_scan_id("primary") == "scan_id"
+    iq = queue_manager.queues["primary"].queue[0]
+    iq.active_scan = iq.scans[0]
+    assert queue_manager._get_active_scan_id("primary") == iq.active_scan.scan_info.scan_id
 
 
 def test_queue_manager_get_active_scan_id_returns_None(queuemanager_mock):
@@ -1575,7 +1514,7 @@ def test_queue_manager_get_active_scan_id_wo_rbl_returns_None(queuemanager_mock)
     queue_manager = queuemanager_mock()
     msg = messages.ScanQueueMessage(
         scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        parameter={"args": {"samx": (1,)}, "kwargs": {"relative": False, "system_config": {}}},
         queue="primary",
         metadata={"RID": "something"},
     )
@@ -1603,7 +1542,7 @@ def test_get_owned_devices_for_instruction_queue_uses_request_block_rid(queueman
     )
     msg = messages.ScanQueueMessage(
         scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        parameter={"args": {"samx": (1,)}, "kwargs": {"relative": False, "system_config": {}}},
         queue="primary",
         metadata={"RID": "rid-123"},
     )
@@ -1632,7 +1571,7 @@ def test_get_owned_devices_for_instruction_queue_returns_none_for_legacy_queue_w
     )
     msg = messages.ScanQueueMessage(
         scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        parameter={"args": {"samx": (1,)}, "kwargs": {"relative": False}},
         queue="primary",
         metadata={"RID": "rid-123"},
     )
@@ -1700,7 +1639,7 @@ def test_request_block_queue_next():
     req_block_queue = RequestBlockQueue(mock.MagicMock(), mock.MagicMock())
     msg = messages.ScanQueueMessage(
         scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        parameter={"args": {"samx": (1,)}, "kwargs": {"relative": False}},
         queue="primary",
         metadata={"RID": "something"},
     )
@@ -1716,7 +1655,7 @@ def test_request_block_queue_next_raises_stopiteration():
     req_block_queue = RequestBlockQueue(mock.MagicMock(), mock.MagicMock())
     msg = messages.ScanQueueMessage(
         scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        parameter={"args": {"samx": (1,)}, "kwargs": {"relative": False}},
         queue="primary",
         metadata={"RID": "something"},
     )
@@ -1733,7 +1672,7 @@ def test_request_block_queue_next_updates_point_id():
     req_block_queue = RequestBlockQueue(mock.MagicMock(), mock.MagicMock())
     msg = messages.ScanQueueMessage(
         scan_type="mv",
-        parameter={"args": {"samx": (1,)}, "kwargs": {}},
+        parameter={"args": {"samx": (1,)}, "kwargs": {"relative": False}},
         queue="primary",
         metadata={"RID": "something", "scan_def_id": "scan_def_id"},
     )
@@ -1794,7 +1733,10 @@ def test_queue_order_change(queuemanager_mock, order_msg, position):
     queue_manager = queuemanager_mock()
     msg = messages.ScanQueueMessage(
         scan_type="line_scan",
-        parameter={"args": {"samx": (-5, 5)}, "kwargs": {"steps": 3}},
+        parameter={
+            "args": {"samx": (-5, 5)},
+            "kwargs": {"steps": 3, "system_config": {}, "relative": False},
+        },
         queue="primary",
         metadata={"RID": "something"},
     )
@@ -1805,14 +1747,14 @@ def test_queue_order_change(queuemanager_mock, order_msg, position):
     queue = queue_manager.queues["primary"]
     assert len(queue.queue) == 10
 
-    target_id = queue.queue[5].queue.scan_id
-    order_msg.scan_id = target_id[0]
+    target_id = queue.queue[5].scans[0].scan_info.scan_id
+    order_msg.scan_id = target_id
     queue_manager._handle_scan_order_change(order_msg)
     for ii in range(10):
         if ii == position:
-            assert queue.queue[ii].queue.scan_id == target_id
+            assert queue.queue[ii].scans[0].scan_info.scan_id == target_id
         else:
-            assert queue.queue[ii].queue.scan_id != target_id
+            assert queue.queue[ii].scans[0].scan_info.scan_id != target_id
 
 
 def test_add_lock_to_queue(queuemanager_mock):
@@ -2097,9 +2039,11 @@ def test_queue_waits_when_locked_and_resumes_after_release(queuemanager_mock):
     queue = queue_manager.queues["primary"]
 
     # Add items to the queue
-    iq1 = InstructionQueueItem(queue, mock.MagicMock(), mock.MagicMock())
+    iq1 = DirectInstructionQueueItem(queue, mock.MagicMock(), queue.scan_worker)
+    iq1.scans = [_build_dummy_v4_scan("scan-id-1")]
     iq1.status = InstructionQueueStatus.PENDING
-    iq2 = InstructionQueueItem(queue, mock.MagicMock(), mock.MagicMock())
+    iq2 = DirectInstructionQueueItem(queue, mock.MagicMock(), queue.scan_worker)
+    iq2.scans = [_build_dummy_v4_scan("scan-id-2")]
     iq2.status = InstructionQueueStatus.PENDING
     queue.queue.append(iq1)
     queue.queue.append(iq2)

--- a/bec_server/tests/tests_scan_server/test_scan_server_scan_manager.py
+++ b/bec_server/tests/tests_scan_server/test_scan_server_scan_manager.py
@@ -8,7 +8,7 @@ from bec_lib.device import Device, DeviceBase, Positioner
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.redis_connector import MessageObject
 from bec_lib.scan_args import ScanArgument
-from bec_server.scan_server.scan_manager import ScanManager
+from bec_server.scan_server.scan_manager import ScanManager, scans_module
 from bec_server.scan_server.scans import ScanArgType
 from bec_server.scan_server.tests.utils import NoopScan
 
@@ -91,6 +91,14 @@ class _GuiConfigModifier:
         return gui_config
 
 
+class _PreferredV4Scan(NoopScan):
+    scan_name = "shared_scan"
+
+
+class _PluginDuplicateScan(NoopScan):
+    scan_name = "shared_scan"
+
+
 def test_scan_manager_does_not_apply_gui_config_overrides_to_legacy_gui_config(scan_manager):
     with (
         mock.patch.object(
@@ -125,6 +133,29 @@ def test_scan_manager_update_available_scans_resets_existing_entries(scan_manage
 
     assert scan_manager.available_scans == first_result
     assert scan_manager.scan_dict == {_GuiConfigScan.scan_name: _GuiConfigScan}
+
+
+def test_scan_manager_get_available_scans_only_appends_new_scan_names():
+    ScanManager.get_available_scans.cache_clear()
+    try:
+        with (
+            mock.patch.object(
+                ScanManager, "_get_v4_scan_members", return_value=[("preferred", _PreferredV4Scan)]
+            ),
+            mock.patch.object(scans_module.LineScan, "scan_name", "shared_scan"),
+            mock.patch(
+                "bec_server.scan_server.scan_manager.inspect.getmembers",
+                return_value=[("legacy", scans_module.LineScan)],
+            ),
+            mock.patch.object(
+                ScanManager, "_get_scan_plugins", return_value={"plugin": _PluginDuplicateScan}
+            ),
+        ):
+            members = ScanManager.get_available_scans()
+    finally:
+        ScanManager.get_available_scans.cache_clear()
+
+    assert members == [("preferred", _PreferredV4Scan)]
 
 
 def test_scan_manager_update_available_scans_reload_forces_discovery_refresh(scan_manager):

--- a/pytest_bec_e2e/pytest_bec_e2e/plugin.py
+++ b/pytest_bec_e2e/pytest_bec_e2e/plugin.py
@@ -29,7 +29,8 @@ class LogTestTool:
 
     def fetch(self, count: int | None = None) -> None:
         """Fetch logs from the server and store them for interrogation, get all by default or get
-        the last `count` logs (latter will not fetch read logs again if they have been seen!)"""
+        the last `count` logs (latter will not fetch read logs again if they have been seen!)
+        """
         log_data = self._conn.xread(MessageEndpoints.log(), from_start=(count is None), count=count)
         if log_data is None:
             self._logs = None

--- a/pytest_bec_e2e/pytest_bec_e2e/plugin.py
+++ b/pytest_bec_e2e/pytest_bec_e2e/plugin.py
@@ -21,6 +21,9 @@ from bec_lib.tests.utils import wait_for_empty_queue
 
 RedisConnector.RETRY_ON_TIMEOUT = 1
 
+CLIENT_SHUTDOWN_TIMEOUT_S = 10
+SERVICE_STOP_TIMEOUT_S = 20
+
 
 class LogTestTool:
     def __init__(self, client: BECIPythonClient):
@@ -205,7 +208,7 @@ def bec_servers(
         try:
             yield
         finally:
-            service_handler.stop(processes)
+            service_handler.stop(processes, timeout_s=SERVICE_STOP_TIMEOUT_S)
     else:
         # Nothing to do here: servers are supposed to be started externally.
         yield
@@ -222,7 +225,7 @@ def bec_ipython_client_with_demo_config(
     try:
         yield bec
     finally:
-        bec.shutdown()
+        bec.shutdown(per_thread_timeout_s=CLIENT_SHUTDOWN_TIMEOUT_S)
         bec._client._reset_singleton()
 
 
@@ -235,7 +238,7 @@ def bec_client_lib_with_demo_config(bec_redis_fixture, bec_services_config_file_
     try:
         yield bec
     finally:
-        bec.shutdown()
+        bec.shutdown(per_thread_timeout_s=CLIENT_SHUTDOWN_TIMEOUT_S)
         bec._client._reset_singleton()
 
 


### PR DESCRIPTION
## Description

This PR replaces the internal legacy scans with v4 scans and renames them accordingly. The feature parity has already been established with the previous PR (#994). 

## How to test

- Run unit tests
- Run scans, stop them, etc. 

## Potential side effects

We need to adapt the scan control widget in BW to filter the v4 scans to only show relevant ones. Two new scan info flags have been introduced in this PR to accomplish that: "is_internal" and "is_scan". 

## Additional Comments

While it does not remove the ability to run legacy scans, it doesn't expose them anymore. Once the OMNY scans are tested on the new system, we can remove them completely.  

## Definition of Done
- [ ] Documentation is up-to-date.

