### PR TITLE
fix: check if enum_strs is None

### DIFF
--- a/bec_server/bec_server/device_server/device_server.py
+++ b/bec_server/bec_server/device_server/device_server.py
@@ -752,7 +752,12 @@ class DeviceServer(BECService):
         Returns:
             Any: The converted value.
         """
-        if hasattr(obj, "enum_strs") and len(obj.enum_strs) > 0 and isinstance(val, float):
+        if (
+            hasattr(obj, "enum_strs")
+            and obj.enum_strs is not None
+            and len(obj.enum_strs) > 0
+            and isinstance(val, float)
+        ):
             if not val.is_integer():
                 raise ValueError(
                     f"Cannot convert float {val} to enum index for {obj.name}. "


### PR DESCRIPTION
On a non-enum `EpicsSignal`, `enum_strs` is a set attribute, just `None`, so `hasattr` didn't catch this. This change adds a check for `None` to the checks for an enum PV.

```python

• p11206 | PX-III@bec [1/202] ❯❯ dev.bl_bright
Out[1]:
                            EpicsSignal: bl_bright
 Enabled           True
 Description       Backlight Brightness
 Read only         False
 Software Trigger  False
 Device class      ophyd.EpicsSignal
 Readout Priority  baseline
 Device tags       state
 User parameter    {'off': 0, 'on': 1.3, 'type': 'continuous', '“tol”': 0.01}
 Limits            [0, 0]

                  Current Values
 Signal     Value             Timestamp
 bl_bright  0.10010071108128  2026-08-13 15:38:29


• p11206 | PX-III@bec [2/202] ❯❯ dev.bl_bright.set(0)
 BEC alarm:
╭─────────────────────────────────────────────────────────── TypeError | Severity MAJOR  ───────────────────────────────────────────────────────────╮
│ TypeError: object of type 'NoneType' has no len()                                                                                                 │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
For more details, use 'bec.show_last_alarm()'

• p11206 | PX-III@bec [3/202] ❯❯ bec.show_last_alarm()
╭── Alarm Info ───╮
│ Alarm Raised    │
│ Severity: MAJOR │
│ Type: TypeError │
│                 │
╰─────────────────╯
╭───────────────────── Summary ─────────────────────╮
│ TypeError: object of type 'NoneType' has no len() │
│                                                   │
╰───────────────────────────────────────────────────╯
Traceback (most recent call last):
  File "/sls/x06da/config/bec/production/bec/bec_server/bec_server/device_server/rpc_handler.py", line 51, in run_rpc
    res = self.process_rpc_instruction(instr)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sls/x06da/config/bec/production/bec/bec_server/bec_server/device_server/rpc_handler.py", line 84, in process_rpc_instruction
    return self._handle_set(instr)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/sls/x06da/config/bec/production/bec/bec_server/bec_server/device_server/rpc_handler.py", line 205, in _handle_set
    val = self.device_server.convert_value_if_needed(obj, val)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sls/x06da/config/bec/production/bec/bec_server/bec_server/device_server/device_server.py", line 755, in convert_value_if_needed
    if hasattr(obj, "enum_strs") and len(obj.enum_strs) > 0 and isinstance(val, float):
                                     ^^^^^^^^^^^^^^^^^^
TypeError: object of type 'NoneType' has no len()


• p11206 | PX-III@bec [4/202] ❯❯ from ophyd import EpicsSignal

• p11206 | PX-III@bec [5/202] ❯❯ s = EpicsSignal(read_pv="X06DA-ES-BL:SET")

• p11206 | PX-III@bec [6/202] ❯❯ s
Out[6]: EpicsSignal(read_pv='X06DA-ES-BL:SET', name='X06DA-ES-BL:SET', timestamp=1786628309.854828, tolerance=0.001, auto_monitor=False, string=False, write_pv='X06DA-ES-BL:SET', limits=False, put_complete=False)

• p11206 | PX-III@bec [7/202] ❯❯ s.enum_strs

• p11206 | PX-III@bec [8/202] ❯❯
```