### PR TITLE
fix: improve error handling and logging for Redis stream connections

### DIFF
--- a/bec_lib/bec_lib/redis_connector/managed_redis_connection.py
+++ b/bec_lib/bec_lib/redis_connector/managed_redis_connection.py
@@ -493,12 +493,13 @@ class ManagedRedisConnection:
             else:
                 return self._redis_conn.xread(topics_ids, block=200) or []  # type: ignore strs are fine key and id types
         except redis.exceptions.ConnectionError:
-            logger.error(self.connection_error_str)
+            return None
         except redis.exceptions.NoPermissionError:
             logger.error(f"Permission denied for stream topics: {set(topics_ids.keys())}")
         # pylint: disable=broad-except
         except Exception:
             sys.excepthook(*sys.exc_info())  # type: ignore # inside except
+        return None
 
     def _read_from_start_streams_and_migrate(self) -> bool:
         """Returns whether there was an error"""
@@ -522,25 +523,39 @@ class ManagedRedisConnection:
         Get stream messages loop. This method is run in a separate thread and listens
         for messages from the redis server.
         """
+        error = False
         while not self._stop_stream_events_listener_thread.is_set():
             # first clear any dead callbacks
             with self._stream_subs.lock:
                 self._stream_subs.gc_cb_refs()
             # First read the "from_start" streams, up until any id which is already in the normal
             # subs, then all those them to the normal streams
-            error = self._read_from_start_streams_and_migrate()
+            from_start_error = self._read_from_start_streams_and_migrate()
             # Then read all the normal streams
             with self._stream_subs.lock:
                 normal_topics = self._stream_subs.topic_ids()
                 normal_subs = self._stream_subs.normal_subs
-            if normal_topics and (response := self._try_read_streams(normal_topics)) is not None:
-                updated_ids = self._handle_stream_msg_list(response, normal_subs)
+            normal_error = False
+            if normal_topics:
+                response = self._try_read_streams(normal_topics)
+                if response is not None:
+                    updated_ids = self._handle_stream_msg_list(response, normal_subs)
+                else:
+                    updated_ids = {}
+                    normal_error = True
             else:
                 updated_ids = {}
             with self._stream_subs.lock:
                 self._stream_subs.update_normal_ids(updated_ids)
-            if error:  # Encountered an error on xread, wait a while without the lock
+            stream_error = from_start_error or normal_error
+            if stream_error:  # Encountered an error on xread, wait a while without the lock
+                if not error:
+                    error = True
+                    logger.error(self.connection_error_str)
                 self._stop_stream_events_listener_thread.wait(timeout=1)
+            elif error:
+                error = False
+                logger.info(f"{self.name} reconnected to redis ({self.host}:{self.port}).")
 
     def _register_stream(
         self,
@@ -683,6 +698,8 @@ class ManagedRedisConnection:
             except Exception:
                 sys.excepthook(*sys.exc_info())  # type: ignore # inside except
             else:
+                if error:
+                    logger.info(f"{self.name} reconnected to redis ({self.host}:{self.port}).")
                 error = False
                 if msg is not None:
                     self._message_callbacks_queue.put(msg)

--- a/bec_lib/tests/test_managed_redis_connection.py
+++ b/bec_lib/tests/test_managed_redis_connection.py
@@ -1,7 +1,9 @@
+import contextlib
 from typing import Any, ClassVar, Optional
 from unittest import mock
 
 import pytest
+import redis.exceptions
 from redis.exceptions import RedisError
 
 import bec_lib.messages as bec_messages
@@ -417,3 +419,63 @@ def test_user_pw_restored_on_auth_fail(connector: ManagedRedisConnection, test_d
     with pytest.raises(RedisError):
         connector.authenticate(username="user", password="pass")
     assert connector._redis_conn.connection_pool.connection_kwargs == test_dict
+
+
+def test_stream_connection_logs_once_and_logs_recovery(connector: ManagedRedisConnection):
+    stream_subs = mock.MagicMock()
+    stream_subs.lock = contextlib.nullcontext()
+    stream_subs.gc_cb_refs = mock.MagicMock()
+    stream_subs.topic_ids = mock.MagicMock(
+        side_effect=[{"topic": "0-0"}, {"topic": "0-0"}, {"topic": "0-0"}]
+    )
+    stream_subs.normal_subs = {}
+    stream_subs.update_normal_ids = mock.MagicMock()
+    connector._stream_subs = stream_subs
+    connector._read_from_start_streams_and_migrate = mock.MagicMock(return_value=False)
+    connector._handle_stream_msg_list = mock.MagicMock(return_value={})
+    connector._stop_stream_events_listener_thread = mock.MagicMock()
+    connector._stop_stream_events_listener_thread.is_set.side_effect = [False, False, False, True]
+    connector._stop_stream_events_listener_thread.wait = mock.MagicMock()
+    connector._redis_conn.xread.side_effect = [
+        redis.exceptions.ConnectionError,
+        redis.exceptions.ConnectionError,
+        [],
+    ]
+
+    with (
+        mock.patch("bec_lib.redis_connector.managed_redis_connection.logger.error") as log_error,
+        mock.patch("bec_lib.redis_connector.managed_redis_connection.logger.info") as log_info,
+    ):
+        connector._get_stream_messages_loop()
+
+    log_error.assert_called_once_with(connector.connection_error_str)
+    log_info.assert_called_once_with(
+        f"{connector.name} reconnected to redis ({connector.host}:{connector.port})."
+    )
+    assert connector._stop_stream_events_listener_thread.wait.call_count == 2
+
+
+def test_pubsub_connection_logs_once_and_logs_recovery(connector: ManagedRedisConnection):
+    connector._garbage_collect_cb_refs = mock.MagicMock()
+    connector._stop_events_listener_thread = mock.MagicMock()
+    connector._stop_events_listener_thread.is_set.side_effect = [False, False, False, True]
+    connector._stop_events_listener_thread.wait = mock.MagicMock()
+    connector._pubsub_conn.get_message.side_effect = [
+        redis.exceptions.ConnectionError,
+        redis.exceptions.ConnectionError,
+        None,
+    ]
+
+    with (
+        mock.patch(
+            "bec_lib.redis_connector.managed_redis_connection.bec_logger.logger.error"
+        ) as log_error,
+        mock.patch("bec_lib.redis_connector.managed_redis_connection.logger.info") as log_info,
+    ):
+        connector._get_messages_loop()
+
+    log_error.assert_called_once_with(connector.connection_error_str)
+    log_info.assert_called_once_with(
+        f"{connector.name} reconnected to redis ({connector.host}:{connector.port})."
+    )
+    assert connector._stop_events_listener_thread.wait.call_count == 2


### PR DESCRIPTION
## Description

Streams were logging at 1 Hz if the connection got lost. While this is unlikely to happen in production, the development machines may not be able to connect to Atlas from the outside of PSI, leading to massive log file. 
Here, I'm changing the logging behavior to log once on connection loss and once when the connection is re-established. 
The pub sub was already only logging once but was lacking the recovery message, which I added now as well. 
