### PR TITLE
fix(device): handle KeyboardInterrupt gracefully in RPC calls

### DIFF
--- a/bec_lib/bec_lib/device.py
+++ b/bec_lib/bec_lib/device.py
@@ -470,7 +470,9 @@ class DeviceBase:
                 return None
             return_val = self._get_rpc_response(request_id, rpc_id)
         except KeyboardInterrupt as exc:
-            self.root.stop(wait_for_rpc_response=False)
+            stop = getattr(self.root, "stop", None)
+            if callable(stop):
+                stop(wait_for_rpc_response=False)
             raise RPCError("User interruption during RPC call.") from exc
 
         return return_val

--- a/bec_lib/tests/test_devices.py
+++ b/bec_lib/tests/test_devices.py
@@ -338,6 +338,18 @@ def test_run_rpc_call_calls_stop_on_keyboardinterrupt(dev: Any):
             mock_stop.assert_called_once()
 
 
+def test_run_rpc_call_keyboardinterrupt_on_top_level_signal_skips_stop(dm_with_override: Any):
+    dm_with_override.parent = mock.MagicMock()
+    signal = Signal(name="top_level_signal", config=BASIC_CONFIG, parent=dm_with_override)
+
+    with mock.patch.object(signal, "_prepare_rpc_msg") as mock_rpc:
+        with mock.patch.object(signal, "_validate_rpc_client"):
+            mock_rpc.side_effect = [KeyboardInterrupt]
+            with pytest.raises(RPCError, match="User interruption during RPC call."):
+                signal.read()
+            mock_rpc.assert_called_once()
+
+
 @pytest.fixture
 def device_config():
     return {


### PR DESCRIPTION
## Description

Signals do not implement .stop so we should only call it if it exists.
