### PR TITLE
fix(rpc): respect read_only during rpc calls

### DIFF
--- a/bec_server/bec_server/device_server/rpc_handler.py
+++ b/bec_server/bec_server/device_server/rpc_handler.py
@@ -78,10 +78,16 @@ class RPCHandler:
             return self._rpc_read_configuration_and_return(instr)
 
         if instr_params.get("kwargs", {}).get("_set_property"):
+            self._assert_rpc_write_allowed(instr)
             return self._handle_rpc_property_set(instr)
 
         if self._instr_with_operation(instr, "set"):
+            self._assert_rpc_write_allowed(instr)
             return self._handle_set(instr)
+
+        if self._instr_with_operation(instr, "put"):
+            self._assert_rpc_write_allowed(instr)
+            return self._handle_misc_rpc(instr)
 
         return self._handle_misc_rpc(instr)
 
@@ -285,6 +291,23 @@ class RPCHandler:
             )
             self.connector.raise_alarm(severity=Alarms.WARNING, info=error_info)
         return res
+
+    def _assert_rpc_write_allowed(self, instr: messages.DeviceInstructionMessage) -> None:
+        """
+        Reject write-style RPCs for read-only devices.
+
+        Args:
+            instr(messages.DeviceInstructionMessage): RPC instruction
+        """
+        # Imported lazily to avoid a circular import during module initialization.
+        from bec_server.device_server.device_server import DisabledDeviceError
+
+        device_root = self._get_device_root(instr)
+        device_obj = self.device_manager.devices[device_root]
+        if device_obj.read_only:
+            raise DisabledDeviceError(
+                f"Setting the device {device_obj.name} is currently disabled."
+            )
 
     def _get_rpc_components(
         self, instr: messages.DeviceInstructionMessage

--- a/bec_server/tests/tests_device_server/test_rpc_handler.py
+++ b/bec_server/tests/tests_device_server/test_rpc_handler.py
@@ -8,7 +8,7 @@ from ophyd import Device, DeviceStatus, Kind, Signal, Staged, StatusBase
 from bec_lib import messages
 from bec_lib.alarm_handler import Alarms
 from bec_lib.endpoints import MessageEndpoints
-from bec_server.device_server.device_server import DeviceServer, RequestHandler
+from bec_server.device_server.device_server import DeviceServer, DisabledDeviceError, RequestHandler
 from bec_server.device_server.rpc_handler import RPCHandler
 
 
@@ -206,6 +206,8 @@ def test_run_rpc_sends_rpc_exception(rpc_cls, instr):
 @pytest.fixture()
 def dev_mock():
     dev_mock = mock.MagicMock()
+    dev_mock.name = "device"
+    dev_mock.read_only = False
     dev_mock.obj = mock.MagicMock(spec=Device)
     dev_mock.obj.readback = mock.MagicMock(spec=Signal)
     dev_mock.obj.readback.kind = Kind.hinted
@@ -313,6 +315,36 @@ def test_process_rpc_instruction_set_attribute_on_sub_device(rpc_cls, dev_mock, 
     rpc_cls.device_manager.devices = {"device": dev_mock}
     rpc_cls.process_rpc_instruction(instr)
     rpc_cls.device_manager.devices["device"].obj.user_setpoint.attr_value == 5
+
+
+@pytest.mark.parametrize(
+    "parameter",
+    [
+        {"func": "velocity.set", "args": [5]},
+        {"func": "user_setpoint.put", "args": [5]},
+        {"func": "attr_value", "args": [5], "kwargs": {"_set_property": True}},
+    ],
+)
+def test_process_rpc_instruction_rejects_write_calls_for_read_only_device(
+    rpc_cls, dev_mock, parameter
+):
+    dev_mock.name = "device"
+    dev_mock.read_only = True
+    rpc_cls.device_manager.devices = {"device": dev_mock}
+    instr = messages.DeviceInstructionMessage(
+        device="device",
+        action="rpc",
+        parameter=parameter,
+        metadata={"RID": "RID", "device_instr_id": "diid"},
+    )
+
+    with mock.patch.object(rpc_cls, "_execute_rpc_call") as mock_execute_rpc:
+        with pytest.raises(
+            DisabledDeviceError, match="Setting the device device is currently disabled."
+        ):
+            rpc_cls.process_rpc_instruction(instr)
+
+    mock_execute_rpc.assert_not_called()
 
 
 def test_set_config_signal_updates_cache(rpc_cls, dev_mock, instr):


### PR DESCRIPTION
## Description

Fixing a bug that allowed rpc calls to bypass the read-only contract

