### PR TITLE
Add batch based publish logs to redis

### DIFF
--- a/bec_ipython_client/tests/conftest.py
+++ b/bec_ipython_client/tests/conftest.py
@@ -9,4 +9,4 @@ from bec_lib.logger import bec_logger
 @pytest.fixture(autouse=True)
 def threads_check(threads_check):
     yield
-    bec_logger.logger.remove()
+    bec_logger.shutdown()

--- a/bec_ipython_client/tests/end-2-end/test_procedures_e2e.py
+++ b/bec_ipython_client/tests/end-2-end/test_procedures_e2e.py
@@ -114,22 +114,32 @@ def test_happy_path_container_procedure_runner(
     _wait_while(lambda: manager._active_workers == {}, 5)
     _wait_while(lambda: manager._active_workers != {}, 90)
 
-    logtool.fetch()
-    assert logtool.is_present_in_any_message("procedure accepted: True, message:")
-    assert logtool.is_present_in_any_message(
-        "Procedure worker started container for queue primary"
-    ), f"Log content relating to procedures: {manager._logs}"
+    tests_passed = False
+    time_started = time.monotonic()
+    timeout = 20
+    while time.monotonic() - time_started < timeout:
+        logtool.fetch()
+        try:
+            assert logtool.is_present_in_any_message("procedure accepted: True, message:")
+            assert logtool.is_present_in_any_message(
+                "Procedure worker started container for queue primary"
+            ), f"Log content relating to procedures: {manager._logs}"
 
-    res, msg = logtool.are_present_in_order(
-        [
-            "Procedure worker 'primary' status update: IDLE",
-            "Procedure worker 'primary' status update: RUNNING",
-            "Procedure worker 'primary' status update: IDLE",
-            "Procedure worker 'primary' status update: FINISHED",
-        ]
-    )
-    assert res, f"failed on {msg}"
+            res, msg = logtool.are_present_in_order(
+                [
+                    "Procedure worker 'primary' status update: IDLE",
+                    "Procedure worker 'primary' status update: RUNNING",
+                    "Procedure worker 'primary' status update: IDLE",
+                    "Procedure worker 'primary' status update: FINISHED",
+                ]
+            )
+            assert res, f"failed on {msg}"
 
-    assert logtool.is_present_in_any_message(
-        f"Builtin procedure log_message_args_kwargs called with args: {test_args} and kwargs: {test_kwargs}"
-    )
+            assert logtool.is_present_in_any_message(
+                f"Builtin procedure log_message_args_kwargs called with args: {test_args} and kwargs: {test_kwargs}"
+            )
+            tests_passed = True
+            break
+        except AssertionError:
+            time.sleep(0.1)
+    assert tests_passed, "Test did not pass within the timeout"

--- a/bec_lib/bec_lib/client.py
+++ b/bec_lib/bec_lib/client.py
@@ -370,7 +370,7 @@ class BECClient(BECService):
         if self.builtin_actors is not None:
             self.builtin_actors.shutdown()
             self.builtin_actors = None  # type: ignore
-        bec_logger.logger.remove()
+        bec_logger.shutdown()
         self.started = False
 
     def _print_available_commands(self, title: str, data: list[tuple[str, str]]) -> None:

--- a/bec_lib/bec_lib/logger.py
+++ b/bec_lib/bec_lib/logger.py
@@ -10,10 +10,13 @@ import enum
 import json
 import os
 import sys
+import threading
 import time
 import traceback
+from collections import deque
 from itertools import takewhile
-from typing import TYPE_CHECKING, Literal
+from queue import Empty
+from typing import TYPE_CHECKING, Generic, Iterable, Literal, TypeVar
 
 # TODO: Importing bec_lib, instead of `from bec_lib.messages import LogMessage`, avoids potential
 # logger <-> messages circular import. But there could be a better solution.
@@ -31,6 +34,42 @@ else:
     loguru_logger = lazy_import_from("loguru", ("logger",))
     LogWriter = lazy_import_from("bec_lib.file_utils", ("LogWriter",))
     RedisConnector = lazy_import_from("bec_lib.redis_connector", ("RedisConnector",))
+
+
+_T = TypeVar("_T")
+
+
+class BatchQueue(Generic[_T]):
+    """Thread-safe queue supporting blocking, atomic batch retrieval."""
+
+    def __init__(self) -> None:
+        self._items: deque[_T] = deque()
+        self._not_empty = threading.Condition()
+
+    def put(self, item: _T) -> None:
+        """Append one item and wake one waiting consumer."""
+        with self._not_empty:
+            self._items.append(item)
+            self._not_empty.notify()
+
+    def put_many(self, items: Iterable[_T]) -> None:
+        """Atomically append multiple items and wake one waiting consumer."""
+        with self._not_empty:
+            self._items.extend(items)
+            self._not_empty.notify()
+
+    def get_all(self, timeout: float | None = None) -> list[_T]:
+        """Block until an item is available, then atomically remove all items."""
+        with self._not_empty:
+            if not self._not_empty.wait_for(lambda: bool(self._items), timeout=timeout):
+                raise Empty
+            items = list(self._items)
+            self._items.clear()
+            return items
+
+    def get_all_nowait(self) -> list[_T]:
+        """Atomically remove all currently available items without blocking."""
+        return self.get_all(timeout=0)
 
 
 class LogLevel(int, enum.Enum):
@@ -133,6 +172,12 @@ class BECLogger:
         self._file_max_size_mb = self.DEFAULT_MAX_FILE_SIZE_MB
         self._file_max_files = self.DEFAULT_MAX_FILES
 
+        # Publish log messages to Redis in throttled batches to improve performance.
+        self._log_thread: threading.Thread | None = None
+        self._log_event: threading.Event | None = None
+        self._log_queue: BatchQueue[tuple[str | dict, str | None]] | None = None
+        self._log_throttle = 0.5
+
     def __new__(cls):
         if not hasattr(cls, "_logger") or cls._logger is None:
             cls._logger = super(BECLogger, cls).__new__(cls)
@@ -142,7 +187,15 @@ class BECLogger:
     def _reset_singleton(cls):
         if cls._logger is not None:
             cls._logger.logger.remove()
+            cls._logger._stop_log_thread()
         cls._logger = None
+
+    def shutdown(self):
+        """
+        Shutdown the logger and stop the log thread.
+        """
+        self.logger.remove()
+        self._stop_log_thread()
 
     def configure(
         self,
@@ -175,6 +228,7 @@ class BECLogger:
         self.connector = self._get_connector(
             connector=connector, connector_cls=connector_cls, bootstrap_server=bootstrap_server
         )
+        self._setup_log_thread()
 
         self.bootstrap_server = bootstrap_server
         self.service_name = service_name
@@ -230,6 +284,61 @@ class BECLogger:
         if not bootstrap_server:
             raise ValueError("bootstrap_server must be provided when using connector_cls")
         return connector_cls(bootstrap=bootstrap_server)
+
+    def _setup_log_thread(self):
+        """
+        Setup the log thread that publishes log messages to redis.
+        """
+        if self.connector is None:
+            return
+        if self._log_thread is not None and self._log_thread.is_alive():
+            return
+
+        self._log_event = threading.Event()
+        self._log_queue = BatchQueue()
+        self._log_thread = threading.Thread(
+            target=self._publish_pipe_to_redis, name="BECLoggerThread", daemon=True
+        )
+        self._log_thread.start()
+
+    def _stop_log_thread(self) -> None:
+        """Stop the Redis publishing thread after flushing queued messages."""
+        if self._log_thread is None:
+            return
+        if self._log_event is not None:
+            self._log_event.set()
+        self._log_thread.join(timeout=max(1.0, self._log_throttle * 4))
+        if self._log_thread.is_alive():
+            return
+        self._log_thread = None
+        self._log_event = None
+        self._log_queue = None
+
+    def _publish_pipe_to_redis(self) -> None:
+        """Collect queued messages into throttled batches and publish them to Redis."""
+        log_event = self._log_event
+        log_queue = self._log_queue
+        if log_event is None or log_queue is None:
+            return
+
+        while not log_event.is_set():
+            try:
+                messages = log_queue.get_all(timeout=self._log_throttle)
+            except Empty:
+                continue
+
+            # Wait for the batching window and atomically include messages which
+            # arrived while waiting.
+            log_event.wait(timeout=self._log_throttle)
+            try:
+                messages.extend(log_queue.get_all_nowait())
+            except Empty:
+                pass
+            if not log_event.is_set():
+                self._publish_log_batch(messages)
+
+        # We might drop messages if _reset_singleton is called with queued logs.
+        # Therefore we don't send any remaining messages after the event is set, to avoid crashing during shutdown.
 
     def _update_base_path(self, service_config: dict | None = None):
         """
@@ -438,7 +547,7 @@ class BECLogger:
             level (LogLevel): Log level.
         """
         self.logger.add(
-            self._publish_log_message,
+            self._queue_log_message,
             serialize=True,
             level=level,
             format=self.formatting(),
@@ -462,12 +571,37 @@ class BECLogger:
     def _console_redis_logger_callback(self, msg):
         if not self._configured or self.connector is None:
             return
-        self._publish_log_message(msg, service_name=f"{self.service_name}_CONSOLE")
+        self._queue_log_message(msg, service_name=f"{self.service_name}_CONSOLE")
+
+    def _queue_log_message(self, msg: str | dict, service_name: str | None = None) -> None:
+        """Queue a message for batched Redis publishing."""
+        if not self._configured or self.connector is None:
+            return
+        self._log_queue.put((msg, service_name))
+
+    def _publish_log_batch(self, messages: list[tuple[str | dict, str | None]]) -> None:
+        """Publish queued messages using one Redis pipeline."""
+        if not messages or self.connector is None:
+            return
+        try:
+            pipeline = self.connector.pipeline()
+            published = False
+            for msg, service_name in messages:
+                published |= self._publish_log_message(
+                    msg, service_name=service_name, pipe=pipeline
+                )
+            if published:
+                self.connector.execute_pipeline(pipeline)
+        except Exception:
+            # The connector may be disconnected during shutdown.
+            return
 
     def _decode_log_payload(self, msg: str | dict) -> dict:
         return json.loads(msg) if isinstance(msg, str) else dict(msg)
 
-    def _publish_log_message(self, msg: str | dict, service_name: str | None = None) -> bool:
+    def _publish_log_message(
+        self, msg: str | dict, service_name: str | None = None, pipe=None
+    ) -> bool:
         if not self._configured or self.connector is None:
             return False
         payload = self._decode_log_payload(msg)
@@ -481,6 +615,7 @@ class BECLogger:
                     )
                 },
                 max_size=10000,
+                pipe=pipe,
             )
             return True
         except Exception:

--- a/bec_lib/bec_lib/logger.py
+++ b/bec_lib/bec_lib/logger.py
@@ -302,7 +302,7 @@ class BECLogger:
         self._log_thread.start()
 
     def _stop_log_thread(self) -> None:
-        """Stop the Redis publishing thread after flushing queued messages."""
+        """Stop the Redis publishing thread."""
         if self._log_thread is None:
             return
         if self._log_event is not None:
@@ -577,7 +577,10 @@ class BECLogger:
         """Queue a message for batched Redis publishing."""
         if not self._configured or self.connector is None:
             return
-        self._log_queue.put((msg, service_name))
+        log_queue = self._log_queue
+        if log_queue is None:
+            return
+        log_queue.put((msg, service_name))
 
     def _publish_log_batch(self, messages: list[tuple[str | dict, str | None]]) -> None:
         """Publish queued messages using one Redis pipeline."""

--- a/bec_lib/tests/conftest.py
+++ b/bec_lib/tests/conftest.py
@@ -15,7 +15,7 @@ from bec_lib.redis_connector import RedisConnector
 @pytest.fixture(autouse=True)
 def threads_check(threads_check):
     yield
-    bec_logger.logger.remove()
+    bec_logger.shutdown()
 
 
 @pytest.fixture(autouse=True)

--- a/bec_lib/tests/test_bec_logger.py
+++ b/bec_lib/tests/test_bec_logger.py
@@ -148,8 +148,9 @@ def test_console_redis_callback_publishes_to_log_endpoint_with_console_service_n
     logger.service_name = "test"
     logger.connector = mock.MagicMock(spec=RedisConnector)
 
-    logger._console_redis_logger_callback(
-        json.dumps({"record": {"level": {"name": "CONSOLE_LOG"}}, "text": "hello"})
+    logger._publish_log_message(
+        json.dumps({"record": {"level": {"name": "CONSOLE_LOG"}}, "text": "hello"}),
+        service_name="test_CONSOLE",
     )
 
     logger.connector.xadd.assert_called_once()
@@ -161,12 +162,14 @@ def test_console_redis_callback_publishes_to_log_endpoint_with_console_service_n
 
 def test_console_redis_callback_ignores_publish_failures(logger):
     logger._configured = True
+    logger._log_throttle = 0.01
     logger.service_name = "test"
     logger.connector = mock.MagicMock(spec=RedisConnector)
     logger.connector.xadd.side_effect = RuntimeError("redis unavailable")
 
-    logger._console_redis_logger_callback(
-        json.dumps({"record": {"level": {"name": "CONSOLE_LOG_ERROR"}}, "text": "oops"})
+    logger._publish_log_message(
+        json.dumps({"record": {"level": {"name": "CONSOLE_LOG_ERROR"}}, "text": "oops"}),
+        service_name="test",
     )
 
     logger.connector.xadd.assert_called_once()

--- a/bec_lib/tests/test_bec_logger.py
+++ b/bec_lib/tests/test_bec_logger.py
@@ -1,13 +1,15 @@
 import datetime
 import json
 import os
+import threading
 from pathlib import Path
+from queue import Empty
 from unittest import mock
 
 import pytest
 
 from bec_lib.bec_errors import ServiceConfigError
-from bec_lib.logger import BECLogger, BECLoguruRotator, LogLevel
+from bec_lib.logger import BatchQueue, BECLogger, BECLoguruRotator, LogLevel
 from bec_lib.redis_connector import RedisConnector
 
 
@@ -16,6 +18,30 @@ def logger():
     BECLogger._reset_singleton()
     logger = BECLogger()
     yield logger
+    logger.shutdown()
+
+
+def test_batch_queue_blocks_and_atomically_drains_all_items():
+    batch_queue = BatchQueue[int]()
+    consumer_started = threading.Event()
+    received = []
+
+    def consume():
+        consumer_started.set()
+        received.extend(batch_queue.get_all(timeout=1))
+
+    consumer = threading.Thread(target=consume)
+    consumer.start()
+    assert consumer_started.wait(timeout=1)
+    assert consumer.is_alive()
+
+    batch_queue.put_many([1, 2, 3])
+    consumer.join(timeout=1)
+
+    assert consumer.is_alive() is False
+    assert received == [1, 2, 3]
+    with pytest.raises(Empty):
+        batch_queue.get_all_nowait()
 
 
 def test_configure(logger, tmp_path):
@@ -144,3 +170,49 @@ def test_console_redis_callback_ignores_publish_failures(logger):
     )
 
     logger.connector.xadd.assert_called_once()
+
+
+def test_redis_callback_queues_message_when_thread_is_configured(logger):
+    logger._configured = True
+    logger.service_name = "test"
+    logger.connector = mock.MagicMock(spec=RedisConnector)
+    logger._log_queue = BatchQueue()
+    message = json.dumps({"record": {"level": {"name": "INFO"}}, "text": "hello"})
+
+    logger._queue_log_message(message)
+
+    assert logger._log_queue.get_all_nowait() == [(message, None)]
+    logger.connector.xadd.assert_not_called()
+
+
+def test_publish_log_batch_uses_one_redis_pipeline(logger):
+    logger._configured = True
+    logger.service_name = "test"
+    logger.connector = mock.MagicMock(spec=RedisConnector)
+    pipeline = logger.connector.pipeline.return_value
+    info = json.dumps({"record": {"level": {"name": "INFO"}}, "text": "hello"})
+    console = json.dumps({"record": {"level": {"name": "CONSOLE_LOG"}}, "text": "console"})
+
+    logger._publish_log_batch([(info, None), (console, "test_CONSOLE")])
+
+    assert logger.connector.xadd.call_count == 2
+    assert all(call.kwargs["pipe"] is pipeline for call in logger.connector.xadd.call_args_list)
+    logger.connector.execute_pipeline.assert_called_once_with(pipeline)
+
+
+def test_log_thread_publishes_queued_messages_as_one_batch(logger):
+    logger._configured = True
+    logger.service_name = "test"
+    logger.connector = mock.MagicMock(spec=RedisConnector)
+    logger._log_throttle = 0.01
+    batch_published = threading.Event()
+    logger.connector.execute_pipeline.side_effect = lambda _: batch_published.set()
+    logger._setup_log_thread()
+    info = json.dumps({"record": {"level": {"name": "INFO"}}, "text": "hello"})
+
+    logger._queue_log_message(info)
+    logger._queue_log_message(info)
+
+    assert batch_published.wait(timeout=1)
+    assert logger.connector.xadd.call_count == 2
+    logger.connector.execute_pipeline.assert_called_once()

--- a/bec_lib/tests/test_bec_service.py
+++ b/bec_lib/tests/test_bec_service.py
@@ -42,7 +42,7 @@ def bec_service(config, connector_cls=None, connector=None, **kwargs):
             yield service
         finally:
             service.shutdown()
-            bec_logger.logger.remove()
+            bec_logger.shutdown()
             bec_logger._reset_singleton()
 
 
@@ -625,7 +625,7 @@ def test_wait_for_service():
             service.wait_for_service("ScanServer", BECStatus.RUNNING)
             mock_sleep.assert_called_once()
         service.shutdown()
-        bec_logger.logger.remove()
+        bec_logger.shutdown()
         bec_logger._reset_singleton()
 
 
@@ -647,7 +647,7 @@ def test_wait_for_service_busy():
             service.wait_for_service("ScanServer", BECStatus.BUSY)
             mock_sleep.assert_called_once()
         service.shutdown()
-        bec_logger.logger.remove()
+        bec_logger.shutdown()
         bec_logger._reset_singleton()
 
 
@@ -673,5 +673,5 @@ def test_wait_for_service_default():
             service.wait_for_service("ScanServer")
             mock_sleep.assert_called_once()
         service.shutdown()
-        bec_logger.logger.remove()
+        bec_logger.shutdown()
         bec_logger._reset_singleton()

--- a/bec_server/bec_server/scan_server/tests/fixtures.py
+++ b/bec_server/bec_server/scan_server/tests/fixtures.py
@@ -18,7 +18,7 @@ def scan_server_mock(dm_with_devices):
     server = ScanServerMock(dm_with_devices)
     yield server
     server.shutdown()
-    bec_logger.logger.remove()
+    bec_logger.shutdown()
 
 
 @pytest.fixture

--- a/bec_server/tests/tests_data_processing/conftest.py
+++ b/bec_server/tests/tests_data_processing/conftest.py
@@ -9,4 +9,4 @@ from bec_lib.logger import bec_logger
 @pytest.fixture(autouse=True)
 def threads_check(threads_check):
     yield
-    bec_logger.logger.remove()
+    bec_logger.shutdown()

--- a/bec_server/tests/tests_device_server/conftest.py
+++ b/bec_server/tests/tests_device_server/conftest.py
@@ -16,7 +16,7 @@ from bec_lib.redis_connector import RedisConnector
 # @pytest.fixture(autouse=True)
 # def threads_check(threads_check):
 #    yield
-#    bec_logger.logger.remove()
+#    bec_logger.shutdown()
 ###
 ### MEANWHILE, THIS FIXTURE WILL JUST CLEAN LOGGER
 ### THREADS, AND THERE WILL BE NO CHECK FOR DANGLING
@@ -48,4 +48,4 @@ def threads_check():
     #     _dispatcher.stop()
     # except Exception:
     #     pass
-    bec_logger.logger.remove()
+    bec_logger.shutdown()

--- a/bec_server/tests/tests_file_writer/conftest.py
+++ b/bec_server/tests/tests_file_writer/conftest.py
@@ -26,4 +26,4 @@ def connected_connector():
 @pytest.fixture(autouse=True)
 def threads_check(threads_check):
     yield
-    bec_logger.logger.remove()
+    bec_logger.shutdown()

--- a/bec_server/tests/tests_file_writer/test_file_writer_manager.py
+++ b/bec_server/tests/tests_file_writer/test_file_writer_manager.py
@@ -56,7 +56,7 @@ def file_writer_manager_mock(dm_with_devices):
             yield file_writer_manager_mock
         finally:
             file_writer_manager_mock.shutdown()
-            bec_logger.logger.remove()
+            bec_logger.shutdown()
             bec_logger._reset_singleton()
 
 

--- a/bec_server/tests/tests_scan_bundler/conftest.py
+++ b/bec_server/tests/tests_scan_bundler/conftest.py
@@ -19,7 +19,7 @@ from bec_server.scan_bundler import ScanBundler
 @pytest.fixture(autouse=True)
 def threads_check(threads_check):
     yield
-    bec_logger.logger.remove()
+    bec_logger.shutdown()
 
 
 class ScanBundlerMock(ScanBundler):

--- a/bec_server/tests/tests_scan_server/conftest.py
+++ b/bec_server/tests/tests_scan_server/conftest.py
@@ -17,7 +17,7 @@ pytest_plugins = ["bec_server.scan_server.tests.scan_fixtures"]
 @pytest.fixture(autouse=True)
 def threads_check(threads_check):
     yield
-    bec_logger.logger.remove()
+    bec_logger.shutdown()
 
 
 def fake_redis_server(host, port, **kwargs):

--- a/bec_server/tests/tests_scihub/conftest.py
+++ b/bec_server/tests/tests_scihub/conftest.py
@@ -19,7 +19,7 @@ from bec_server.scihub.atlas.atlas_connector import AtlasConnector
 @pytest.fixture(autouse=True)
 def threads_check(threads_check):
     yield
-    bec_logger.logger.remove()
+    bec_logger.shutdown()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
# Summary
Goal of this PR is to improve the log performance of the bec_logger. Instead of sending each update to Redis, we batch log updates together and have a dedicated thread that sends log messages through a pipe together. For this, we also benchmarked the previous implementation. 

## Performance overview
File and stdout logs are each around 70.000-80.000 msg/s, while Redis logs were pulling down performance. The previous implementation was around ~6.000msg/s. 

The update with a push frequency of 2Hz is a 2.x performance increase around 12.000-14.000 msg/s.

*OLD*
<img width="449" height="367" alt="Screenshot 2026-07-28 at 14 40 31" src="https://github.com/user-attachments/assets/6487850e-09c6-47f5-9520-c1413b496516" />

*NEW*
<img width="419" height="360" alt="Screenshot 2026-07-28 at 14 43 17" src="https://github.com/user-attachments/assets/e5d1214f-ca9d-43a6-a9b0-f09bb5d5cc49" />
