### PR TITLE
feat(async writer): add tracking for written async signals

### DIFF
--- a/bec_server/bec_server/file_writer/async_writer.py
+++ b/bec_server/bec_server/file_writer/async_writer.py
@@ -106,8 +106,19 @@ class AsyncWriter(threading.Thread):
         self.device_data_replace = {}
         self.append_shapes = {}
         self.written_devices = set()
+        self._written_signals = defaultdict(set)
         self.file_handle = None
         self.cursor = defaultdict(dict)
+
+    @property
+    def written_signals(self) -> dict[str, list[str]]:
+        """
+        Return the async signals that were written, grouped by device.
+        """
+        return {
+            device_name: sorted(signal_names)
+            for device_name, signal_names in self._written_signals.items()
+        }
 
     def initialize_stream_keys(self):
         """
@@ -305,6 +316,7 @@ class AsyncWriter(threading.Thread):
                                 info=error_info,
                                 metadata={"scan_id": self.scan_id, "scan_number": self.scan_number},
                             )
+                    self._written_signals[device_name].add(signal_name)
 
         if write_replace:
             for group_name, value in self.device_data_replace.items():

--- a/bec_server/bec_server/file_writer/default_writer.py
+++ b/bec_server/bec_server/file_writer/default_writer.py
@@ -26,6 +26,7 @@ class DefaultFormat:
         beamline_states: dict[str, list[messages.BeamlineStateMessage]],
         device_manager: DeviceManagerBase,
         additional_scan_metadata: AdditionalScanMetadata,
+        written_async_signals: dict[str, list[str]] | None = None,
     ):
         self.storage = storage
         self.data = data
@@ -35,6 +36,7 @@ class DefaultFormat:
         self.info_storage = info_storage
         self.beamline_states = beamline_states
         self.additional_scan_metadata = additional_scan_metadata
+        self.written_async_signals = written_async_signals
 
     def _experiment_metadata(self) -> dict:
         deployment_info = self.additional_scan_metadata.deployment_info
@@ -78,23 +80,18 @@ class DefaultFormat:
 
     def has_async_signal(self, device_name: str, signal_name: str) -> bool:
         """
-        Check if a device has an async signal.
+        Check if the specified device was written with the given async signal.
 
         Args:
             device_name (str): The name of the device.
             signal_name (str): The name of the signal.
 
         Returns:
-            bool: True if the device has an async signal, False otherwise.
+            bool: True if the device was written with the given async signal, False otherwise.
         """
-        signals = self.device_manager.get_bec_signals(
-            ["AsyncMultiSignal", "AsyncSignal", "DynamicSignal"]
-        )
-        for device_name_, _, signal_info in signals:
-            obj_name = signal_info.get("object_name", "")
-            obj_name_without_prefix = obj_name.removeprefix("devicename")
-            if device_name_ == device_name and (signal_name in [obj_name, obj_name_without_prefix]):
-                return True
+        if self.written_async_signals is not None:
+            return signal_name in self.written_async_signals.get(device_name, [])
+
         return False
 
     def get_entry(self, name: str, signal: str | None = None, default=None) -> Any:
@@ -113,7 +110,11 @@ class DefaultFormat:
         """
         signal = signal or name
         if isinstance(self.data.get(name), list) and isinstance(self.data[name][0], dict):
-            return [sub_data.get(signal, {}).get("value", default) for sub_data in self.data[name]]
+            out = [sub_data.get(signal, {}).get("value", default) for sub_data in self.data[name]]
+            # If all values are None, return None instead of a list of None values
+            if all(val is None for val in out):
+                return None
+            return out
 
         return self.data.get(name, {}).get(signal, {}).get("value", default)
 

--- a/bec_server/bec_server/file_writer/file_writer.py
+++ b/bec_server/bec_server/file_writer/file_writer.py
@@ -261,6 +261,7 @@ class HDF5FileWriter:
         configuration_data: dict[str, dict],
         mode="w",
         file_handle=None,
+        written_async_signals: dict[str, list[str]] | None = None,
     ):
         """
         Write the data to an HDF5 file.
@@ -268,8 +269,10 @@ class HDF5FileWriter:
         Args:
             file_path (str): File path
             data (ScanStorage): Scan data
+            configuration_data (dict[str, dict]): Configuration data
             mode (str, optional): File mode. Defaults to "w".
             file_handle (h5py.File, optional): File handle. Defaults to None.
+            written_async_signals (dict[str, list[str]], optional): Dictionary of written async signals. Defaults to None.
 
         Raises:
             NeXusLayoutError: Raised when the NeXus layout is incorrect.
@@ -340,6 +343,7 @@ class HDF5FileWriter:
             beamline_states=data.beamline_states,
             device_manager=self.file_writer_manager.device_manager,
             additional_scan_metadata=additional_scan_metadata,
+            written_async_signals=written_async_signals,
         ).get_storage_format()
 
         file_data = {}

--- a/bec_server/bec_server/file_writer/file_writer_manager.py
+++ b/bec_server/bec_server/file_writer/file_writer_manager.py
@@ -427,10 +427,13 @@ class FileWriterManager(BECService):
                 log_if_dir_does_not_exist=False,
             )
             successful = True
+            written_async_signals = (
+                storage.async_writer.written_signals if storage.async_writer else None
+            )
 
             # If we've already written device data, we need to append to the file
-            writte_devices = None if not self.async_writer else self.async_writer.written_devices
-            write_mode = "w" if not writte_devices else "a"
+            written_devices = set(written_async_signals or {})
+            write_mode = "w" if not written_devices else "a"
             file_handle = storage.async_writer.file_handle if storage.async_writer else None
 
             if write_mode == "w":
@@ -449,6 +452,7 @@ class FileWriterManager(BECService):
                 configuration_data=self.device_configuration,
                 mode=write_mode,
                 file_handle=file_handle,
+                written_async_signals=written_async_signals,
             )
         # pylint: disable=broad-except
         # pylint: disable=unused-variable

--- a/bec_server/tests/tests_file_writer/test_async_file_writer.py
+++ b/bec_server/tests/tests_file_writer/test_async_file_writer.py
@@ -451,6 +451,7 @@ def test_async_writer_async_signal(async_writer):
     # Check that the data was appended correctly
     expected_data = np.array([1, 2, 3, 4, 5, 6, 7, 8])
     assert np.array_equal(out, expected_data)
+    assert async_writer.written_signals == {"waveform": ["waveform_data"]}
 
 
 def test_async_writer_mixed_readback_and_signal(async_writer):
@@ -509,6 +510,10 @@ def test_async_writer_mixed_readback_and_signal(async_writer):
         signal_out = f[async_writer.BASE_PATH]["waveform"]["waveform_data"]["value"][:]
         expected_signal = np.array([100, 200, 300, 400, 500])
         assert np.array_equal(signal_out, expected_signal)
+    assert async_writer.written_signals == {
+        "monitor_async": ["monitor_async"],
+        "waveform": ["waveform_data"],
+    }
 
 
 def test_async_writer_same_device_readback_and_signal(async_writer):

--- a/bec_server/tests/tests_file_writer/test_file_writer.py
+++ b/bec_server/tests/tests_file_writer/test_file_writer.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 from test_file_writer_manager import file_writer_manager_mock
 
-from bec_lib import messages
+from bec_lib import messages, plugin_helper
 from bec_lib.endpoints import MessageEndpoints
 from bec_server.file_writer import HDF5FileWriter
 from bec_server.file_writer.default_writer import DefaultFormat
@@ -18,6 +18,18 @@ class PluginFormatForTest(DefaultFormat):
     def format(self) -> None:
         entry = self.storage.create_group("entry")
         entry.attrs["definition"] = "NXtest"
+
+
+class CapturingFormatForTest(DefaultFormat):
+    last_written_async_signals = None
+
+    def __init__(self, *args, written_async_signals=None, **kwargs):
+        self.__class__.last_written_async_signals = written_async_signals
+        super().__init__(*args, written_async_signals=written_async_signals, **kwargs)
+
+    def format(self) -> None:
+        entry = self.storage.create_group("entry")
+        entry.attrs["definition"] = "NXcapture"
 
 
 def _make_additional_scan_metadata(
@@ -49,6 +61,11 @@ def hdf5_file_writer(file_writer_manager_mock_with_dm):
     file_manager = file_writer_manager_mock_with_dm
     file_writer = HDF5FileWriter(file_manager)
     yield file_writer
+
+
+@pytest.fixture(autouse=True)
+def no_file_writer_plugins(monkeypatch):
+    monkeypatch.setattr(plugin_helper, "get_file_writer_plugins", lambda: {})
 
 
 @pytest.fixture
@@ -93,6 +110,7 @@ def default_format(file_writer_manager_mock_with_dm):
         device_manager=file_writer_manager_mock_with_dm.device_manager,
         beamline_states={},
         additional_scan_metadata=_make_additional_scan_metadata(),
+        written_async_signals=None,
     )
 
 
@@ -113,18 +131,28 @@ def test_get_entry_returns_default_for_missing_signal(default_format):
     assert default_format.get_entry("missing", default="fallback") == "fallback"
 
 
-def test_has_async_signal_matches_prefixed_and_unprefixed_object_names(default_format):
+def test_has_async_signal_returns_false_without_written_async_signals(default_format):
     with mock.patch.object(
         default_format.device_manager, "get_bec_signals"
     ) as mock_get_bec_signals:
-        mock_get_bec_signals.return_value = [
-            ("samx", None, {"object_name": "devicenamesamx"}),
-            ("waveform", None, {"object_name": "waveform"}),
-        ]
-
-        assert default_format.has_async_signal("samx", "samx") is True
-        assert default_format.has_async_signal("waveform", "waveform") is True
+        assert default_format.has_async_signal("samx", "samx") is False
+        assert default_format.has_async_signal("waveform", "waveform") is False
         assert default_format.has_async_signal("samx", "other") is False
+
+    mock_get_bec_signals.assert_not_called()
+
+
+def test_has_async_signal_uses_written_async_signals_when_provided(default_format):
+    default_format.written_async_signals = {"waveform": ["waveform_data"]}
+
+    with mock.patch.object(
+        default_format.device_manager, "get_bec_signals"
+    ) as mock_get_bec_signals:
+        assert default_format.has_async_signal("waveform", "waveform_data") is True
+        assert default_format.has_async_signal("waveform", "other") is False
+        assert default_format.has_async_signal("samx", "samx") is False
+
+    mock_get_bec_signals.assert_not_called()
 
 
 def test_safe_dataset_skips_missing_device(default_format):
@@ -595,3 +623,18 @@ def test_states_are_converted_to_compound_types(tmp_path, hdf5_file_writer, scan
         assert label_1 == "Shutter moving"
         assert status_1 == "warning"
         assert values[1]["timestamp"] == 2.34
+
+
+def test_hdf5_writer_forwards_written_async_signals(tmp_path, hdf5_file_writer, scan_storage_mock):
+    with mock.patch(
+        "bec_lib.plugin_helper.get_file_writer_plugins"
+    ) as mock_get_file_writer_plugins:
+        mock_get_file_writer_plugins.return_value = {"capture": CapturingFormatForTest}
+        hdf5_file_writer.write(
+            f"{tmp_path}/test.h5",
+            scan_storage_mock,
+            configuration_data={},
+            written_async_signals={"waveform": ["waveform_data"]},
+        )
+
+    assert CapturingFormatForTest.last_written_async_signals == {"waveform": ["waveform_data"]}

--- a/bec_server/tests/tests_file_writer/test_file_writer_manager.py
+++ b/bec_server/tests/tests_file_writer/test_file_writer_manager.py
@@ -218,7 +218,15 @@ class MockWriter(HDF5FileWriter):
         super().__init__(file_writer_manager)
         self.write_called = False
 
-    def write(self, file_path: str, data, configuration_data, mode="w", file_handle=None):
+    def write(
+        self,
+        file_path: str,
+        data,
+        configuration_data,
+        mode="w",
+        file_handle=None,
+        written_async_signals=None,
+    ):
         self.write_called = True
 
 
@@ -232,6 +240,24 @@ def test_write_file(file_writer_manager_mock, scan_storage_mock):
         file_manager.file_writer = MockWriter(file_manager)
         file_manager.write_file("scan_id")
         assert file_manager.file_writer.write_called is True
+
+
+def test_write_file_forwards_written_async_signals(file_writer_manager_mock, scan_storage_mock):
+    file_manager = file_writer_manager_mock
+    scan_storage_mock.async_writer = mock.Mock(
+        written_signals={"waveform": ["waveform_data"]}, file_handle=None
+    )
+    file_manager.scan_storage["scan_id"] = scan_storage_mock
+
+    with mock.patch("bec_server.file_writer.file_writer_manager.get_full_path") as mock_filename:
+        mock_filename.return_value = "path"
+        file_manager.file_writer.write = mock.Mock()
+        file_manager.write_file("scan_id")
+
+    file_manager.file_writer.write.assert_called_once()
+    assert file_manager.file_writer.write.call_args.kwargs["written_async_signals"] == {
+        "waveform": ["waveform_data"]
+    }
 
 
 def test_write_file_invalid_scan_id(file_writer_manager_mock, scan_storage_mock):


### PR DESCRIPTION
## Description

Forward the information about the written async signals from the async writer to the nexus declaration. This allows users to customize their file writer depending on the availability of async signals without checking the nexus file. 

