### PR TITLE
fix(ci): added webengine flags "--disable-gpu" for bec widgets tests

### DIFF
--- a/.github/workflows/child_repos.yml
+++ b/.github/workflows/child_repos.yml
@@ -28,6 +28,7 @@ jobs:
     env: 
       QTWEBENGINE_DISABLE_SANDBOX: 1
       QT_QPA_PLATFORM: "offscreen"
+      QTWEBENGINE_CHROMIUM_FLAGS: "--disable-gpu"
 
     steps:
       - name: Checkout BEC Widgets


### PR DESCRIPTION
Added web engine flag to fix segfault after version migration of qt in bec widgets